### PR TITLE
Bump release version to 1.5.0rc2

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.0rc1``
+     - ``1.5.0rc2``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.0rc1"
+version = "1.5.0rc2"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0rc1"
+version = "1.5.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Bump the Newton 1.5 release branch from `1.5.0rc1` to `1.5.0rc2` after the
approved post-RC1 fixes landed in #3806. Regenerate the API version table and
update only Newton's own version entry in `uv.lock`.

The release dependencies and public-PyPI configuration remain unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `UV_CACHE_DIR=/tmp/newton-uv-cache uv run docs/generate_api.py`
- `UV_CACHE_DIR=/tmp/newton-uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/newton-uv-cache UV_TOOL_DIR=/tmp/newton-uv-tools PRE_COMMIT_HOME=/tmp/newton-pre-commit-cache-rc2 uvx --python 3.12 pre-commit run -a`
- `UV_CACHE_DIR=/tmp/newton-uv-cache uv build --wheel --out-dir /tmp/newton-1.5.0rc2-preflight`
- Clean isolated wheel install verified package metadata and
  `newton.__version__` both report `1.5.0rc2`.

The preceding integration head in #3806 passed the full platform and GPU unit
test matrices. Its GPU benchmark job was canceled automatically when the PR
merged after reaching 72.67%; it did not report a benchmark assertion failure.
