### PR TITLE
Skip unused initial MuJoCo contacts

### DIFF
--- a/changelog/3824.fixed.md
+++ b/changelog/3824.fixed.md
@@ -1,1 +1,1 @@
-Skip the initialization-only MuJoCo collision pass when using Newton-generated contacts.
+Skip the initialization-only MuJoCo collision pass without reducing Newton-generated contact or constraint capacity.

--- a/changelog/3824.fixed.md
+++ b/changelog/3824.fixed.md
@@ -1,0 +1,1 @@
+Skip the initialization-only MuJoCo collision pass when using Newton-generated contacts.

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -652,6 +652,48 @@ def _estimate_rigid_contact_max(model: Model) -> int:
     return max(_RIGID_CONTACT_MIN_CAPACITY, total_contacts)
 
 
+def _estimate_rigid_contact_max_per_world(model: Model, rigid_contact_max: int) -> int:
+    """Estimate the busiest world's share of a global rigid-contact capacity.
+
+    The collision pipeline stores contacts in one heterogeneous global buffer,
+    while downstream solvers may allocate constraint rows per world. Bound that
+    per-world allocation from the model's world-compatible shape pairs instead
+    of duplicating the entire global contact capacity into every world.
+
+    Args:
+        model: The simulation model.
+        rigid_contact_max: Global rigid-contact capacity.
+
+    Returns:
+        Maximum estimated contacts that one world can contribute, capped by the
+        global rigid-contact capacity.
+    """
+    if rigid_contact_max <= 0 or model.shape_contact_pair_count == 0:
+        return 0
+
+    pairs = model.shape_contact_pairs.numpy().reshape((-1, 2))
+    types = model.shape_type.numpy()
+    mesh_types = (int(GeoType.MESH), int(GeoType.HFIELD))
+    mesh_pairs = np.isin(types[pairs], mesh_types).any(axis=1)
+    contacts_per_pair = np.where(
+        mesh_pairs,
+        _RIGID_CONTACTS_PER_MESH_PAIR,
+        _RIGID_CONTACTS_PER_PRIMITIVE_PAIR,
+    )
+
+    worlds = model.shape_world.numpy()
+    pair_worlds = np.maximum(worlds[pairs[:, 0]], worlds[pairs[:, 1]])
+    local_pairs = pair_worlds >= 0
+    contacts_by_world = np.bincount(
+        pair_worlds[local_pairs],
+        weights=contacts_per_pair[local_pairs],
+        minlength=model.world_count,
+    )
+    busiest_world_contacts = int(np.max(contacts_by_world, initial=0))
+    global_contacts = int(np.sum(contacts_per_pair[~local_pairs]))
+    return min(rigid_contact_max, busiest_world_contacts + global_contacts)
+
+
 def _compute_per_world_shape_pairs_max(model: Model) -> int:
     """Compute the maximum number of candidate shape pairs using per-world counts.
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -32,6 +32,7 @@ from ...sim import (
     StateFlags,
 )
 from ...sim.articulation import eval_articulation_fk, eval_fk
+from ...sim.collide import _estimate_rigid_contact_max
 from ...sim.contacts import GENERATION_SENTINEL as _GENERATION_SENTINEL
 from ...sim.graph_coloring import color_graph, plot_graph
 from ...utils import topological_sort
@@ -7680,6 +7681,24 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             # TODO find better heuristics to determine nconmax and njmax
             if disable_contacts:
                 nconmax = 0
+            elif not self._use_mujoco_contacts:
+                # The initialization forward intentionally produces no contacts
+                # in this mode, so size MJWarp from Newton's collision budget.
+                if nconmax is None:
+                    newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
+                    nconmax = (newton_contact_max + nworld - 1) // nworld
+
+                if njmax is None:
+                    max_contact_dim = max(
+                        1,
+                        int(np.max(self.mj_model.geom_condim, initial=1)),
+                        int(np.max(self.mj_model.pair_dim, initial=1)),
+                    )
+                    if self.mj_model.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC:
+                        constraint_rows_per_contact = max_contact_dim
+                    else:
+                        constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
+                    njmax = self.mj_data.nefc + nconmax * constraint_rows_per_contact
             elif nconmax is not None and nconmax < self.mj_data.ncon:
                 warnings.warn(
                     f"[WARNING] Value for nconmax is changed from {nconmax} to {self.mj_data.ncon} following an MjWarp requirement.",

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7684,21 +7684,32 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             elif not self._use_mujoco_contacts:
                 # The initialization forward intentionally produces no contacts
                 # in this mode, so size MJWarp from Newton's collision budget.
+                newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
+                default_nconmax = (newton_contact_max + nworld - 1) // nworld
                 if nconmax is None:
-                    newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
-                    nconmax = (newton_contact_max + nworld - 1) // nworld
+                    nconmax = default_nconmax
+                elif nconmax >= 0:
+                    nconmax = max(nconmax, default_nconmax)
 
+                max_contact_dim = max(
+                    1,
+                    int(np.max(self.mj_model.geom_condim, initial=1)),
+                    int(np.max(self.mj_model.pair_dim, initial=1)),
+                )
+                if self.mj_model.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC:
+                    constraint_rows_per_contact = max_contact_dim
+                else:
+                    constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
+
+                # MJWarp stores contacts in one heterogeneous buffer, so every
+                # contact can belong to one world even though nconmax is passed
+                # as a per-world allocation. Constraint rows are strictly
+                # per-world and must cover that concentrated global capacity.
+                default_njmax = self.mj_data.nefc + nconmax * nworld * constraint_rows_per_contact
                 if njmax is None:
-                    max_contact_dim = max(
-                        1,
-                        int(np.max(self.mj_model.geom_condim, initial=1)),
-                        int(np.max(self.mj_model.pair_dim, initial=1)),
-                    )
-                    if self.mj_model.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC:
-                        constraint_rows_per_contact = max_contact_dim
-                    else:
-                        constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
-                    njmax = self.mj_data.nefc + nconmax * constraint_rows_per_contact
+                    njmax = default_njmax
+                elif njmax >= 0:
+                    njmax = max(njmax, default_njmax)
             elif nconmax is not None and nconmax < self.mj_data.ncon:
                 warnings.warn(
                     f"[WARNING] Value for nconmax is changed from {nconmax} to {self.mj_data.ncon} following an MjWarp requirement.",

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7383,7 +7383,20 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # just setting qpos0 to d.qpos leads to weird behavior here, needs
         # to be investigated.
 
-        mujoco.mj_forward(self.mj_model, self.mj_data)
+        # ``use_mujoco_contacts=False`` switches MJWarp collision detection off
+        # after conversion, but this CPU forward runs before that option exists.
+        # Temporarily suppress MuJoCo contacts so large Newton-contact scenes do
+        # not build an unused contact set (and potentially overflow mjData's
+        # stack) during solver construction. Restore the authored option before
+        # the model is handed to MJWarp; injected Newton contacts remain enabled.
+        restore_contact_disable = not disable_contacts and not self._use_mujoco_contacts
+        if restore_contact_disable:
+            self.mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+        try:
+            mujoco.mj_forward(self.mj_model, self.mj_data)
+        finally:
+            if restore_contact_disable:
+                self.mj_model.opt.disableflags &= ~int(mujoco.mjtDisableBit.mjDSBL_CONTACT)
 
         # now that the model is compiled, get the actual geom indices and compute
         # shape transform corrections

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -32,7 +32,7 @@ from ...sim import (
     StateFlags,
 )
 from ...sim.articulation import eval_articulation_fk, eval_fk
-from ...sim.collide import _estimate_rigid_contact_max
+from ...sim.collide import _estimate_rigid_contact_max, _estimate_rigid_contact_max_per_world
 from ...sim.contacts import GENERATION_SENTINEL as _GENERATION_SENTINEL
 from ...sim.graph_coloring import color_graph, plot_graph
 from ...utils import topological_sort
@@ -7684,6 +7684,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             elif not self._use_mujoco_contacts:
                 # The initialization forward intentionally produces no contacts
                 # in this mode, so size MJWarp from Newton's collision budget.
+                from mujoco_warp._src.io import _default_njmax as estimate_mujoco_warp_njmax
+
                 newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
                 default_nconmax = (newton_contact_max + nworld - 1) // nworld
                 if nconmax is None:
@@ -7702,10 +7704,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
 
                 # MJWarp stores contacts in one heterogeneous buffer, so every
-                # contact can belong to one world even though nconmax is passed
-                # as a per-world allocation. Constraint rows are strictly
-                # per-world and must cover that concentrated global capacity.
-                default_njmax = self.mj_data.nefc + nconmax * nworld * constraint_rows_per_contact
+                # contact can belong to any compatible world even though
+                # nconmax is passed as a per-world allocation. Constraint rows
+                # are strictly per-world, so size them from the busiest-world
+                # topology rather than duplicating the global capacity.
+                per_world_contact_max = _estimate_rigid_contact_max_per_world(model, nconmax * nworld)
+                default_njmax = max(
+                    estimate_mujoco_warp_njmax(self.mj_model, self.mj_data),
+                    self.mj_data.nefc + per_world_contact_max * constraint_rows_per_contact,
+                )
                 if njmax is None:
                     njmax = default_njmax
                 elif njmax >= 0:

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4390,20 +4390,59 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         )
 
     def test_initial_forward_skips_mujoco_contacts(self):
-        """Newton-contact mode avoids transient MuJoCo collision detection."""
-        mujoco, _ = SolverMuJoCo.import_mujoco()
-        original_forward = mujoco.mj_forward
-        contact_disabled_during_forward: list[bool] = []
+        """Verify Newton-contact initialization skips transient MuJoCo collision detection."""
+        try:
+            mujoco, _ = SolverMuJoCo.import_mujoco()
+            original_forward = mujoco.mj_forward
+            contact_disabled_during_forward: list[bool] = []
 
-        def recording_forward(model, data):
-            contact_disabled_during_forward.append(bool(model.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_CONTACT))
-            return original_forward(model, data)
+            def recording_forward(model, data):
+                contact_disabled_during_forward.append(
+                    bool(model.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_CONTACT)
+                )
+                return original_forward(model, data)
 
-        with patch.object(mujoco, "mj_forward", side_effect=recording_forward):
-            solver = SolverMuJoCo(self.model, use_mujoco_contacts=False)
+            with patch.object(mujoco, "mj_forward", side_effect=recording_forward):
+                solver = SolverMuJoCo(self.model, use_mujoco_contacts=False)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
 
         self.assertEqual(contact_disabled_during_forward, [True])
         self.assertFalse(solver.mj_model.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_CONTACT)
+
+    def test_newton_contact_defaults_preserve_generated_contacts(self):
+        """Preserve generated Newton contacts when sizing default MuJoCo buffers."""
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        for sphere_index in range(60):
+            body = builder.add_body(
+                xform=wp.transform(
+                    wp.vec3(float(sphere_index % 10) * 2.0, float(sphere_index // 10) * 2.0, 0.45),
+                    wp.quat_identity(),
+                )
+            )
+            builder.add_shape_sphere(body=body, radius=0.5)
+        model = builder.finalize()
+
+        try:
+            solver = SolverMuJoCo(model, use_mujoco_contacts=False)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        state = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+        collision_pipeline = newton.CollisionPipeline(model)
+        contacts = collision_pipeline.contacts()
+        collision_pipeline.collide(state, contacts)
+        generated_contact_count = int(contacts.rigid_contact_count.numpy()[0])
+
+        self.assertGreater(generated_contact_count, 48)
+        self.assertGreaterEqual(solver.mjw_data.naconmax, generated_contact_count)
+        self.assertGreaterEqual(solver.mjw_data.njmax, generated_contact_count * 4)
+
+        solver._convert_contacts_to_mjwarp(model, state, contacts)
+        injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertEqual(injected_contact_count, generated_contact_count)
 
     def test_sphere_rolls_without_slip_with_newton_contacts(self):
         radius = 0.1

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -9,6 +9,7 @@ import time
 import unittest
 import warnings
 import xml.etree.ElementTree as ET
+from unittest.mock import patch
 
 import numpy as np  # For numerical operations and random values
 import warp as wp
@@ -4387,6 +4388,22 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
             self.sphere_radius * 1.2,
             f"Sphere is floating above the plane. Final height: {final_height}",
         )
+
+    def test_initial_forward_skips_mujoco_contacts(self):
+        """Newton-contact mode avoids transient MuJoCo collision detection."""
+        mujoco, _ = SolverMuJoCo.import_mujoco()
+        original_forward = mujoco.mj_forward
+        contact_disabled_during_forward: list[bool] = []
+
+        def recording_forward(model, data):
+            contact_disabled_during_forward.append(bool(model.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_CONTACT))
+            return original_forward(model, data)
+
+        with patch.object(mujoco, "mj_forward", side_effect=recording_forward):
+            solver = SolverMuJoCo(self.model, use_mujoco_contacts=False)
+
+        self.assertEqual(contact_disabled_during_forward, [True])
+        self.assertFalse(solver.mj_model.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_CONTACT)
 
     def test_sphere_rolls_without_slip_with_newton_contacts(self):
         radius = 0.1

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4334,6 +4334,21 @@ class TestMuJoCoSolverFixedTendonProperties(TestMuJoCoSolverPropertiesBase):
 
 
 class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
+    @staticmethod
+    def _build_grounded_spheres(sphere_count):
+        """Build a single-world model with separated spheres touching the ground."""
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        for sphere_index in range(sphere_count):
+            body = builder.add_body(
+                xform=wp.transform(
+                    wp.vec3(float(sphere_index % 10) * 2.0, float(sphere_index // 10) * 2.0, 0.45),
+                    wp.quat_identity(),
+                )
+            )
+            builder.add_shape_sphere(body=body, radius=0.5)
+        return builder.finalize()
+
     def setUp(self):
         """Set up a simple model with a sphere and a plane."""
         builder = newton.ModelBuilder()
@@ -4412,17 +4427,7 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
 
     def test_newton_contact_defaults_preserve_generated_contacts(self):
         """Preserve generated Newton contacts when sizing default MuJoCo buffers."""
-        builder = newton.ModelBuilder()
-        builder.add_ground_plane()
-        for sphere_index in range(60):
-            body = builder.add_body(
-                xform=wp.transform(
-                    wp.vec3(float(sphere_index % 10) * 2.0, float(sphere_index // 10) * 2.0, 0.45),
-                    wp.quat_identity(),
-                )
-            )
-            builder.add_shape_sphere(body=body, radius=0.5)
-        model = builder.finalize()
+        model = self._build_grounded_spheres(60)
 
         try:
             solver = SolverMuJoCo(model, use_mujoco_contacts=False)
@@ -4443,6 +4448,75 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         solver._convert_contacts_to_mjwarp(model, state, contacts)
         injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
         self.assertEqual(injected_contact_count, generated_contact_count)
+
+    def test_newton_contact_defaults_bound_explicit_capacities(self):
+        """Preserve Newton-derived lower bounds for explicit MuJoCo capacities."""
+        model = self._build_grounded_spheres(60)
+        state = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+        collision_pipeline = newton.CollisionPipeline(model)
+        contacts = collision_pipeline.contacts()
+        collision_pipeline.collide(state, contacts)
+        generated_contact_count = int(contacts.rigid_contact_count.numpy()[0])
+
+        try:
+            solver = SolverMuJoCo(model, use_mujoco_contacts=False, nconmax=16, njmax=16)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        self.assertGreater(generated_contact_count, 48)
+        self.assertGreater(model.rigid_contact_max, 16)
+        self.assertGreaterEqual(solver.mjw_data.naconmax, model.rigid_contact_max)
+        self.assertGreaterEqual(solver.mjw_data.njmax, model.rigid_contact_max * 4)
+
+        solver._convert_contacts_to_mjwarp(model, state, contacts)
+        injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertEqual(injected_contact_count, generated_contact_count)
+
+    def test_newton_contact_constraints_cover_uneven_worlds(self):
+        """Size per-world constraints for contacts concentrated in one world."""
+        sphere_count = 30
+        world = newton.ModelBuilder()
+        for sphere_index in range(sphere_count):
+            body = world.add_body(
+                xform=wp.transform(
+                    wp.vec3(float(sphere_index % 10) * 2.0, float(sphere_index // 10) * 2.0, 0.45),
+                    wp.quat_identity(),
+                )
+            )
+            world.add_shape_sphere(body=body, radius=0.5)
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        builder.add_world(world, xform=wp.transform_identity())
+        builder.add_world(world, xform=wp.transform(wp.vec3(0.0, 0.0, 10.0), wp.quat_identity()))
+        model = builder.finalize()
+
+        state_0 = model.state()
+        state_1 = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+        collision_pipeline = newton.CollisionPipeline(model, rigid_contact_max=sphere_count)
+        contacts = collision_pipeline.contacts()
+        collision_pipeline.collide(state_0, contacts)
+        generated_contact_count = int(contacts.rigid_contact_count.numpy()[0])
+
+        try:
+            solver = SolverMuJoCo(model, separate_worlds=True, use_mujoco_contacts=False)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        self.assertEqual(generated_contact_count, sphere_count)
+        solver.step(state_0, state_1, model.control(), contacts, 1.0 / 240.0)
+
+        injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        contact_worlds = solver.mjw_data.contact.worldid.numpy()[:injected_contact_count]
+        contacts_per_world = np.bincount(contact_worlds, minlength=model.world_count)
+        constraints_per_world = solver.mjw_data.nefc.numpy()
+
+        self.assertEqual(injected_contact_count, generated_contact_count)
+        np.testing.assert_array_equal(contacts_per_world, [sphere_count, 0])
+        self.assertEqual(int(constraints_per_world[0]), sphere_count * 4)
+        self.assertLessEqual(int(np.max(constraints_per_world)), solver.mjw_data.njmax)
 
     def test_sphere_rolls_without_slip_with_newton_contacts(self):
         radius = 0.1

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4473,6 +4473,49 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
         self.assertEqual(injected_contact_count, generated_contact_count)
 
+    def test_newton_contact_capacity_preserves_delayed_joint_limits(self):
+        """Preserve default capacity for non-contact constraints activated after initialization."""
+        joint_count = 10
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        inertia = wp.mat33(np.eye(3) * 0.1)
+        for joint_index in range(joint_count):
+            body = builder.add_link(
+                mass=1.0,
+                com=wp.vec3(0.0, 0.0, 0.0),
+                inertia=inertia,
+                label=f"limited_body_{joint_index}",
+            )
+            joint = builder.add_joint_revolute(
+                parent=-1,
+                child=body,
+                limit_lower=-1.0,
+                limit_upper=1.0,
+                label=f"limited_joint_{joint_index}",
+            )
+            builder.add_articulation([joint])
+        model = builder.finalize()
+
+        collision_pipeline = newton.CollisionPipeline(model, rigid_contact_max=1)
+        contacts = collision_pipeline.contacts()
+        try:
+            baseline_solver = SolverMuJoCo(model, use_mujoco_contacts=True)
+            solver = SolverMuJoCo(model, use_mujoco_contacts=False)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        self.assertGreaterEqual(solver.mjw_data.njmax, baseline_solver.mjw_data.njmax)
+
+        state_0 = model.state()
+        state_1 = model.state()
+        state_0.joint_q.assign(np.full(model.joint_coord_count, 2.0, dtype=np.float32))
+        newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+        collision_pipeline.collide(state_0, contacts)
+        solver.step(state_0, state_1, model.control(), contacts, 1.0 / 240.0)
+
+        constraints_per_world = solver.mjw_data.nefc.numpy()
+        self.assertEqual(int(constraints_per_world[0]), joint_count)
+        self.assertLessEqual(int(np.max(constraints_per_world)), solver.mjw_data.njmax)
+
     def test_newton_contact_constraints_cover_uneven_worlds(self):
         """Size per-world constraints for contacts concentrated in one world."""
         sphere_count = 30
@@ -4517,6 +4560,28 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         np.testing.assert_array_equal(contacts_per_world, [sphere_count, 0])
         self.assertEqual(int(constraints_per_world[0]), sphere_count * 4)
         self.assertLessEqual(int(np.max(constraints_per_world)), solver.mjw_data.njmax)
+
+    def test_newton_contact_constraints_scale_with_busiest_world(self):
+        """Bound per-world constraint capacity by the busiest cloned world."""
+        world_count = 64
+        world = newton.ModelBuilder()
+        body = world.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.45), wp.quat_identity()))
+        world.add_shape_sphere(body=body, radius=0.5)
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        builder.replicate(world, world_count)
+        model = builder.finalize()
+        newton.CollisionPipeline(model)
+
+        try:
+            baseline_solver = SolverMuJoCo(model, separate_worlds=True, use_mujoco_contacts=True)
+            solver = SolverMuJoCo(model, separate_worlds=True, use_mujoco_contacts=False)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        self.assertGreaterEqual(solver.mjw_data.naconmax, model.rigid_contact_max)
+        self.assertEqual(solver.mjw_data.njmax, baseline_solver.mjw_data.njmax)
 
     def test_sphere_rolls_without_slip_with_newton_contacts(self):
         radius = 0.1


### PR DESCRIPTION
## Summary

- temporarily disable MuJoCo contact generation during the initialization-only CPU `mj_forward` when `use_mujoco_contacts=False`
- size the global MJWarp contact buffer independently from that skipped collision pass, while preserving the documented larger-of behavior for explicit `nconmax`
- preserve MJWarp's existing non-contact constraint default and augment it with Newton contact rows, including constraints that activate after initialization
- derive the per-world `njmax` contact requirement from the busiest world-compatible shape-pair topology instead of duplicating the global contact budget into every world
- restore the original contact-disable option before MJWarp setup so injected Newton contacts remain active
- add regression coverage for initialization flags, optional dependencies, explicit undersized capacities, delayed joint limits, uneven worlds, and 64 cloned-world sizing

Closes #3824.

## Validation

```text
uv run --frozen --extra dev python -m unittest newton.tests.test_mujoco_solver

Ran 282 tests in 46.335s
OK (skipped=7)
```

```text
uvx pre-commit run -a

All hooks passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved Newton-generated contacts when sizing MuJoCo collision and constraint buffers.
  - Prevented initialization from unnecessarily reducing contact or constraint capacity.
  - Ensured capacity accounts for contacts concentrated in a single simulation world and constraints activated after initialization.
  - Restored configured collision settings after initialization.

- **Tests**
  - Added regression coverage for contact and constraint capacity sizing.
  - Improved test behavior by skipping cleanly when MuJoCo is unavailable.

- **Documentation**
  - Updated the changelog to reflect the initialization collision-handling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->