### PR TITLE
Clarify public release note guidance

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -8,6 +8,12 @@ description: Use when drafting or reviewing Newton GitHub Release notes, release
 Draft concise GitHub Release notes that explain why a Newton release exists and
 what users should know. Do not reproduce the full changelog; link to it.
 
+Write for external users moving from the previous final release to the current
+artifact without assuming they followed development or release candidates.
+Final-release notes must not mention earlier RCs. Never mention or link internal
+release audits, audit gists, readiness reports, cutoff SHAs, bake durations,
+audit counts, or other audit-only metadata; use those sources as evidence only.
+
 ## Workflow
 
 1. Identify the artifact, target version, and release type:
@@ -60,7 +66,11 @@ what users should know. Do not reproduce the full changelog; link to it.
 7. Draft a high-level overview and a short highlights list. Keep only
    consumer-relevant items. Omit CI, workflow, README layout, release-link
    pinning, and other internal/docs polish unless the user explicitly asks or it
-   affects library users.
+   affects library users. When a validated release review supplies the
+   highlights, preserve its release-defining conclusions, ordering, and public
+   wording unless publication rules require a change. Rewrite audit-oriented
+   framing, remove audit-only metadata, and adapt references to the release-note
+   format without weakening the user-facing claims.
 8. Keep a review-ready release-branch draft. After tagging, refresh it against
    the final tag and inspect the workflow-created draft GitHub Release. Publish
    only after verifying the final artifact and links per `docs/guide/release.rst`.
@@ -90,7 +100,10 @@ what users should know. Do not reproduce the full changelog; link to it.
 ## Style
 
 - Start with a short paragraph naming the version, release type, and purpose.
-- Use a `## Highlights` section with 3-6 grouped bullets.
+- Use a `## Highlights` section with typically 3-6 grouped bullets. Retain
+  additional release-defining highlights when the user explicitly requests them
+  or a validated release review establishes that they belong; do not drop a
+  significant theme merely to meet the usual count.
 - For bugfix releases, keep notes slim: no `## New features` section unless a
   genuinely notable capability shipped in the patch. The highlights are a
   categorized digest of fixes.


### PR DESCRIPTION
## Description

Clarify that final Newton release notes are standalone public communication for users upgrading from the previous final release. Internal audit artifacts and metadata remain evidence, not release-note content.

Preserve the conclusions, ordering, and public wording of validated release highlights while adapting references and removing audit-only framing. Allow more than the usual six highlights when explicitly requested or justified by a validated release review.

## Checklist

- [x] New or existing validation covers these changes
- [x] The documentation is up to date with these changes
- [x] A changelog fragment is not required because this changes agent guidance only

## Test plan

```text
uv run python /home/jcarius/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/release-notes
env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools PRE_COMMIT_HOME=/tmp/pre-commit-cache uvx --python 3.12 pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-note guidance to produce clearer final-release summaries.
  * Removed references to release candidates and internal audit details from public-facing notes.
  * Preserved validated release conclusions and approved wording while adapting them for end-user communication.
  * Expanded guidance to include additional significant highlights when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->