### PR TITLE
Fix kamino asv graph capture

### DIFF
--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -359,15 +359,7 @@ class DRLegsBenchmarkWorkload:
         if use_cuda_graph:
             device = self.model.device
             if device.is_cuda and wp.is_mempool_enabled(device):
-                with wp.ScopedCapture() as reset_capture:
-                    self._reset_tick()
-                self.reset_graph = reset_capture.graph
-                self._capturing_graph = True
-                with wp.ScopedCapture() as capture:
-                    self.simulate_tick()
-                self._capturing_graph = False
-                self.graph = capture.graph
-                self.solver.reset(state=self.state_0)
+                self._capture_cuda_graphs()
             else:
                 warnings.warn(
                     f"use_cuda_graph=True but CUDA graph capture is unavailable on device '{device}' "
@@ -377,6 +369,24 @@ class DRLegsBenchmarkWorkload:
                 )
 
         wp.synchronize_device()
+
+    def _capture_cuda_graphs(self):
+        # Initialize lazy solver buffers eagerly. Large captured allocation nodes can make
+        # cudaGraphInstantiate reject an otherwise valid graph on the first replay.
+        self.simulate_tick()
+        self.solver.reset(state=self.state_0)
+
+        with wp.ScopedCapture() as reset_capture:
+            self._reset_tick()
+        self.reset_graph = reset_capture.graph
+        self._capturing_graph = True
+        try:
+            with wp.ScopedCapture() as capture:
+                self.simulate_tick()
+        finally:
+            self._capturing_graph = False
+        self.graph = capture.graph
+        self.solver.reset(state=self.state_0)
 
     @staticmethod
     def _set_newton_joint_params(model, cfg, world_count):

--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -524,6 +524,9 @@ class DRLegsBenchmarkWorkload:
 
         settings = RigidBodySim.default_settings(sim_dt)
         settings.solver.collision_detector = settings.collision_detector
+        # The detector's default contact limit is model-wide, so scale it to preserve
+        # the geometry-derived per-world capacity when the robot is replicated.
+        settings.collision_detector.max_contacts *= model.world_count
         # Pin the linear solver so a change to default_settings cannot
         # silently switch what this benchmark measures.
         settings.solver.dynamics.linear_solver_type = "LLTBRCM"

--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -93,6 +93,17 @@ ROBOT_CONFIGS = {
 }
 
 
+def _configure_kamino_solver_settings(settings, world_count):
+    settings.solver.collision_detector = settings.collision_detector
+    # The detector's default contact limit is model-wide, so scale it to preserve
+    # the geometry-derived per-world capacity when the robot is replicated.
+    settings.collision_detector.max_contacts *= world_count
+    # Pin the linear solver so a change to default_settings cannot
+    # silently switch what this benchmark measures.
+    settings.solver.dynamics.linear_solver_type = "LLTBRCM"
+    return settings.solver
+
+
 def _load_robot_config(robot):
     asset_cfg = ROBOT_CONFIGS[robot]
     asset_path = newton.utils.download_asset(asset_cfg["asset_name"], ref=asset_cfg["asset_ref"])
@@ -523,14 +534,8 @@ class DRLegsBenchmarkWorkload:
         from newton._src.solvers.kamino.examples.rl.simulation import RigidBodySim  # noqa: PLC0415
 
         settings = RigidBodySim.default_settings(sim_dt)
-        settings.solver.collision_detector = settings.collision_detector
-        # The detector's default contact limit is model-wide, so scale it to preserve
-        # the geometry-derived per-world capacity when the robot is replicated.
-        settings.collision_detector.max_contacts *= model.world_count
-        # Pin the linear solver so a change to default_settings cannot
-        # silently switch what this benchmark measures.
-        settings.solver.dynamics.linear_solver_type = "LLTBRCM"
-        return newton.solvers.SolverKamino(model, config=settings.solver)
+        solver_settings = _configure_kamino_solver_settings(settings, model.world_count)
+        return newton.solvers.SolverKamino(model, config=solver_settings)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -184,6 +184,43 @@ class TestSimulationBenchmarks(unittest.TestCase):
         config = json.loads((BENCHMARK_DIR.parents[1] / "asv.conf.json").read_text(encoding="utf-8"))
         self.assertGreater(bench_kamino.KpiDRLegs.setup_cache.timeout, config["default_benchmark_timeout"])
 
+    def test_kamino_capture_warms_up_solver_eagerly(self):
+        """Warm up lazy Kamino allocations before CUDA graph capture."""
+        workload = DRLegsBenchmarkWorkload.__new__(DRLegsBenchmarkWorkload)
+        workload.state_0 = object()
+        workload.solver = Mock()
+        workload.graph = None
+        workload.reset_graph = None
+        workload._capturing_graph = False
+
+        capture_active = False
+        simulate_capture_states = []
+
+        class FakeCapture:
+            def __init__(self):
+                self.graph = object()
+
+            def __enter__(self):
+                nonlocal capture_active
+                capture_active = True
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                nonlocal capture_active
+                capture_active = False
+
+        workload.simulate_tick = Mock(side_effect=lambda: simulate_capture_states.append(capture_active))
+        workload._reset_tick = Mock()
+
+        with patch("benchmark_kamino.wp.ScopedCapture", FakeCapture):
+            workload._capture_cuda_graphs()
+
+        self.assertEqual(simulate_capture_states, [False, True])
+        self.assertEqual(workload.solver.reset.call_count, 2)
+        self.assertIsNotNone(workload.reset_graph)
+        self.assertIsNotNone(workload.graph)
+        self.assertFalse(workload._capturing_graph)
+
     def test_aws_benchmark_comparison_gates_only_runtime_metrics(self):
         """Gate PR comparisons on runtime while retaining dashboard metrics."""
         workflow_path = BENCHMARK_DIR.parents[1] / ".github" / "workflows" / "aws_gpu_benchmarks.yml"

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -223,6 +223,8 @@ class TestSimulationBenchmarks(unittest.TestCase):
 
     def test_kamino_contact_capacity_scales_with_world_count(self):
         """Scale the model-wide Kamino contact cap across replicated worlds."""
+        from newton._src.solvers.kamino.examples.rl.simulation import RigidBodySim  # noqa: PLC0415
+
         settings = SimpleNamespace(
             collision_detector=SimpleNamespace(max_contacts=1000),
             solver=SimpleNamespace(collision_detector=None, dynamics=SimpleNamespace(linear_solver_type=None)),
@@ -230,10 +232,7 @@ class TestSimulationBenchmarks(unittest.TestCase):
         model = SimpleNamespace(world_count=4096)
 
         with (
-            patch(
-                "newton._src.solvers.kamino.examples.rl.simulation.RigidBodySim.default_settings",
-                return_value=settings,
-            ),
+            patch.object(RigidBodySim, "default_settings", return_value=settings),
             patch("benchmark_kamino.newton.solvers.SolverKamino", return_value=object()) as solver_kamino,
         ):
             solver = DRLegsBenchmarkWorkload.create_solver(model, sim_dt=0.001)

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -6,7 +6,7 @@ import re
 import sys
 import unittest
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -31,7 +31,7 @@ try:
 
     _DEFERRED_WORKLOAD_MODULES_AFTER_METRIC_IMPORT = {name: name in sys.modules for name in _DEFERRED_WORKLOAD_MODULES}
 
-    from benchmark_kamino import DRLegsBenchmarkWorkload
+    from benchmark_kamino import DRLegsBenchmarkWorkload, _configure_kamino_solver_settings
     from benchmark_mujoco import Example as MuJoCoExample
 finally:
     for _name, _value in _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS.items():
@@ -227,19 +227,13 @@ class TestSimulationBenchmarks(unittest.TestCase):
             collision_detector=SimpleNamespace(max_contacts=1000),
             solver=SimpleNamespace(collision_detector=None, dynamics=SimpleNamespace(linear_solver_type=None)),
         )
-        model = SimpleNamespace(world_count=4096)
-        simulation_module = ModuleType("newton._src.solvers.kamino.examples.rl.simulation")
-        simulation_module.RigidBodySim = SimpleNamespace(default_settings=Mock(return_value=settings))
 
-        with (
-            patch.dict(sys.modules, {simulation_module.__name__: simulation_module}),
-            patch("benchmark_kamino.newton.solvers.SolverKamino", return_value=object()) as solver_kamino,
-        ):
-            solver = DRLegsBenchmarkWorkload.create_solver(model, sim_dt=0.001)
+        solver_settings = _configure_kamino_solver_settings(settings, world_count=4096)
 
-        self.assertIs(solver, solver_kamino.return_value)
+        self.assertIs(solver_settings, settings.solver)
         self.assertEqual(settings.collision_detector.max_contacts, 4_096_000)
         self.assertIs(settings.solver.collision_detector, settings.collision_detector)
+        self.assertEqual(settings.solver.dynamics.linear_solver_type, "LLTBRCM")
 
     def test_aws_benchmark_comparison_gates_only_runtime_metrics(self):
         """Gate PR comparisons on runtime while retaining dashboard metrics."""

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -221,6 +221,27 @@ class TestSimulationBenchmarks(unittest.TestCase):
         self.assertIsNotNone(workload.graph)
         self.assertFalse(workload._capturing_graph)
 
+    def test_kamino_contact_capacity_scales_with_world_count(self):
+        """Scale the model-wide Kamino contact cap across replicated worlds."""
+        settings = SimpleNamespace(
+            collision_detector=SimpleNamespace(max_contacts=1000),
+            solver=SimpleNamespace(collision_detector=None, dynamics=SimpleNamespace(linear_solver_type=None)),
+        )
+        model = SimpleNamespace(world_count=4096)
+
+        with (
+            patch(
+                "newton._src.solvers.kamino.examples.rl.simulation.RigidBodySim.default_settings",
+                return_value=settings,
+            ),
+            patch("benchmark_kamino.newton.solvers.SolverKamino", return_value=object()) as solver_kamino,
+        ):
+            solver = DRLegsBenchmarkWorkload.create_solver(model, sim_dt=0.001)
+
+        self.assertIs(solver, solver_kamino.return_value)
+        self.assertEqual(settings.collision_detector.max_contacts, 4_096_000)
+        self.assertIs(settings.solver.collision_detector, settings.collision_detector)
+
     def test_aws_benchmark_comparison_gates_only_runtime_metrics(self):
         """Gate PR comparisons on runtime while retaining dashboard metrics."""
         workflow_path = BENCHMARK_DIR.parents[1] / ".github" / "workflows" / "aws_gpu_benchmarks.yml"

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -6,7 +6,7 @@ import re
 import sys
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -223,16 +223,16 @@ class TestSimulationBenchmarks(unittest.TestCase):
 
     def test_kamino_contact_capacity_scales_with_world_count(self):
         """Scale the model-wide Kamino contact cap across replicated worlds."""
-        from newton._src.solvers.kamino.examples.rl.simulation import RigidBodySim  # noqa: PLC0415
-
         settings = SimpleNamespace(
             collision_detector=SimpleNamespace(max_contacts=1000),
             solver=SimpleNamespace(collision_detector=None, dynamics=SimpleNamespace(linear_solver_type=None)),
         )
         model = SimpleNamespace(world_count=4096)
+        simulation_module = ModuleType("newton._src.solvers.kamino.examples.rl.simulation")
+        simulation_module.RigidBodySim = SimpleNamespace(default_settings=Mock(return_value=settings))
 
         with (
-            patch.object(RigidBodySim, "default_settings", return_value=settings),
+            patch.dict(sys.modules, {simulation_module.__name__: simulation_module}),
             patch("benchmark_kamino.newton.solvers.SolverKamino", return_value=object()) as solver_kamino,
         ):
             solver = DRLegsBenchmarkWorkload.create_solver(model, sim_dt=0.001)


### PR DESCRIPTION
## Description

Fix the 4,096-world Kamino DR Legs ASV benchmark by warming up lazy solver allocations before CUDA graph capture and scaling the model-wide contact cap with the replicated world count.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not user-facing)

## Test plan

```
uv run python -m unittest newton.tests.test_benchmark_simulation
uvx pre-commit run -a
```

Manually verified the 4,096-world eager, CUDA graph, and policy-backed CUDA graph workloads complete with finite state and no contact overflow.

## Bug fix

**Steps to reproduce:**

1. Construct `DRLegsBenchmarkWorkload` with 4,096 worlds and CUDA graphs enabled.
2. Run one benchmark step.
3. Observe CUDA graph instantiation failure; eager execution also reports contact-capacity overflow and becomes non-finite.

**Minimal reproduction:**

```python
from benchmark_kamino import DRLegsBenchmarkWorkload

workload = DRLegsBenchmarkWorkload(world_count=4096, use_policy=False, use_cuda_graph=True)
workload.step()
workload.test_final()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Collision contact capacity now scales correctly with the number of replicated simulation worlds.
  * Improved CUDA graph initialization and solver warmup for more reliable simulation execution.
  * Ensured simulation state is restored consistently after graph capture.

* **Tests**
  * Added coverage for CUDA graph capture, solver warmup, reset behavior, and initialization cleanup.
  * Added tests verifying contact capacity scaling across multiple simulation worlds and solver configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->