### PR TITLE
Fix minimum-dependency strict-warning failures

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -78,6 +78,11 @@ _WARP_SDF_CONSTANT_CONVERSION_WARNING_RE = (
     r")+"
     r"^\d+ warnings? generated\.\n?"
 )
+_ANYMAL_TEXTURE_WITHOUT_UVS_WARNING_RE = (
+    r"^.*newton[/\\]_src[/\\]utils[/\\]import_urdf\.py:\d+: UserWarning: Warning: mesh "
+    r"[^\n]*[/\\]base\.dae has a texture but no UVs; texture will be ignored\.\n"
+    r"  parse_shapes\(link, visuals, density=0\.0, just_visual=True, visible=not hide_visuals\)\n?"
+)
 _EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_PXR_WORK_THREAD_LIMIT_OUTPUT_RE, "stderr"),
     (_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "stderr"),
@@ -742,6 +747,7 @@ add_example_test(
     name="mpm.example_mpm_anymal",
     devices=cuda_test_devices,
     test_options={"num-frames": 100, "onnx_required": True},
+    allow_output_regexes=[(_ANYMAL_TEXTURE_WITHOUT_UVS_WARNING_RE, "stderr")],
     use_viewer=True,
 )
 

--- a/newton/tests/test_texture.py
+++ b/newton/tests/test_texture.py
@@ -20,7 +20,7 @@ def _write_png(path: Path, color: tuple[int, int, int]) -> None:
     """Write a small solid-color RGB PNG to *path*."""
     from PIL import Image
 
-    Image.fromarray(np.full((4, 4, 3), color, dtype=np.uint8), "RGB").save(str(path))
+    Image.fromarray(np.full((4, 4, 3), color, dtype=np.uint8)).save(str(path))
 
 
 def _build_usdz_with_texture(tmpdir: str, color: tuple[int, int, int]) -> Path:


### PR DESCRIPTION
## Description

Fix the minimum-dependency test failures caused by strict warning handling:

- Let Pillow infer RGB from the packaged-texture test array instead of passing the deprecated `mode` argument.
- Narrowly allow the expected missing-UV warning from the AnyMal MPM example without weakening output checks for other warnings or examples.

This restores coverage at the declared Pillow 11.3 dependency floor.

Closes #3797.
Contributes to #3265.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (no user-facing documentation affected)
- [x] `CHANGELOG.md` has been updated (not required for this test-only fix)

## Test plan

- Reproduced the original `Image.fromarray(..., "RGB")` failure with Pillow 11.3.0 and `DeprecationWarning` promoted to an error.
- Ran both packaged-texture tests with Pillow 11.3.0 and strict deprecation handling: 2 passed.
- Verified the AnyMal allow-pattern exactly consumes the stderr reported by minimum-dependency CI.
- Ran `uvx pre-commit run -a`.

## Bug fix

**Steps to reproduce:**

1. Resolve the declared direct dependency floors.
2. Run the full suite with strict warning handling.
3. Observe two Pillow deprecation errors and one unexpected AnyMal warning failure.

**Minimal reproduction:**

```bash
uv sync --extra dev --resolution lowest-direct
uv run --no-sync -m newton.tests --strict-warnings
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation for the Anymal example by recognizing an expected texture warning without treating it as a failure.
  - Updated PNG image generation checks to better reflect inferred image color modes.
  - Increased test reliability for examples involving URDF textures and generated PNG assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->