### PR TITLE
Start Newton 1.6 development

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.0.dev0``
+     - ``1.6.0.dev0``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.0.dev0"
+version = "1.6.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0.dev0"
+version = "1.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Move `main` to `1.6.0.dev0` after cutting the Newton 1.5 release branch. Regenerate the API version table and update the editable Newton package entry in `uv.lock`.

## Checklist

- [x] New or existing tests cover these changes (version-only change)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable; no user-facing change)

## Test plan

- `uv lock --check`
- `uvx --python 3.12 pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented project version to 1.6.0.dev0.

* **Chores**
  * Incremented the project release version to 1.6.0.dev0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->