### PR TITLE
Rename implicit MPM status check

### DIFF
--- a/changelog/+implicit-mpm-status-8f2c4a1d.changed.md
+++ b/changelog/+implicit-mpm-status-8f2c4a1d.changed.md
@@ -1,1 +1,0 @@
-Rename `SolverImplicitMPM.check_status()` to `SolverImplicitMPM.check_sparse_grid_rebuild_status()`; call the new method after graph replay to detect sparse-grid capacity failures.

--- a/changelog/+implicit-mpm-status-8f2c4a1d.changed.md
+++ b/changelog/+implicit-mpm-status-8f2c4a1d.changed.md
@@ -1,0 +1,1 @@
+Rename `SolverImplicitMPM.check_status()` to `SolverImplicitMPM.check_sparse_grid_rebuild_status()`; call the new method after graph replay to detect sparse-grid capacity failures.

--- a/changelog/+implicit-mpm-status-8f2c4a1d.skip
+++ b/changelog/+implicit-mpm-status-8f2c4a1d.skip
@@ -1,0 +1,1 @@
+Release 1.5 API cleanup; changelog coverage is handled by the release-branch cherry-pick.

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -773,8 +773,9 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
     capture resources internally. Run an uncaptured warm-up step for rheology
     modes that build an inner graph lazily, and keep model topology, solver
     configuration, captured buffers, and step arguments fixed across replays.
-    Keep :meth:`reset` outside capture and call :meth:`check_status` after
-    replay to report sparse-grid capacity failures.
+    Keep :meth:`reset` outside capture and call
+    :meth:`check_sparse_grid_rebuild_status` after replay to report
+    sparse-grid capacity failures.
 
     [1] https://doi.org/10.1145/2897824.2925877
 
@@ -846,8 +847,8 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
         A positive value reserves persistent sparse-grid capacity and bounds
         active subsets of dense and fixed grids.
         ``-1`` retains per-step sparse-grid allocation and uses exact active
-        counts elsewhere. Call :meth:`check_status` after graph replay to
-        detect sparse-grid overflow.
+        counts elsewhere. Call :meth:`check_sparse_grid_rebuild_status` after
+        graph replay to detect sparse-grid overflow.
         """
         max_leaf_node_count: int = -1
         """Maximum NanoVDB leaf-node count across all worlds.
@@ -1334,12 +1335,17 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
         """Grid voxel size used by the solver."""
         return self._mpm_model.voxel_size
 
-    def _check_sparse_grid_rebuild_status(self) -> None:
+    def check_sparse_grid_rebuild_status(self) -> None:
         """Raise if a rebuildable sparse grid exceeded its reserved capacity.
 
-        The check synchronizes the solver device and is therefore intended for
-        initialization diagnostics or calls made after graph replay, not
-        from inside graph capture.
+        Rebuildable sparse-grid failures accumulate until a valid
+        :meth:`reset`. Call this method outside graph capture after replay; the
+        check synchronizes the solver device. It is a no-op when the solver has
+        no asynchronous sparse-grid status buffer.
+
+        Raises:
+            RuntimeError: If rebuild status is inspected during graph capture,
+                or if a rebuild reported a capacity or topology failure.
         """
         if self._grid_status is None:
             return
@@ -1352,26 +1358,12 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
         if status != wp.Volume.REBUILD_SUCCESS:
             raise _sparse_grid_rebuild_error(status)
 
-    def check_status(self) -> None:
-        """Raise if a sparse-grid rebuild exceeded its reserved capacity.
-
-        Rebuildable sparse-grid failures accumulate until a valid
-        :meth:`reset`. Call this method outside graph capture after replay; the
-        check synchronizes the solver device. It is a no-op when the solver has
-        no asynchronous sparse-grid status buffer.
-
-        Raises:
-            RuntimeError: If rebuild status is inspected during graph capture,
-                or if a rebuild reported a capacity or topology failure.
-        """
-        self._check_sparse_grid_rebuild_status()
-
     def _clear_sparse_grid_rebuild_status(self) -> None:
         """Clear the latest and accumulated sparse-grid rebuild status.
 
         Call this outside graph capture after handling a reported rebuild
-        failure. A subsequent :meth:`check_status` then reports only failures
-        produced after this boundary.
+        failure. A subsequent :meth:`check_sparse_grid_rebuild_status` then
+        reports only failures produced after this boundary.
 
         Raises:
             RuntimeError: If called while the solver device is capturing a graph.
@@ -2120,7 +2112,7 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
                             status=self._grid_status,
                             **capacity_kwargs,
                         )
-                        self._check_sparse_grid_rebuild_status()
+                        self.check_sparse_grid_rebuild_status()
                     else:
                         cell_ijks = [
                             voxel_coordinates(positions[begin:end], voxel_size, padding_voxels=padding_voxels)
@@ -2171,7 +2163,7 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
                         max_upper_node_count=self.max_upper_node_count,
                     )
                     if self._sparse_rebuildable:
-                        self._check_sparse_grid_rebuild_status()
+                        self.check_sparse_grid_rebuild_status()
                         grid = fem.Nanogrid(volume, temporary_store=temporary_store, rebuildable=True)
                     else:
                         grid = fem.Nanogrid(volume, temporary_store=temporary_store)

--- a/newton/tests/test_coupled_solver.py
+++ b/newton/tests/test_coupled_solver.py
@@ -697,7 +697,8 @@ class TestSolverCoupledContactsAndMPM(unittest.TestCase):
 
         self.assertFalse(hasattr(SolverImplicitMPM, "supports_graph_capture"))
         self.assertFalse(hasattr(SolverImplicitMPM, "prepare_graph_capture"))
-        self.assertTrue(hasattr(SolverImplicitMPM, "check_status"))
+        self.assertFalse(hasattr(SolverImplicitMPM, "check_status"))
+        self.assertTrue(hasattr(SolverImplicitMPM, "check_sparse_grid_rebuild_status"))
 
     def test_implicit_mpm_reset_syncs_namespaced_non_in_place_state(self):
         """Verify coupled reset mirrors MPM history into the non-in-place output state."""

--- a/newton/tests/test_implicit_mpm_multiworld_sparse.py
+++ b/newton/tests/test_implicit_mpm_multiworld_sparse.py
@@ -453,12 +453,12 @@ def test_sparse_status_is_sticky_until_explicitly_cleared(test, device):
     test.assertEqual(int(solver._grid_status.numpy()[0]), wp.Volume.REBUILD_SUCCESS)
     test.assertTrue(int(solver._grid_accumulated_status.numpy()[0]) & wp.Volume.REBUILD_VOXEL_CAPACITY_EXCEEDED)
     with test.assertRaisesRegex(RuntimeError, "sparse grid rebuild capacity"):
-        solver.check_status()
+        solver.check_sparse_grid_rebuild_status()
 
     solver._clear_sparse_grid_rebuild_status()
     test.assertEqual(int(solver._grid_status.numpy()[0]), wp.Volume.REBUILD_SUCCESS)
     test.assertEqual(int(solver._grid_accumulated_status.numpy()[0]), wp.Volume.REBUILD_SUCCESS)
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
 
     with wp.ScopedCapture(device=device, force_module_load=False):
         with test.assertRaisesRegex(RuntimeError, "clear sparse grid rebuild status.*graph capture"):
@@ -722,10 +722,10 @@ def test_coupled_mpm_non_in_place_capture_replays_after_reset(test, device):
 
     for _ in range(2):
         wp.capture_launch(capture.graph)
-        mpm_solver.check_status()
+        mpm_solver.check_sparse_grid_rebuild_status()
     coupled.reset(state_1, world_mask=wp.array((True, False, False), dtype=wp.bool, device=device))
     wp.capture_launch(capture.graph)
-    mpm_solver.check_status()
+    mpm_solver.check_sparse_grid_rebuild_status()
 
     test.assertTrue(np.isfinite(state_0.particle_q.numpy()).all())
     test.assertTrue(np.isfinite(state_1.particle_q.numpy()).all())
@@ -824,7 +824,7 @@ def test_sparse_multiworld_capture_rebuilds_isolated_topology(test, device):
         solver.step(state_1, state_0, control=None, contacts=None, dt=dt)
 
     wp.capture_launch(capture.graph)
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
     rebuilt = _sparse_grid_snapshot(grid)
 
     test.assertEqual(int(solver._grid_status.numpy()[0]), wp.Volume.REBUILD_SUCCESS)
@@ -874,7 +874,7 @@ def test_sparse_multiworld_outer_capture_matches_eager(test, device):
         eager_solver.step(eager_state_0, eager_state_1, control=None, contacts=None, dt=dt)
         eager_solver.step(eager_state_1, eager_state_0, control=None, contacts=None, dt=dt)
         wp.capture_launch(capture.graph)
-        captured_solver.check_status()
+        captured_solver.check_sparse_grid_rebuild_status()
 
         test.assertEqual(int(captured_solver._grid_status.numpy()[0]), wp.Volume.REBUILD_SUCCESS)
         eager_arrays = _sparse_case_state_arrays(eager_state_0)

--- a/newton/tests/test_implicit_mpm_rebuildable_sparse.py
+++ b/newton/tests/test_implicit_mpm_rebuildable_sparse.py
@@ -53,12 +53,14 @@ def _make_sparse_solver(
 
 
 def test_rebuildable_sparse_s2_is_enabled(test, device):
+    """Verify S2 collider bases enable rebuildable sparse grids."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     solver = _make_sparse_solver(model, max_active_cell_count=4, collider_basis="S2")
     test.assertTrue(solver._sparse_rebuildable)
 
 
 def test_rebuildable_sparse_rejects_grid_warmstart(test, device):
+    """Verify rebuildable sparse grids reject grid-backed warm starts."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     for warmstart_mode in ("grid", "smoothed"):
         with (
@@ -69,6 +71,7 @@ def test_rebuildable_sparse_rejects_grid_warmstart(test, device):
 
 
 def test_rebuildable_sparse_auto_uses_particle_warmstart(test, device):
+    """Verify automatic warm starts use particles for rebuildable sparse grids."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
 
     rebuildable = _make_sparse_solver(model, max_active_cell_count=4, warmstart_mode="auto")
@@ -81,6 +84,7 @@ def test_rebuildable_sparse_auto_uses_particle_warmstart(test, device):
 
 
 def test_rebuildable_sparse_refreshes_retained_topologies(test, device):
+    """Verify retained function-space topologies rebuild in place."""
     del test, device
     geometry = object()
     topologies = [SimpleNamespace(rebuild=mock.Mock()) for _ in range(3)]
@@ -110,6 +114,7 @@ def test_rebuildable_sparse_refreshes_retained_topologies(test, device):
 
 
 def test_rebuildable_sparse_node_capacity_validation(test, device):
+    """Verify rebuildable sparse-grid node capacities reject invalid values."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     for name in ("max_leaf_node_count", "max_lower_node_count", "max_upper_node_count"):
         for value in (0, -2, True, 1.5):
@@ -118,6 +123,7 @@ def test_rebuildable_sparse_node_capacity_validation(test, device):
 
 
 def test_rebuildable_sparse_grid_reserves_explicit_hierarchy_capacity(test, device):
+    """Verify explicit sparse-grid hierarchy capacities are reserved."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     solver = _make_sparse_solver(
         model,
@@ -135,6 +141,7 @@ def test_rebuildable_sparse_grid_reserves_explicit_hierarchy_capacity(test, devi
 
 
 def test_rebuildable_sparse_automatic_hierarchy_respects_explicit_leaf(test, device):
+    """Verify automatic internal-node capacities respect an explicit leaf capacity."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     solver = _make_sparse_solver(model, max_active_cell_count=64, max_leaf_node_count=1)
 
@@ -145,6 +152,7 @@ def test_rebuildable_sparse_automatic_hierarchy_respects_explicit_leaf(test, dev
 
 
 def test_rebuildable_sparse_automatic_upper_capacity_respects_explicit_lower(test, device):
+    """Verify automatic upper-node capacity respects an explicit lower capacity."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     solver = _make_sparse_solver(model, max_active_cell_count=64, max_lower_node_count=1)
 
@@ -155,6 +163,7 @@ def test_rebuildable_sparse_automatic_upper_capacity_respects_explicit_lower(tes
 
 
 def test_rebuildable_sparse_rejects_inconsistent_hierarchy_capacity(test, device):
+    """Verify inconsistent sparse-grid hierarchy capacities are rejected."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01)])
     with test.assertRaisesRegex(ValueError, "capacity hierarchy"):
         _make_sparse_solver(
@@ -167,15 +176,17 @@ def test_rebuildable_sparse_rejects_inconsistent_hierarchy_capacity(test, device
 
 
 def test_rebuildable_sparse_grid_excludes_inactive_particles(test, device):
+    """Verify inactive particles do not contribute to sparse-grid construction."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01), (1000.01, 1000.01, 1000.01)], (1,))
     solver = _make_sparse_solver(model, max_active_cell_count=2)
 
     test.assertTrue(solver._sparse_rebuildable)
     test.assertEqual(solver._scratchpad.grid.cell_grid.get_active_stats().voxel_count, 1)
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
 
 
 def test_rebuildable_sparse_grid_excludes_deformable_collider_particles(test, device):
+    """Verify deformable collider particles are excluded from sparse-grid rebuilds."""
     positions = (
         (0.01, 0.01, 0.01),
         (0.02, 0.01, 0.01),
@@ -219,6 +230,7 @@ def test_rebuildable_sparse_grid_excludes_deformable_collider_particles(test, de
 
 
 def test_rebuildable_sparse_grid_excludes_nonfinite_particles_before_rebuild(test, device):
+    """Verify non-finite particles are excluded before sparse-grid rebuilds."""
     model = _make_particle_model(
         device,
         [(0.01, 0.01, 0.01), (1.01, 1.01, 1.01), (2.01, 2.01, 2.01), (3.01, 3.01, 3.01)],
@@ -249,6 +261,7 @@ def test_rebuildable_sparse_grid_excludes_nonfinite_particles_before_rebuild(tes
 
 
 def test_rebuildable_sparse_rebuild_uses_mpm_transfer_flags(test, device):
+    """Verify sparse-grid rebuilds use MPM transfer flags."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01), (1000.01, 1000.01, 1000.01)], (1,))
     solver = _make_sparse_solver(model, max_active_cell_count=2)
     state_in = model.state()
@@ -260,10 +273,11 @@ def test_rebuildable_sparse_rebuild_uses_mpm_transfer_flags(test, device):
     solver.step(state_in, state_out, None, None, 0.001)
 
     test.assertEqual(solver._scratchpad.grid.cell_grid.get_active_stats().voxel_count, 1)
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
 
 
 def test_rebuildable_sparse_grid_reserves_empty_capacity(test, device):
+    """Verify empty sparse grids retain their configured capacity."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01), (1.01, 1.01, 1.01)], (0, 1))
     solver = _make_sparse_solver(model, max_active_cell_count=4)
 
@@ -273,6 +287,7 @@ def test_rebuildable_sparse_grid_reserves_empty_capacity(test, device):
 
 
 def test_rebuildable_sparse_grid_reports_initial_overflow(test, device):
+    """Verify initial sparse-grid capacity overflow raises."""
     model = _make_particle_model(device, [(0.01, 0.01, 0.01), (1.01, 1.01, 1.01)])
 
     with test.assertRaisesRegex(RuntimeError, "sparse grid rebuild capacity"):
@@ -345,7 +360,7 @@ def _check_rebuildable_sparse_auto_gs_cuda_graph(test, device, collider_basis):
     for _ in range(2):
         wp.capture_launch(capture.graph)
 
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
     test.assertEqual(solver._scratchpad.grid.cell_grid.id, cell_grid_id)
     final_cell_count = grid.cell_grid.get_active_stats().voxel_count
     final_cells = {tuple(ijk) for ijk in grid.cell_grid.get_voxels().numpy()[:final_cell_count]}
@@ -362,6 +377,7 @@ def _check_rebuildable_sparse_auto_gs_cuda_graph(test, device, collider_basis):
 
 
 def test_rebuildable_sparse_auto_gs_cuda_graph(test, device):
+    """Verify automatic Gauss-Seidel matches eager execution under graph replay."""
     if not wp.is_mempool_enabled(device):
         test.skipTest("CUDA graph capture requires the Warp memory pool")
 
@@ -371,6 +387,7 @@ def test_rebuildable_sparse_auto_gs_cuda_graph(test, device):
 
 
 def test_rebuildable_sparse_cuda_graph_reports_overflow(test, device):
+    """Verify CUDA graph replay reports sparse-grid capacity overflow."""
     if not wp.is_mempool_enabled(device):
         test.skipTest("CUDA graph capture requires the Warp memory pool")
 
@@ -388,11 +405,11 @@ def test_rebuildable_sparse_cuda_graph_reports_overflow(test, device):
     wp.capture_launch(capture.graph)
 
     with test.assertRaisesRegex(RuntimeError, "sparse grid rebuild capacity"):
-        solver.check_status()
+        solver.check_sparse_grid_rebuild_status()
     status = int(solver._grid_accumulated_status.numpy()[0])
     test.assertTrue(status & wp.Volume.REBUILD_VOXEL_CAPACITY_EXCEEDED)
     solver._clear_sparse_grid_rebuild_status()
-    solver.check_status()
+    solver.check_sparse_grid_rebuild_status()
 
 
 class TestImplicitMPMRebuildableSparse(unittest.TestCase):


### PR DESCRIPTION
## Description

Rename `SolverImplicitMPM.check_status()` to
`SolverImplicitMPM.check_sparse_grid_rebuild_status()` before the API reaches
a stable release. The narrower name reflects that the method only synchronizes
and reports rebuildable sparse-grid capacity or topology failures after graph
replay; it does not define a general solver status protocol.

Update internal references and tests, add the missing required docstrings to
the rebuildable sparse-grid tests, and add a skip fragment because release-note
coverage will be handled when this change is cherry-picked to 1.5.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added to `changelog/`

## Test plan

- `uv run --extra dev python -m unittest newton.tests.test_implicit_mpm_rebuildable_sparse.TestImplicitMPMRebuildableSparse -v`
- Four affected graph-replay tests in `TestImplicitMPMMultiworldSparse`
- `TestSolverCoupledContactsAndMPM.test_graph_capture_setup_stays_solver_specific`
- `uv run docs/generate_api.py`
- `towncrier build --draft --version 1.5.0 --date 2026-08-06`
- `uvx --python 3.12 pre-commit run -a`

## New feature / API change

```python
solver.check_sparse_grid_rebuild_status()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Renamed the sparse-grid status check API to `check_sparse_grid_rebuild_status()`.
  - The previous generic `check_status()` method is no longer available.

- **Bug Fixes**
  - Sparse-grid capacity failures are now detected after graph replay, improving error reporting for rebuild issues.

- **Tests**
  - Updated sparse-grid and coupled-solver coverage to validate the renamed API and rebuild-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->