### PR TITLE
Preserve shell mesh inertia in MuJoCo

### DIFF
--- a/changelog/3822.fixed.md
+++ b/changelog/3822.fixed.md
@@ -1,1 +1,1 @@
-Preserve shell inertia for mesh shapes exported by `SolverMuJoCo`.
+Preserve shell inertia for non-solid mesh shapes exported to MuJoCo by `SolverMuJoCo`.

--- a/changelog/3822.fixed.md
+++ b/changelog/3822.fixed.md
@@ -1,0 +1,1 @@
+Preserve shell inertia for mesh shapes exported by `SolverMuJoCo`.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5541,6 +5541,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         shape_transform = model.shape_transform.numpy()
         shape_type = model.shape_type.numpy()
         shape_size = model.shape_scale.numpy()
+        shape_is_solid = model.shape_is_solid.numpy()
         shape_flags = model.shape_flags.numpy()
         shape_collision_group = model.shape_collision_group.numpy()
         shape_world = model.shape_world.numpy()
@@ -6098,12 +6099,14 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                             f"{model.shape_label[shape]!r} (shape {shape}). Use use_mujoco_contacts=False so "
                             "Newton's collision pipeline handles this mesh, or replace it with a plane/box/thick mesh."
                         )
-                    spec.add_mesh(
+                    mesh_spec = spec.add_mesh(
                         name=name,
                         uservert=vertices.flatten(),
                         userface=indices.flatten(),
                         maxhullvert=maxhullvert,
                     )
+                    if not shape_is_solid[shape]:
+                        mesh_spec.inertia = mujoco.mjtMeshInertia.mjMESH_INERTIA_SHELL
                     geom_params["meshname"] = name
                 geom_params["pos"] = tf.p
                 geom_params["quat"] = quat_to_mjc(tf.q)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -94,6 +94,37 @@ class TestMuJoCoSolver(unittest.TestCase):
         self.assertIn((-2147483648, 2147483647), actual_masks)
         self.assertIn((1, 1), actual_masks)
 
+    def test_shell_mesh_inertia_is_preserved_in_mujoco(self):
+        """Preserve hollow Newton mesh inertia when exporting to MuJoCo."""
+        builder = newton.ModelBuilder()
+        body = builder.add_link(
+            mass=1.0,
+            com=wp.vec3(0.0, 0.0, 0.0),
+            inertia=wp.mat33(np.eye(3)),
+        )
+        mesh = Mesh.create_box(0.1, 0.1, 0.01, compute_inertia=False)
+        builder.add_shape_mesh(
+            body=body,
+            mesh=mesh,
+            cfg=newton.ModelBuilder.ShapeConfig(density=0.0, is_solid=False),
+            label="shell_mesh",
+        )
+        joint = builder.add_joint_free(child=body)
+        builder.add_articulation([joint])
+        model = builder.finalize(device="cpu")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            xml_path = os.path.join(temp_dir, "shell_mesh.xml")
+            SolverMuJoCo(
+                model,
+                use_mujoco_cpu=True,
+                save_to_mjcf=xml_path,
+            )
+            mesh_element = ET.parse(xml_path).find("./asset/mesh")
+
+        self.assertIsNotNone(mesh_element)
+        self.assertEqual(mesh_element.get("inertia"), "shell")
+
     def test_tolerance_options(self):
         """Test that tolerance and ls_tolerance options are properly set on the MuJoCo Warp model."""
         # Create minimal model with proper inertia


### PR DESCRIPTION
## Description

Preserve Newton's hollow mesh inertia intent when `SolverMuJoCo` exports mesh assets to `MjSpec`.

`Model.shape_is_solid=False` now maps to `mujoco.mjtMeshInertia.mjMESH_INERTIA_SHELL`. This prevents MuJoCo from attempting volume inertia integration for thin shell meshes and convex-decomposition parts.

Closes #3822.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] A changelog fragment has been added

## Test plan

```
uv run --frozen --extra dev python -m unittest \
  newton.tests.test_schema_resolver.TestSchemaResolver.test_mass_model \
  newton.tests.test_mujoco_solver.TestMuJoCoSolver.test_shell_mesh_inertia_is_preserved_in_mujoco

uvx pre-commit run --files \
  newton/_src/solvers/mujoco/solver_mujoco.py \
  newton/tests/test_mujoco_solver.py \
  changelog/3822.fixed.md
```

Both commands pass.

## Bug fix

**Steps to reproduce:**

1. Add a mesh with `ModelBuilder.ShapeConfig(is_solid=False)`.
2. Construct `SolverMuJoCo` and save the generated MJCF.
3. Observe that the `<mesh>` asset omits `inertia="shell"`.
4. Thin or convex-decomposed meshes can then fail `MjSpec.compile()` with "mesh volume is too small".

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton
from newton.solvers import SolverMuJoCo

builder = newton.ModelBuilder()
body = builder.add_link(
    mass=1.0,
    com=wp.vec3(0.0, 0.0, 0.0),
    inertia=wp.mat33(np.eye(3)),
)
builder.add_shape_mesh(
    body=body,
    mesh=newton.Mesh.create_box(0.1, 0.1, 0.01, compute_inertia=False),
    cfg=newton.ModelBuilder.ShapeConfig(density=0.0, is_solid=False),
)
joint = builder.add_joint_free(child=body)
builder.add_articulation([joint])
SolverMuJoCo(builder.finalize(device="cpu"), use_mujoco_cpu=True)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved shell inertia when exporting hollow or non-solid mesh shapes to MuJoCo.
  - Solid meshes continue using MuJoCo’s standard inertia behavior.

- **Tests**
  - Added coverage verifying that shell inertia is retained in exported MJCF files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->