### PR TITLE
Fix locked D6 root base classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - Fix `ModelBuilder.add_usd()` marking a `guide`-purpose collider visible when it has a bound render material. Such a collider is not viewport geometry, and the extra `VISIBLE` flag left it drawn by the viewer's visual toggle instead of its collision toggle. `force_show_colliders` still reveals it.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix MJCF contact pairs ignoring properties inherited from pair default classes.
+- Fix `ArticulationView.is_fixed_base` for roots with zero effective degrees of freedom, including fully locked D6 joints. (#3727)
 - Fix USD plane visual width and length to scale along the axes defined by the `UsdGeomPlane` schema, and orient X- and Y-axis plane visuals along the authored axis.
 - Validate `ArticulationView` mask shapes and devices before launching selection kernels. (#3448)
 - Exclude active particles with non-finite positions from rebuildable `SolverImplicitMPM` sparse-grid packing.

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -754,8 +754,9 @@ class ArticulationView:
             raise ValueError("Articulations are not identical")
 
         self.root_joint_type = root_joint_types[0][0]
+        root_joint_dof_count = int(model_joint_qd_start[arti_joint_begin + 1] - model_joint_qd_start[arti_joint_begin])
         # fixed base means that all linear and angular degrees of freedom are locked at the root
-        self.is_fixed_base = self.root_joint_type == JointType.FIXED
+        self.is_fixed_base = root_joint_dof_count == 0
         # floating base means that all linear and angular degrees of freedom are unlocked at the root
         # (though there might be constraints like distance)
         self.is_floating_base = self.root_joint_type in (JointType.FREE, JointType.DISTANCE)

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -151,6 +151,33 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.get_dof_velocities(state).shape, (1, 1, 0))
         self.assertEqual(view.get_dof_forces(control).shape, (1, 1, 0))
 
+    def test_root_base_classification_uses_dof_count(self):
+        """Classify zero-DOF roots as fixed while preserving floating roots."""
+        cases = (
+            ("fixed", True, False),
+            ("locked_d6", True, False),
+            ("free", False, True),
+        )
+
+        for root_kind, expected_fixed, expected_floating in cases:
+            with self.subTest(root_kind=root_kind):
+                builder = newton.ModelBuilder()
+                root = builder.add_link(label="root")
+
+                if root_kind == "fixed":
+                    root_joint = builder.add_joint_fixed(parent=-1, child=root)
+                elif root_kind == "locked_d6":
+                    root_joint = builder.add_joint_d6(parent=-1, child=root)
+                else:
+                    root_joint = builder.add_joint_free(parent=-1, child=root)
+
+                builder.add_articulation([root_joint], label=root_kind)
+                model = builder.finalize(device="cpu")
+                view = ArticulationView(model, root_kind)
+
+                self.assertEqual(view.is_fixed_base, expected_fixed)
+                self.assertEqual(view.is_floating_base, expected_floating)
+
     def test_labels_preserve_full_paths(self):
         """Two-finger gripper whose distal bodies, finger joints, and tip
         shapes each share a colliding leaf name. ``*_names`` attributes


### PR DESCRIPTION
## Description

Fixes #3727.

`ArticulationView` classified fixed bases solely from a root joint's `JointType`, so a fully locked, zero-DOF D6 root reported neither fixed nor floating. This caused downstream consumers to reserve six nonexistent base DOFs and select incorrect Jacobian columns.

Classify a root as fixed when its effective DOF count is zero. Keep floating-base classification restricted to `FREE` and `DISTANCE` roots, preserving their existing coordinate-layout assumptions.

## Known limitation

`ArticulationView` already assumes selected articulations share one template, but its existing validation can allow heterogeneous root-DOF layouts and then expose metadata from the first articulation. This predates this PR; #3792 only corrects zero-DOF root classification for supported identical views. The validation gap is tracked separately in #3793.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m unittest newton.tests.test_selection
uvx --python 3.12 pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Build an articulation whose root is a D6 joint with no linear or angular axes.
2. Construct an `ArticulationView` for it.
3. Observe that `is_fixed_base` and `is_floating_base` are both `False` without this change.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
root = builder.add_link(label="root")
root_joint = builder.add_joint_d6(parent=-1, child=root)
builder.add_articulation([root_joint], label="robot")

model = builder.finalize(device="cpu")
view = newton.selection.ArticulationView(model, "robot")

assert view.is_fixed_base
assert not view.is_floating_base
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed root base classification for articulations with zero effective degrees of freedom, including fully constrained joints, which now correctly report as fixed-base.

* **Tests**
  * Added regression test for root-base classification across different joint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->