### PR TITLE
Fix max dof checks, and clarify public API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)
-- Add experimental `newton.controllers` module with `ControllerBase` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control.
+- Add experimental `newton.controllers` module with `ControllerBase` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control. Supports heterogeneous robot fleets whose articulations differ in DOF count, with optional gravity compensation, Coriolis compensation, and inertia decoupling. See the `controller_joint_impedance_heterogeneous` example.
 - Add list-of-pattern and explicit-index selectors to `ArticulationView`.
 - Add full-surface (edge/face) rigid-soft contacts to `SolverVBD` proxy-body coupling under `SolverCoupledProxy` through shared or proxy-local collision pipelines. Proxy-particle coupling rejects full-surface contacts.
 - Add `newton[onnx]` for ONNX policy inference through Warp-NN; `ControllerNeuralMLP`, `ControllerNeuralLSTM`, and RL policy examples can run exported `.onnx` policies without requiring PyTorch for ONNX execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)
-- Add experimental `newton.controllers` module with `ControllerBase` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control. Supports heterogeneous robot fleets whose articulations differ in DOF count, with optional gravity compensation, Coriolis compensation, and inertia decoupling. See the `controller_joint_impedance_heterogeneous` example.
+- Add experimental `newton.controllers` module with `ControllerBase` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control.
 - Add list-of-pattern and explicit-index selectors to `ArticulationView`.
 - Add full-surface (edge/face) rigid-soft contacts to `SolverVBD` proxy-body coupling under `SolverCoupledProxy` through shared or proxy-local collision pipelines. Proxy-particle coupling rejects full-surface contacts.
 - Add `newton[onnx]` for ONNX policy inference through Warp-NN; `ControllerNeuralMLP`, `ControllerNeuralLSTM`, and RL policy examples can run exported `.onnx` policies without requiring PyTorch for ONNX execution.

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -24,7 +24,7 @@ from newton._src.sim.builder import ModelBuilder
 from newton._src.sim.inverse_dynamics import eval_inverse_dynamics_passive
 
 from ...controller import ControllerBase
-from ...utils import _normalize_indices
+from ...utils import _normalize_indices, _validate_array, _validate_flat_port
 from ._common import _gather_dof_flat_kernel, _idx_max
 from .model_free import ControllerJointImpedanceModelFree
 
@@ -143,9 +143,6 @@ class ControllerJointImpedance(ControllerBase):
     ):
         if not isinstance(builder, ModelBuilder):
             raise TypeError(f"builder must be a newton.ModelBuilder, got {type(builder).__name__}.")
-        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
-            raise TypeError("default_dof_indices must be wp.array[uint32].")
-
         robot_count = builder.articulation_count
         if robot_count < 1:
             raise ValueError("builder has no articulations.")
@@ -163,7 +160,7 @@ class ControllerJointImpedance(ControllerBase):
                 f"zero-DOF fixed joints; found unsupported joint types: {unsupported_joints}"
             )
 
-        self._device = device if device is not None else wp.get_device()
+        self._device = wp.get_device(device)
         self._requires_grad = requires_grad
         self._use_gravity = bool(use_gravity_compensation)
         self._use_coriolis = bool(use_coriolis_compensation)
@@ -189,21 +186,40 @@ class ControllerJointImpedance(ControllerBase):
         dofs_per_robot = wp.array(dofs_per_robot_np, dtype=wp.int32, device=self._device)
         total_dofs = int(dofs_per_robot_np.sum())
 
-        if int(default_dof_indices.size) != total_dofs:
-            raise ValueError(
-                f"default_dof_indices length {default_dof_indices.size} must equal "
-                f"sum of per-robot DOF counts = {total_dofs}."
-            )
+        # ------------------------------------------------------------------
+        # Validation: every wp.array argument is checked here, and nowhere
+        # else. This runs after finalize() because the expected shapes derive
+        # from the finalized model.
+        # ------------------------------------------------------------------
+        gain_shape, idx_shape = (robot_count, max_dofs), (total_dofs,)
+        for name, array, dtype, shape, required in (
+            ("default_dof_indices", default_dof_indices, wp.uint32, idx_shape, True),
+            ("stiffness", stiffness, wp.float32, gain_shape, False),
+            ("damping", damping, wp.float32, gain_shape, False),
+            ("joint_q_idx", joint_q_idx, wp.uint32, idx_shape, False),
+            ("joint_qd_idx", joint_qd_idx, wp.uint32, idx_shape, False),
+            ("joint_q_des_idx", joint_q_des_idx, wp.uint32, idx_shape, False),
+            ("joint_qd_des_idx", joint_qd_des_idx, wp.uint32, idx_shape, False),
+            ("joint_qdd_idx", joint_qdd_idx, wp.uint32, idx_shape, False),
+            ("joint_f_idx", joint_f_idx, wp.uint32, idx_shape, False),
+        ):
+            _validate_array(array=array, name=name, dtype=dtype, shape=shape, device=self._device, required=required)
+        # ------------------------------------------------------------------
 
         self._robot_count = robot_count
         self._max_dofs = max_dofs
         self._total_dofs = total_dofs
 
-        self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
-        self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
-        self._q_des_idx = _normalize_indices(joint_q_des_idx, default_dof_indices, name="joint_q_des")
-        self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
-        self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
+        self._q_idx = _normalize_indices(idx=joint_q_idx, default_idx=default_dof_indices)
+        self._qd_idx = _normalize_indices(idx=joint_qd_idx, default_idx=default_dof_indices)
+        self._q_des_idx = _normalize_indices(idx=joint_q_des_idx, default_idx=default_dof_indices)
+        self._qd_des_idx = _normalize_indices(idx=joint_qd_des_idx, default_idx=default_dof_indices)
+        self._qdd_idx = _normalize_indices(idx=joint_qdd_idx, default_idx=default_dof_indices)
+
+        # joint_q and joint_qd are gathered by this class before it delegates,
+        # so their ports are checked here rather than by the inner controller.
+        self._min_len_q = _idx_max(self._q_idx)
+        self._min_len_qd = _idx_max(self._qd_idx)
 
         self._mass_matrix: wp.array3d[wp.float32] | None = None
         self._gravity_flat: wp.array[wp.float32] | None = None
@@ -318,6 +334,15 @@ class ControllerJointImpedance(ControllerBase):
             outputs: :class:`Outputs` struct to write torques into.
             dt: Unused. Accepted for API compatibility.
         """
+        # Checked here because the gathers below read these two ports before
+        # the inner controller — which validates the rest — ever sees them.
+        _validate_flat_port(
+            array=inputs.joint_q, name="inputs.joint_q", min_length=self._min_len_q, device=self._device
+        )
+        _validate_flat_port(
+            array=inputs.joint_qd, name="inputs.joint_qd", min_length=self._min_len_qd, device=self._device
+        )
+
         wp.launch(
             _gather_dof_flat_kernel,
             dim=self._total_dofs,

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -38,8 +38,7 @@ class ControllerJointImpedance(ControllerBase):
     kinematics and the enabled dynamics terms on every :meth:`step`, so the
     caller supplies only joint positions and velocities.
 
-    ``builder`` is snapshotted at construction — neither consumed nor modified —
-    but the model cannot be rebuilt afterwards. Later changes to ``builder`` or
+    ``builder`` is not modified at construction — and the internal :class:`newton.Model` cannot be rebuilt after construction. Later changes to ``builder`` or
     to the simulated model do not propagate, so a mismatched topology computes
     dynamics for a different robot with no diagnostic.
 

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -52,8 +52,9 @@ class ControllerJointImpedance(ControllerBase):
     supported. The PD error term ``q_des - q`` is only valid for scalar
     joint coordinates.
 
-    See also :class:`ControllerJointImpedanceModelFree`, which takes these
-    terms as inputs instead.
+    See also :class:`ControllerJointImpedanceModelFree`, which takes the mass
+    matrix, gravity, and Coriolis terms as inputs instead of computing them
+    from a :class:`newton.Model`.
 
     Impedance law (terms enabled at construction):
 

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -30,13 +30,18 @@ from .model_free import ControllerJointImpedanceModelFree
 
 
 class ControllerJointImpedance(ControllerBase):
-    """One-step joint-space impedance controller for a batch of robots.
+    """Joint-space impedance controller with internally computed dynamics.
 
-    Has an identical input/output interface to
-    :class:`ControllerJointImpedanceModelFree` — flat 1D sim arrays in,
-    flat 1D torque array out — except that the dynamics terms (mass matrix,
-    gravity force, Coriolis force) are computed internally from the Newton
-    model rather than supplied by the caller.
+    Implements the joint-space impedance control law. This model-based variant
+    computes the mass matrix, gravity, and Coriolis terms itself: it holds a
+    private :class:`~newton.Model` built from ``builder`` and evaluates forward
+    kinematics and the enabled dynamics terms on every :meth:`step`, so the
+    caller supplies only joint positions and velocities.
+
+    ``builder`` is snapshotted at construction — neither consumed nor modified —
+    but the model cannot be rebuilt afterwards. Later changes to ``builder`` or
+    to the simulated model do not propagate, so a mismatched topology computes
+    dynamics for a different robot with no diagnostic.
 
     Supports heterogeneous robot fleets — robots in the batch may have
     different DOF counts. The ``builder`` articulations define the
@@ -47,16 +52,8 @@ class ControllerJointImpedance(ControllerBase):
     supported. The PD error term ``q_des - q`` is only valid for scalar
     joint coordinates.
 
-    Implements the same control law as :class:`ControllerJointImpedanceModelFree`,
-    but computes the dynamics itself. It holds a private :class:`~newton.Model`
-    built from ``builder``, evaluates forward kinematics, the mass matrix,
-    gravity, and Coriolis forces each step, and passes them to an internal
-    model-free instance. The caller supplies only joint positions and velocities.
-
-    ``builder`` is snapshotted at construction — neither consumed nor modified —
-    but the model cannot be rebuilt afterwards. Later changes to ``builder`` or
-    to the simulated model do not propagate, so a mismatched topology computes
-    dynamics for a different robot with no diagnostic.
+    See also :class:`ControllerJointImpedanceModelFree`, which takes these
+    terms as inputs instead.
 
     Impedance law (terms enabled at construction):
 

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -218,9 +218,7 @@ class ControllerJointImpedance(ControllerBase):
         identity_idx = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self._device)
 
         self._model_free = ControllerJointImpedanceModelFree(
-            robot_count=robot_count,
             dofs_per_robot=dofs_per_robot,
-            max_dofs=max_dofs,
             default_dof_indices=default_dof_indices,
             stiffness=stiffness,
             damping=damping,

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -47,6 +47,17 @@ class ControllerJointImpedance(ControllerBase):
     supported. The PD error term ``q_des - q`` is only valid for scalar
     joint coordinates.
 
+    Implements the same control law as :class:`ControllerJointImpedanceModelFree`,
+    but computes the dynamics itself. It holds a private :class:`~newton.Model`
+    built from ``builder``, evaluates forward kinematics, the mass matrix,
+    gravity, and Coriolis forces each step, and passes them to an internal
+    model-free instance. The caller supplies only joint positions and velocities.
+
+    ``builder`` is snapshotted at construction — neither consumed nor modified —
+    but the model cannot be rebuilt afterwards. Later changes to ``builder`` or
+    to the simulated model do not propagate, so a mismatched topology computes
+    dynamics for a different robot with no diagnostic.
+
     Impedance law (terms enabled at construction):
 
         τ = [M(q) if use_inertia_decoupling else I] · (q̈_des + Kp·Δq + Kd·Δq̇)
@@ -60,11 +71,14 @@ class ControllerJointImpedance(ControllerBase):
             ``sum(dofs per articulation)`` mapping controller DOF slots to
             positions in the flat simulation arrays (robot 0's indices first,
             then robot 1's, etc.).
-        stiffness: Position-error gain Kp [N/m or N·m/rad], shape
-            ``(N, max_dofs)``. Pass a baked array or ``None`` to read from
-            ``inputs.stiffness`` each step.
-        damping: Velocity-error gain Kd [N·s/m or N·m·s/rad]. Same format
-            as ``stiffness``.
+        stiffness: Position-error gain Kp, shape ``(N, max_dofs)``. Units
+            depend on ``use_inertia_decoupling``: [1/s²] when enabled, since
+            the PD term is then an acceleration premultiplied by M(q);
+            otherwise [N/m or N·m/rad]. Pass an array to copy it at
+            construction, or ``None`` to read ``inputs.stiffness`` each step.
+        damping: Velocity-error gain Kd, [1/s] when
+            ``use_inertia_decoupling`` is enabled, otherwise
+            [N·s/m or N·m·s/rad]. Same format as ``stiffness``.
         use_gravity_compensation: Add gravity generalized forces to τ.
         use_coriolis_compensation: Add Coriolis generalized forces to τ.
         use_inertia_decoupling: Premultiply the PD term by M(q).
@@ -100,9 +114,9 @@ class ControllerJointImpedance(ControllerBase):
         joint_qdd: wp.array[wp.float32] | None
         """Desired acceleration feedforward [m/s² or rad/s²], flat sim-level array. ``None`` unless ``has_qdd_feedforward=True``."""
         stiffness: wp.array2d[wp.float32] | None
-        """Position-error gain Kp [N/m or N·m/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        """Position-error gain Kp, shape ``(robot_count, max_dofs)``. [1/s²] when ``use_inertia_decoupling`` is enabled, otherwise [N/m or N·m/rad]. ``None`` when gains are baked at construction."""
         damping: wp.array2d[wp.float32] | None
-        """Velocity-error gain Kd [N·s/m or N·m·s/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        """Velocity-error gain Kd, shape ``(robot_count, max_dofs)``. [1/s] when ``use_inertia_decoupling`` is enabled, otherwise [N·s/m or N·m·s/rad]. ``None`` when gains are baked at construction."""
 
     class Outputs:
         """Output struct returned by :meth:`~ControllerJointImpedance.output`."""

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -53,6 +53,16 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     (e.g. ``gravity_force`` when ``use_gravity_compensation=False``) are
     allocated as ``None`` and must not be written.
 
+    Implements the joint-space impedance control law. This model-free variant
+    expects the mass matrix, gravity, and Coriolis terms to be computed
+    externally — it is the caller's responsibility to compute the enabled ones
+    correctly and write them into the input struct before every :meth:`step`.
+    Shapes and devices are checked on each call, but staleness is not: a missed
+    update silently yields torques for an old configuration.
+
+    See :class:`ControllerJointImpedance` to have these computed from a Newton
+    model instead.
+
     Args:
         dofs_per_robot: DOF count for each robot. Its length sets
             :attr:`robot_count` and its maximum sets :attr:`max_dofs`, the
@@ -61,11 +71,14 @@ class ControllerJointImpedanceModelFree(ControllerBase):
             ``sum(dofs_per_robot)`` mapping controller DOF slots to positions
             in the flat simulation arrays (robot 0's indices first, then
             robot 1's, etc.).
-        stiffness: Position-error gain Kp [N/m or N·m/rad], shape
-            ``(robot_count, max_dofs)``. Pass a baked array or ``None`` to
-            read from ``inputs.stiffness`` each step.
-        damping: Velocity-error gain Kd [N·s/m or N·m·s/rad]. Same format
-            as ``stiffness``.
+        stiffness: Position-error gain Kp, shape ``(robot_count, max_dofs)``.
+            Units depend on ``use_inertia_decoupling``: [1/s²] when enabled,
+            since the PD term is then an acceleration premultiplied by M(q);
+            otherwise [N/m or N·m/rad]. Pass an array to copy it at
+            construction, or ``None`` to read ``inputs.stiffness`` each step.
+        damping: Velocity-error gain Kd, [1/s] when
+            ``use_inertia_decoupling`` is enabled, otherwise
+            [N·s/m or N·m·s/rad]. Same format as ``stiffness``.
         use_gravity_compensation: Add gravity generalized forces to τ.
         use_coriolis_compensation: Add Coriolis generalized forces to τ.
         use_inertia_decoupling: Premultiply the PD term by M(q).
@@ -106,11 +119,11 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         coriolis_force: wp.array[wp.float32] | None
         """Coriolis generalized forces [N or N·m], flat sim-level array. ``None`` unless ``use_coriolis_compensation=True``."""
         mass_matrix: wp.array3d[wp.float32] | None
-        """Per-robot generalized mass matrices [kg or kg·m²], shape ``(robot_count, max_dofs, max_dofs)``. ``None`` unless ``use_inertia_decoupling=True``."""
+        """Per-robot generalized mass matrices, shape ``(robot_count, max_dofs, max_dofs)``. Entry units depend on the row and column DOF types: [kg] for two translational DOFs, [kg·m] for mixed translational/rotational DOFs, and [kg·m²] for two rotational DOFs. ``None`` unless ``use_inertia_decoupling=True``."""
         stiffness: wp.array2d[wp.float32] | None
-        """Position-error gain Kp [N/m or N·m/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        """Position-error gain Kp, shape ``(robot_count, max_dofs)``. [1/s²] when ``use_inertia_decoupling`` is enabled, otherwise [N/m or N·m/rad]. ``None`` when gains are baked at construction."""
         damping: wp.array2d[wp.float32] | None
-        """Velocity-error gain Kd [N·s/m or N·m·s/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        """Velocity-error gain Kd, shape ``(robot_count, max_dofs)``. [1/s] when ``use_inertia_decoupling`` is enabled, otherwise [N·s/m or N·m·s/rad]. ``None`` when gains are baked at construction."""
 
     class Outputs:
         """Output struct returned by :meth:`~ControllerJointImpedanceModelFree.output`."""
@@ -194,6 +207,17 @@ class ControllerJointImpedanceModelFree(ControllerBase):
                 "to the same simulation DOF slot."
             )
 
+        # Smallest flat array each port may be bound to, so step() can reject a
+        # short array before the gather/scatter kernels read out of bounds.
+        self._min_len_q = _idx_max(self._q_idx)
+        self._min_len_qd = _idx_max(self._qd_idx)
+        self._min_len_q_des = _idx_max(self._q_des_idx)
+        self._min_len_qd_des = _idx_max(self._qd_des_idx)
+        self._min_len_qdd = _idx_max(self._qdd_idx)
+        self._min_len_gravity = _idx_max(self._gravity_idx)
+        self._min_len_coriolis = _idx_max(self._coriolis_idx)
+        self._min_len_f = _idx_max(self._f_idx)
+
         self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
         self._damping_baked = self._normalize_gain(damping, "damping")
 
@@ -235,6 +259,13 @@ class ControllerJointImpedanceModelFree(ControllerBase):
             f"Port '{name}': must be wp.array2d[wp.float32] of shape (robot_count, max_dofs) "
             f"or None; got {type(value).__name__}."
         )
+
+    def _validate_flat_port(self, array: wp.array[wp.float32], name: str, min_length: int) -> None:
+        """Check a caller-bound flat array's device and length before any kernel reads it."""
+        if array.device != self._device:
+            raise ValueError(f"{name} is on device {array.device}, expected {self._device}.")
+        if array.size < min_length:
+            raise ValueError(f"{name} has length {array.size}, expected at least {min_length}.")
 
     @property
     def robot_count(self) -> int:
@@ -315,6 +346,30 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         """
         stiffness = self._stiffness_baked if self._stiffness_baked is not None else inputs.stiffness
         damping = self._damping_baked if self._damping_baked is not None else inputs.damping
+
+        self._validate_flat_port(inputs.joint_q, "inputs.joint_q", self._min_len_q)
+        self._validate_flat_port(inputs.joint_qd, "inputs.joint_qd", self._min_len_qd)
+        self._validate_flat_port(inputs.joint_q_des, "inputs.joint_q_des", self._min_len_q_des)
+        self._validate_flat_port(inputs.joint_qd_des, "inputs.joint_qd_des", self._min_len_qd_des)
+        if self._has_qdd:
+            self._validate_flat_port(inputs.joint_qdd, "inputs.joint_qdd", self._min_len_qdd)
+        if self._use_gravity:
+            self._validate_flat_port(inputs.gravity_force, "inputs.gravity_force", self._min_len_gravity)
+        if self._use_coriolis:
+            self._validate_flat_port(inputs.coriolis_force, "inputs.coriolis_force", self._min_len_coriolis)
+        self._validate_flat_port(outputs.joint_f, "outputs.joint_f", self._min_len_f)
+
+        expected_2d = (self._robot_count, self._max_dofs)
+        if tuple(stiffness.shape) != expected_2d:
+            raise ValueError(f"stiffness has shape {tuple(stiffness.shape)}, expected {expected_2d}.")
+        if tuple(damping.shape) != expected_2d:
+            raise ValueError(f"damping has shape {tuple(damping.shape)}, expected {expected_2d}.")
+        if self._use_inertia:
+            expected_3d = (self._robot_count, self._max_dofs, self._max_dofs)
+            if tuple(inputs.mass_matrix.shape) != expected_3d:
+                raise ValueError(
+                    f"inputs.mass_matrix has shape {tuple(inputs.mass_matrix.shape)}, expected {expected_3d}."
+                )
 
         dim2d = (self._robot_count, self._max_dofs)
 

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -142,8 +142,12 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     ):
         if not isinstance(dofs_per_robot, wp.array) or dofs_per_robot.dtype != wp.int32:
             raise TypeError("dofs_per_robot must be wp.array[int32].")
+        if dofs_per_robot.ndim != 1:
+            raise ValueError(f"dofs_per_robot must be 1-D, got shape {tuple(dofs_per_robot.shape)}.")
         if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
             raise TypeError("default_dof_indices must be wp.array[uint32].")
+        if default_dof_indices.ndim != 1:
+            raise ValueError(f"default_dof_indices must be 1-D, got shape {tuple(default_dof_indices.shape)}.")
 
         dofs_per_robot_np = dofs_per_robot.numpy()
         robot_count = int(dofs_per_robot_np.size)

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -43,6 +43,13 @@ from ._common import (
 class ControllerJointImpedanceModelFree(ControllerBase):
     """Joint-space impedance controller with caller-supplied dynamics.
 
+    Implements the joint-space impedance control law. This model-free variant
+    expects the mass matrix, gravity, and Coriolis terms to be computed
+    externally — it is the caller's responsibility to compute the enabled ones
+    correctly and write them into the input struct before every :meth:`step`.
+    Shapes and devices are checked on each call, but staleness is not: a missed
+    update silently yields torques for an old configuration.
+
     Supports heterogeneous robot fleets — robots in the batch may have
     different DOF counts. Internal buffers are padded to ``max_dofs``; kernels
     skip padding slots via a per-robot guard.
@@ -53,15 +60,8 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     (e.g. ``gravity_force`` when ``use_gravity_compensation=False``) are
     allocated as ``None`` and must not be written.
 
-    Implements the joint-space impedance control law. This model-free variant
-    expects the mass matrix, gravity, and Coriolis terms to be computed
-    externally — it is the caller's responsibility to compute the enabled ones
-    correctly and write them into the input struct before every :meth:`step`.
-    Shapes and devices are checked on each call, but staleness is not: a missed
-    update silently yields torques for an old configuration.
-
-    See :class:`ControllerJointImpedance` to have these computed from a Newton
-    model instead.
+    See also :class:`ControllerJointImpedance`, which computes these terms
+    internally from a Newton model.
 
     Args:
         dofs_per_robot: DOF count for each robot. Its length sets

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -60,8 +60,8 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     (e.g. ``gravity_force`` when ``use_gravity_compensation=False``) are
     allocated as ``None`` and must not be written.
 
-    See also :class:`ControllerJointImpedance`, which computes these terms
-    internally from a Newton model.
+    See also :class:`ControllerJointImpedance`, which computes the mass matrix,
+    gravity, and Coriolis terms internally from a Newton model.
 
     Args:
         dofs_per_robot: DOF count for each robot. Its length sets

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -29,7 +29,7 @@ import numpy as np
 import warp as wp
 
 from ...controller import ControllerBase
-from ...utils import _normalize_indices
+from ...utils import _normalize_indices, _validate_array, _validate_flat_port
 from ._common import (
     _add_term_kernel,
     _gather_dof_kernel,
@@ -47,8 +47,10 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     expects the mass matrix, gravity, and Coriolis terms to be computed
     externally — it is the caller's responsibility to compute the enabled ones
     correctly and write them into the input struct before every :meth:`step`.
-    Shapes and devices are checked on each call, but staleness is not: a missed
-    update silently yields torques for an old configuration.
+
+    Array shapes and devices are validated on each direct call to :meth:`step`,
+    but not when a captured graph is replayed, since the checks run in Python
+    at capture time only.
 
     Supports heterogeneous robot fleets — robots in the batch may have
     different DOF counts. Internal buffers are padded to ``max_dofs``; kernels
@@ -119,7 +121,7 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         coriolis_force: wp.array[wp.float32] | None
         """Coriolis generalized forces [N or N·m], flat sim-level array. ``None`` unless ``use_coriolis_compensation=True``."""
         mass_matrix: wp.array3d[wp.float32] | None
-        """Per-robot generalized mass matrices, shape ``(robot_count, max_dofs, max_dofs)``. Entry units depend on the row and column DOF types: [kg] for two translational DOFs, [kg·m] for mixed translational/rotational DOFs, and [kg·m²] for two rotational DOFs. ``None`` unless ``use_inertia_decoupling=True``."""
+        """Per-robot mass matrices, shape ``(robot_count, max_dofs, max_dofs)``. Units by row/column DOF type: [kg] translational, [kg·m] mixed, [kg·m²] rotational. ``None`` unless ``use_inertia_decoupling=True``."""
         stiffness: wp.array2d[wp.float32] | None
         """Position-error gain Kp, shape ``(robot_count, max_dofs)``. [1/s²] when ``use_inertia_decoupling`` is enabled, otherwise [N/m or N·m/rad]. ``None`` when gains are baked at construction."""
         damping: wp.array2d[wp.float32] | None
@@ -153,14 +155,14 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         device: Any = None,
         requires_grad: bool = False,
     ):
-        if not isinstance(dofs_per_robot, wp.array) or dofs_per_robot.dtype != wp.int32:
-            raise TypeError("dofs_per_robot must be wp.array[int32].")
-        if dofs_per_robot.ndim != 1:
-            raise ValueError(f"dofs_per_robot must be 1-D, got shape {tuple(dofs_per_robot.shape)}.")
-        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
-            raise TypeError("default_dof_indices must be wp.array[uint32].")
-        if default_dof_indices.ndim != 1:
-            raise ValueError(f"default_dof_indices must be 1-D, got shape {tuple(default_dof_indices.shape)}.")
+        self._device = wp.get_device(device)
+
+        # ------------------------------------------------------------------
+        # Validation: every wp.array argument is checked here, and nowhere
+        # else. dofs_per_robot comes first because the shapes below derive
+        # from it.
+        # ------------------------------------------------------------------
+        _validate_array(array=dofs_per_robot, name="dofs_per_robot", dtype=wp.int32, shape=(-1,), device=self._device)
 
         dofs_per_robot_np = dofs_per_robot.numpy()
         robot_count = int(dofs_per_robot_np.size)
@@ -171,10 +173,23 @@ class ControllerJointImpedanceModelFree(ControllerBase):
 
         max_dofs = int(dofs_per_robot_np.max())
         total_dofs = int(dofs_per_robot_np.sum())
-        if int(default_dof_indices.size) != total_dofs:
-            raise ValueError(
-                f"default_dof_indices length {default_dof_indices.size} must equal sum(dofs_per_robot) = {total_dofs}."
-            )
+        gain_shape, idx_shape = (robot_count, max_dofs), (total_dofs,)
+
+        for name, array, dtype, shape, required in (
+            ("default_dof_indices", default_dof_indices, wp.uint32, idx_shape, True),
+            ("stiffness", stiffness, wp.float32, gain_shape, False),
+            ("damping", damping, wp.float32, gain_shape, False),
+            ("joint_q_idx", joint_q_idx, wp.uint32, idx_shape, False),
+            ("joint_qd_idx", joint_qd_idx, wp.uint32, idx_shape, False),
+            ("joint_q_des_idx", joint_q_des_idx, wp.uint32, idx_shape, False),
+            ("joint_qd_des_idx", joint_qd_des_idx, wp.uint32, idx_shape, False),
+            ("joint_qdd_idx", joint_qdd_idx, wp.uint32, idx_shape, False),
+            ("gravity_force_idx", gravity_force_idx, wp.uint32, idx_shape, False),
+            ("coriolis_force_idx", coriolis_force_idx, wp.uint32, idx_shape, False),
+            ("joint_f_idx", joint_f_idx, wp.uint32, idx_shape, False),
+        ):
+            _validate_array(array=array, name=name, dtype=dtype, shape=shape, device=self._device, required=required)
+        # ------------------------------------------------------------------
 
         self._robot_count = robot_count
         self._max_dofs = max_dofs
@@ -183,7 +198,6 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         self._use_coriolis = bool(use_coriolis_compensation)
         self._use_inertia = bool(use_inertia_decoupling)
         self._has_qdd = bool(has_qdd_feedforward)
-        self._device = device if device is not None else wp.get_device()
         self._requires_grad = requires_grad
 
         self._dofs_per_robot = dofs_per_robot
@@ -191,14 +205,14 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         offsets_np[1:] = np.cumsum(dofs_per_robot_np[:-1])
         self._dof_offsets = wp.array(offsets_np, dtype=wp.int32, device=self._device)
 
-        self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
-        self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
-        self._q_des_idx = _normalize_indices(joint_q_des_idx, default_dof_indices, name="joint_q_des")
-        self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
-        self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
-        self._gravity_idx = _normalize_indices(gravity_force_idx, default_dof_indices, name="gravity_force")
-        self._coriolis_idx = _normalize_indices(coriolis_force_idx, default_dof_indices, name="coriolis_force")
-        self._f_idx = _normalize_indices(joint_f_idx, default_dof_indices, name="joint_f")
+        self._q_idx = _normalize_indices(idx=joint_q_idx, default_idx=default_dof_indices)
+        self._qd_idx = _normalize_indices(idx=joint_qd_idx, default_idx=default_dof_indices)
+        self._q_des_idx = _normalize_indices(idx=joint_q_des_idx, default_idx=default_dof_indices)
+        self._qd_des_idx = _normalize_indices(idx=joint_qd_des_idx, default_idx=default_dof_indices)
+        self._qdd_idx = _normalize_indices(idx=joint_qdd_idx, default_idx=default_dof_indices)
+        self._gravity_idx = _normalize_indices(idx=gravity_force_idx, default_idx=default_dof_indices)
+        self._coriolis_idx = _normalize_indices(idx=coriolis_force_idx, default_idx=default_dof_indices)
+        self._f_idx = _normalize_indices(idx=joint_f_idx, default_idx=default_dof_indices)
 
         f_idx_np = self._f_idx.numpy()
         if len(f_idx_np) != len(np.unique(f_idx_np)):
@@ -218,8 +232,8 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         self._min_len_coriolis = _idx_max(self._coriolis_idx)
         self._min_len_f = _idx_max(self._f_idx)
 
-        self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
-        self._damping_baked = self._normalize_gain(damping, "damping")
+        self._stiffness_baked = self._bake_gain(stiffness)
+        self._damping_baked = self._bake_gain(damping)
 
         def _buf():
             return wp.zeros((robot_count, max_dofs), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
@@ -235,37 +249,22 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         self._tau_buf = _buf()
         self._acc_buf: wp.array2d[wp.float32] | None = _buf() if self._use_inertia else None
 
-    def _normalize_gain(
-        self,
-        value: wp.array2d[wp.float32] | None,
-        name: str,
-    ) -> wp.array2d[wp.float32] | None:
-        """Validate and copy a baked gain array, or return ``None`` for live gains."""
+    def _bake_gain(self, value: wp.array2d[wp.float32] | None) -> wp.array2d[wp.float32] | None:
+        """Copy a gain array so later edits to the caller's array have no effect.
+
+        Returns ``None`` for live gains, which are read from the input struct
+        each step instead. Already validated by :func:`_validate_array`.
+        """
         if value is None:
             return None
-        if isinstance(value, wp.array):
-            expected = (self._robot_count, self._max_dofs)
-            if tuple(value.shape) != expected:
-                raise ValueError(
-                    f"Port '{name}': baked array shape {tuple(value.shape)} must equal "
-                    f"(robot_count, max_dofs) = {expected}."
-                )
-            if value.dtype != wp.float32:
-                raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
-            baked = wp.zeros(expected, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad)
-            wp.copy(baked, value)
-            return baked
-        raise TypeError(
-            f"Port '{name}': must be wp.array2d[wp.float32] of shape (robot_count, max_dofs) "
-            f"or None; got {type(value).__name__}."
+        baked = wp.zeros(
+            (self._robot_count, self._max_dofs),
+            dtype=wp.float32,
+            device=self._device,
+            requires_grad=self._requires_grad,
         )
-
-    def _validate_flat_port(self, array: wp.array[wp.float32], name: str, min_length: int) -> None:
-        """Check a caller-bound flat array's device and length before any kernel reads it."""
-        if array.device != self._device:
-            raise ValueError(f"{name} is on device {array.device}, expected {self._device}.")
-        if array.size < min_length:
-            raise ValueError(f"{name} has length {array.size}, expected at least {min_length}.")
+        wp.copy(baked, value)
+        return baked
 
     @property
     def robot_count(self) -> int:
@@ -347,29 +346,51 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         stiffness = self._stiffness_baked if self._stiffness_baked is not None else inputs.stiffness
         damping = self._damping_baked if self._damping_baked is not None else inputs.damping
 
-        self._validate_flat_port(inputs.joint_q, "inputs.joint_q", self._min_len_q)
-        self._validate_flat_port(inputs.joint_qd, "inputs.joint_qd", self._min_len_qd)
-        self._validate_flat_port(inputs.joint_q_des, "inputs.joint_q_des", self._min_len_q_des)
-        self._validate_flat_port(inputs.joint_qd_des, "inputs.joint_qd_des", self._min_len_qd_des)
+        _validate_flat_port(
+            array=inputs.joint_q, name="inputs.joint_q", min_length=self._min_len_q, device=self._device
+        )
+        _validate_flat_port(
+            array=inputs.joint_qd, name="inputs.joint_qd", min_length=self._min_len_qd, device=self._device
+        )
+        _validate_flat_port(
+            array=inputs.joint_q_des, name="inputs.joint_q_des", min_length=self._min_len_q_des, device=self._device
+        )
+        _validate_flat_port(
+            array=inputs.joint_qd_des, name="inputs.joint_qd_des", min_length=self._min_len_qd_des, device=self._device
+        )
         if self._has_qdd:
-            self._validate_flat_port(inputs.joint_qdd, "inputs.joint_qdd", self._min_len_qdd)
+            _validate_flat_port(
+                array=inputs.joint_qdd, name="inputs.joint_qdd", min_length=self._min_len_qdd, device=self._device
+            )
         if self._use_gravity:
-            self._validate_flat_port(inputs.gravity_force, "inputs.gravity_force", self._min_len_gravity)
+            _validate_flat_port(
+                array=inputs.gravity_force,
+                name="inputs.gravity_force",
+                min_length=self._min_len_gravity,
+                device=self._device,
+            )
         if self._use_coriolis:
-            self._validate_flat_port(inputs.coriolis_force, "inputs.coriolis_force", self._min_len_coriolis)
-        self._validate_flat_port(outputs.joint_f, "outputs.joint_f", self._min_len_f)
+            _validate_flat_port(
+                array=inputs.coriolis_force,
+                name="inputs.coriolis_force",
+                min_length=self._min_len_coriolis,
+                device=self._device,
+            )
+        _validate_flat_port(
+            array=outputs.joint_f, name="outputs.joint_f", min_length=self._min_len_f, device=self._device
+        )
 
-        expected_2d = (self._robot_count, self._max_dofs)
-        if tuple(stiffness.shape) != expected_2d:
-            raise ValueError(f"stiffness has shape {tuple(stiffness.shape)}, expected {expected_2d}.")
-        if tuple(damping.shape) != expected_2d:
-            raise ValueError(f"damping has shape {tuple(damping.shape)}, expected {expected_2d}.")
+        gain_shape = (self._robot_count, self._max_dofs)
+        _validate_array(array=stiffness, name="stiffness", dtype=wp.float32, shape=gain_shape, device=self._device)
+        _validate_array(array=damping, name="damping", dtype=wp.float32, shape=gain_shape, device=self._device)
         if self._use_inertia:
-            expected_3d = (self._robot_count, self._max_dofs, self._max_dofs)
-            if tuple(inputs.mass_matrix.shape) != expected_3d:
-                raise ValueError(
-                    f"inputs.mass_matrix has shape {tuple(inputs.mass_matrix.shape)}, expected {expected_3d}."
-                )
+            _validate_array(
+                array=inputs.mass_matrix,
+                name="inputs.mass_matrix",
+                dtype=wp.float32,
+                shape=(self._robot_count, self._max_dofs, self._max_dofs),
+                device=self._device,
+            )
 
         dim2d = (self._robot_count, self._max_dofs)
 

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -54,11 +54,9 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     allocated as ``None`` and must not be written.
 
     Args:
-        robot_count: Number of parallel robots.
-        dofs_per_robot: DOF count for each robot, length ``robot_count``.
-        max_dofs: Padded buffer width — must equal
-            ``int(dofs_per_robot.numpy().max())``. Passed explicitly to avoid
-            a device round-trip.
+        dofs_per_robot: DOF count for each robot. Its length sets
+            :attr:`robot_count` and its maximum sets :attr:`max_dofs`, the
+            padded width of all internal buffers.
         default_dof_indices: Concatenated per-robot index arrays of length
             ``sum(dofs_per_robot)`` mapping controller DOF slots to positions
             in the flat simulation arrays (robot 0's indices first, then
@@ -123,9 +121,7 @@ class ControllerJointImpedanceModelFree(ControllerBase):
     def __init__(
         self,
         *,
-        robot_count: int,
         dofs_per_robot: wp.array[wp.int32],
-        max_dofs: int,
         default_dof_indices: wp.array[wp.uint32],
         stiffness: wp.array2d[wp.float32] | None,
         damping: wp.array2d[wp.float32] | None,
@@ -144,18 +140,19 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         device: Any = None,
         requires_grad: bool = False,
     ):
-        if robot_count < 1:
-            raise ValueError(f"robot_count must be >= 1, got {robot_count}.")
         if not isinstance(dofs_per_robot, wp.array) or dofs_per_robot.dtype != wp.int32:
             raise TypeError("dofs_per_robot must be wp.array[int32].")
-        if int(dofs_per_robot.size) != robot_count:
-            raise ValueError(f"dofs_per_robot length {dofs_per_robot.size} must equal robot_count={robot_count}.")
-        if max_dofs < 1:
-            raise ValueError(f"max_dofs must be >= 1, got {max_dofs}.")
         if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
             raise TypeError("default_dof_indices must be wp.array[uint32].")
 
         dofs_per_robot_np = dofs_per_robot.numpy()
+        robot_count = int(dofs_per_robot_np.size)
+        if robot_count < 1:
+            raise ValueError("dofs_per_robot must not be empty.")
+        if dofs_per_robot_np.min() < 1:
+            raise ValueError(f"every robot must have >= 1 DOF, got dofs_per_robot={dofs_per_robot_np.tolist()}.")
+
+        max_dofs = int(dofs_per_robot_np.max())
         total_dofs = int(dofs_per_robot_np.sum())
         if int(default_dof_indices.size) != total_dofs:
             raise ValueError(

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -23,6 +23,9 @@ def _normalize_indices(
     if (not isinstance(idx, wp.array)) or (idx.dtype != wp.uint32):
         raise TypeError(f"Port '{name}': idx must be wp.array[uint32] or None, got {type(idx).__name__}.")
 
+    if idx.ndim != 1:
+        raise ValueError(f"Port '{name}': idx must be 1-D, got shape {tuple(idx.shape)}.")
+
     if idx.size != default_idx.size:
         raise ValueError(
             f"Port '{name}': indices must be the same size as default_dof_indices: {idx.size} != {default_idx.size}."

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -10,25 +10,78 @@ from typing import Any
 import warp as wp
 
 
-def _normalize_indices(
-    idx: Any,
-    default_idx: wp.array[wp.uint32],
+def _validate_array(
     *,
+    array: Any,
     name: str,
+    dtype: Any,
+    shape: tuple[int, ...],
+    device: wp.DeviceLike,
+    required: bool = True,
+) -> None:
+    """Validate a ``wp.array`` argument's dtype, shape, and device.
+
+    Args:
+        array: Value to validate, or ``None`` for an omitted optional argument.
+        name: Argument name, used in error messages.
+        dtype: Warp dtype the array must have.
+        shape: Shape the array must have. A ``-1`` entry accepts any size in
+            that dimension, so ``(-1,)`` means "1-D, any length".
+        device: Device the array must live on.
+        required: Whether ``None`` is rejected.
+    """
+    if array is None:
+        if required:
+            raise ValueError(f"{name} is required, cannot be `None`.")
+        return
+    if not isinstance(array, wp.array):
+        raise TypeError(f"{name} must be a wp.array, got {type(array).__name__}.")
+    if array.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}, got {array.dtype}.")
+    actual = tuple(array.shape)
+    if len(actual) != len(shape) or any(want not in (-1, got) for got, want in zip(actual, shape, strict=True)):
+        expected = "(" + ", ".join("*" if d == -1 else str(d) for d in shape) + ")"
+        raise ValueError(f"{name} must have shape {expected}, got {actual}.")
+    if array.device != device:
+        raise ValueError(f"{name} must be on device {device}, got {array.device}.")
+
+
+def _validate_flat_port(
+    *,
+    array: Any,
+    name: str,
+    min_length: int,
+    device: wp.DeviceLike,
+) -> None:
+    """Validate a caller-bound flat float32 array before any kernel reads it.
+
+    Unlike :func:`_validate_array`, the length is a lower bound: a port may be
+    bound to a larger simulation array that the controller indexes into.
+
+    Args:
+        array: Array bound to the port by the caller.
+        name: Port name, used in error messages.
+        min_length: Smallest length the port's indices can be read from safely.
+        device: Device the array must live on.
+    """
+    if not isinstance(array, wp.array):
+        raise TypeError(f"{name} must be a wp.array, got {type(array).__name__}.")
+    if array.dtype != wp.float32:
+        raise TypeError(f"{name} must have dtype {wp.float32}, got {array.dtype}.")
+    if array.device != device:
+        raise ValueError(f"{name} must be on device {device}, got {array.device}.")
+    if array.size < min_length:
+        raise ValueError(f"{name} must have length at least {min_length}, got {array.size}.")
+
+
+def _normalize_indices(
+    *,
+    idx: wp.array[wp.uint32] | None,
+    default_idx: wp.array[wp.uint32],
 ) -> wp.array[wp.uint32]:
-    """Return ``idx`` after validation, or ``default_idx`` if ``idx`` is ``None``."""
-    if idx is None:
-        return default_idx
+    """Return ``idx`` if supplied, otherwise ``default_idx``.
 
-    if (not isinstance(idx, wp.array)) or (idx.dtype != wp.uint32):
-        raise TypeError(f"Port '{name}': idx must be wp.array[uint32] or None, got {type(idx).__name__}.")
-
-    if idx.ndim != 1:
-        raise ValueError(f"Port '{name}': idx must be 1-D, got shape {tuple(idx.shape)}.")
-
-    if idx.size != default_idx.size:
-        raise ValueError(
-            f"Port '{name}': indices must be the same size as default_dof_indices: {idx.size} != {default_idx.size}."
-        )
-
-    return idx
+    Both are validated by :func:`_validate_array` at construction, so this only
+    selects between them.
+    """
+    return default_idx if idx is None else idx

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -338,6 +338,72 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
                 device=device,
             )
 
+    def test_2d_dofs_per_robot_raises(self):
+        """Verify a 2-D dofs_per_robot raises instead of silently deriving incorrect robot_count."""
+        device = wp.get_device()
+        # A (2, 3) array has size 6, which would otherwise be read as 6 robots.
+        dofs_2d = wp.full((2, 3), 1, dtype=wp.int32, device=device)
+        with self.assertRaises(ValueError):
+            ControllerJointImpedanceModelFree(
+                dofs_per_robot=dofs_2d,
+                default_dof_indices=_iota(6, device),
+                stiffness=_gains(6, 1, 1.0, device),
+                damping=_gains(6, 1, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
+
+    def test_2d_default_dof_indices_raises(self):
+        """Verify a 2-D default_dof_indices raises even when its total element count matches."""
+        device = wp.get_device()
+        # Shape (2, 1) has size 2, matching sum(dofs_per_robot) for two 1-DOF robots.
+        indices_2d = wp.array(np.arange(2, dtype=np.uint32).reshape(2, 1), dtype=wp.uint32, device=device)
+        with self.assertRaises(ValueError):
+            ControllerJointImpedanceModelFree(
+                dofs_per_robot=_dofs_arr([1, 1], device),
+                default_dof_indices=indices_2d,
+                stiffness=_gains(2, 1, 1.0, device),
+                damping=_gains(2, 1, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
+
+    def test_2d_index_override_raises(self):
+        """Verify a 2-D per-port index override raises."""
+        device = wp.get_device()
+        indices_2d = wp.array(np.arange(2, dtype=np.uint32).reshape(2, 1), dtype=wp.uint32, device=device)
+        with self.assertRaises(ValueError):
+            ControllerJointImpedanceModelFree(
+                dofs_per_robot=_dofs_arr([1, 1], device),
+                default_dof_indices=_iota(2, device),
+                stiffness=_gains(2, 1, 1.0, device),
+                damping=_gains(2, 1, 0.0, device),
+                joint_q_idx=indices_2d,
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
+
+    def test_zero_dof_robot_raises(self):
+        """Verify a robot declaring zero DOFs raises at construction."""
+        device = wp.get_device()
+        with self.assertRaises(ValueError):
+            ControllerJointImpedanceModelFree(
+                dofs_per_robot=_dofs_arr([2, 0], device),
+                default_dof_indices=_iota(2, device),
+                stiffness=_gains(2, 2, 1.0, device),
+                damping=_gains(2, 2, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
+
 
 # ---------------------------------------------------------------------------
 # ControllerJointImpedanceModelFree — heterogeneous
@@ -584,6 +650,22 @@ class TestControllerJointImpedance(unittest.TestCase):
             ControllerJointImpedance(
                 builder=builder,
                 default_dof_indices=_iota(5, device),
+                stiffness=_gains(1, 1, 1.0, device),
+                damping=_gains(1, 1, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                device=device,
+            )
+
+    def test_2d_default_dof_indices_raises(self):
+        """Verify a 2-D default_dof_indices raises even when its total element count matches."""
+        device = wp.get_device()
+        builder = _build_single_prismatic()
+        indices_2d = wp.array(np.arange(1, dtype=np.uint32).reshape(1, 1), dtype=wp.uint32, device=device)
+        with self.assertRaises(ValueError):
+            ControllerJointImpedance(
+                builder=builder,
+                default_dof_indices=indices_2d,
                 stiffness=_gains(1, 1, 1.0, device),
                 damping=_gains(1, 1, 0.0, device),
                 use_gravity_compensation=False,

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -389,6 +389,64 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
                 device=device,
             )
 
+    def test_short_input_array_raises(self):
+        """Verify an input array too short for its indices raises instead of reading out of bounds."""
+        device = wp.get_device()
+        # Indices reach slot 5, so any bound array must hold at least 6 entries.
+        ctrl = ControllerJointImpedanceModelFree(
+            dofs_per_robot=_dofs_arr([2], device),
+            default_dof_indices=wp.array([0, 5], dtype=wp.uint32, device=device),
+            stiffness=_gains(1, 2, 1.0, device),
+            damping=_gains(1, 2, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins, outs = ctrl.input(), ctrl.output()
+        self.assertEqual(ins.joint_q.shape, (6,))
+        ins.joint_q = wp.zeros(2, dtype=wp.float32, device=device)
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
+
+    def test_wrong_device_input_raises(self):
+        """Verify an input array on another device raises instead of being dereferenced."""
+        device = wp.get_device()
+        if not device.is_cuda:
+            self.skipTest("needs a second device to mismatch against")
+        ctrl = _make_mf(dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        ins, outs = ctrl.input(), ctrl.output()
+        ins.joint_q_des = wp.array([1.0, 1.0], dtype=wp.float32, device="cpu")
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
+
+    def test_wrong_shape_live_gain_raises(self):
+        """Verify a live gain whose shape differs from (robot_count, max_dofs) raises."""
+        device = wp.get_device()
+        ctrl = ControllerJointImpedanceModelFree(
+            dofs_per_robot=_dofs_arr([2, 2], device),
+            default_dof_indices=_iota(4, device),
+            stiffness=None,  # live: read from inputs.stiffness each step
+            damping=_gains(2, 2, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins, outs = ctrl.input(), ctrl.output()
+        ins.stiffness = wp.full((1, 1), 7.0, dtype=wp.float32, device=device)
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
+
+    def test_wrong_shape_mass_matrix_raises(self):
+        """Verify a mass matrix whose shape differs from (robot_count, max_dofs, max_dofs) raises."""
+        device = wp.get_device()
+        ctrl = _make_mf(dofs_list=[2, 2], kp=1.0, kd=0.0, device=device, use_inertia=True)
+        ins, outs = ctrl.input(), ctrl.output()
+        ins.mass_matrix = wp.zeros((1, 1, 1), dtype=wp.float32, device=device)
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
+
     def test_zero_dof_robot_raises(self):
         """Verify a robot declaring zero DOFs raises at construction."""
         device = wp.get_device()

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -447,6 +447,59 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         with self.assertRaises(ValueError):
             ctrl.step(inputs=ins, outputs=outs, dt=0.01)
 
+    def test_wrong_device_constructor_array_raises(self):
+        """Verify every wp.array constructor argument is rejected when it is on the wrong device."""
+        device = wp.get_device()
+        if not device.is_cuda:
+            self.skipTest("needs a second device to mismatch against")
+        other = "cpu"
+
+        def _kwargs():
+            return {
+                "dofs_per_robot": _dofs_arr([2], device),
+                "default_dof_indices": _iota(2, device),
+                "stiffness": _gains(1, 2, 1.0, device),
+                "damping": _gains(1, 2, 0.0, device),
+                "use_gravity_compensation": False,
+                "use_coriolis_compensation": False,
+                "use_inertia_decoupling": False,
+                "device": device,
+            }
+
+        # One entry per wp.array argument, each moved to the wrong device in turn.
+        wrong = {
+            "dofs_per_robot": _dofs_arr([2], other),
+            "default_dof_indices": _iota(2, other),
+            "stiffness": _gains(1, 2, 1.0, other),
+            "damping": _gains(1, 2, 0.0, other),
+            "joint_q_idx": _iota(2, other),
+            "joint_qd_idx": _iota(2, other),
+            "joint_q_des_idx": _iota(2, other),
+            "joint_qd_des_idx": _iota(2, other),
+            "joint_qdd_idx": _iota(2, other),
+            "gravity_force_idx": _iota(2, other),
+            "coriolis_force_idx": _iota(2, other),
+            "joint_f_idx": _iota(2, other),
+        }
+        for name, bad_array in wrong.items():
+            with self.subTest(argument=name), self.assertRaises(ValueError):
+                ControllerJointImpedanceModelFree(**{**_kwargs(), name: bad_array})
+
+    def test_wrong_dtype_constructor_array_raises(self):
+        """Verify a wp.array constructor argument with the wrong dtype raises TypeError."""
+        device = wp.get_device()
+        with self.assertRaises(TypeError):
+            ControllerJointImpedanceModelFree(
+                dofs_per_robot=_dofs_arr([2], device),
+                default_dof_indices=wp.zeros(2, dtype=wp.int32, device=device),  # want uint32
+                stiffness=_gains(1, 2, 1.0, device),
+                damping=_gains(1, 2, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
+
     def test_zero_dof_robot_raises(self):
         """Verify a robot declaring zero DOFs raises at construction."""
         device = wp.get_device()
@@ -760,6 +813,26 @@ class TestControllerJointImpedance(unittest.TestCase):
                 use_coriolis_compensation=False,
                 device=device,
             )
+
+    def test_short_joint_q_raises_before_gather(self):
+        """Verify a short joint_q is rejected before the internal FK gather reads it."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device)
+        ins, outs = ctrl.input(), ctrl.output()
+        ins.joint_q = wp.zeros(0, dtype=wp.float32, device=device)
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
+
+    def test_wrong_device_joint_q_raises_before_gather(self):
+        """Verify a joint_q on another device is rejected before the internal FK gather reads it."""
+        device = wp.get_device()
+        if not device.is_cuda:
+            self.skipTest("needs a second device to mismatch against")
+        ctrl = self._make_ctrl(device)
+        ins, outs = ctrl.input(), ctrl.output()
+        ins.joint_q = wp.zeros(1, dtype=wp.float32, device="cpu")
+        with self.assertRaises(ValueError):
+            ctrl.step(inputs=ins, outputs=outs, dt=0.01)
 
     def test_input_outputs_shapes(self):
         """Verify input/output struct arrays have the expected flat shapes."""

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -87,7 +87,6 @@ def _build_two_robot_mixed():
 
 def _make_mf(
     *,
-    robot_count,
     dofs_list,
     kp,
     kd,
@@ -98,12 +97,11 @@ def _make_mf(
     has_qdd=False,
 ):
     """Construct a ControllerJointImpedanceModelFree with identity indices."""
+    robot_count = len(dofs_list)
     max_dofs = max(dofs_list)
     total_dofs = sum(dofs_list)
     return ControllerJointImpedanceModelFree(
-        robot_count=robot_count,
         dofs_per_robot=_dofs_arr(dofs_list, device),
-        max_dofs=max_dofs,
         default_dof_indices=_iota(total_dofs, device),
         stiffness=_gains(robot_count, max_dofs, kp, device),
         damping=_gains(robot_count, max_dofs, kd, device),
@@ -138,7 +136,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_zero_error_gives_zero_torque(self):
         """Verify that zero position and velocity error produces zero torque."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=10.0, kd=1.0, device=device)
+        ctrl = _make_mf(dofs_list=[3], kp=10.0, kd=1.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.1, 0.2, 0.3], qd=[0.0, 0.0, 0.0], q_des=[0.1, 0.2, 0.3], qd_des=[0.0, 0.0, 0.0], device=device
         )
@@ -147,7 +145,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_position_error_produces_stiffness_torque(self):
         """Verify τ = Kp * (q_des - q) when Kd=0."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=5.0, kd=0.0, device=device)
+        ctrl = _make_mf(dofs_list=[3], kp=5.0, kd=0.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[1.0, 0.0, 0.0], qd_des=[0.0, 0.0, 0.0], device=device
         )
@@ -156,7 +154,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_velocity_error_produces_damping_torque(self):
         """Verify τ = Kd * (qd_des - qd) when Kp=0."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=0.0, kd=2.0, device=device)
+        ctrl = _make_mf(dofs_list=[3], kp=0.0, kd=2.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[0.0, 0.0, 0.0], qd_des=[0.0, 1.0, 0.0], device=device
         )
@@ -166,7 +164,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         """Verify that torques for each robot depend only on that robot's error."""
         device = wp.get_device()
         robot_count, num_dofs = 3, 2
-        ctrl = _make_mf(robot_count=robot_count, dofs_list=[num_dofs] * robot_count, kp=1.0, kd=0.0, device=device)
+        ctrl = _make_mf(dofs_list=[num_dofs] * robot_count, kp=1.0, kd=0.0, device=device)
         q_des = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         q = np.zeros((robot_count, num_dofs), dtype=np.float32)
         tau = _run_mf(ctrl, q=q, qd=q * 0, q_des=q_des, qd_des=q * 0, device=device)
@@ -175,7 +173,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_inertia_decoupling_scales_by_mass_matrix(self):
         """Verify τ = M @ (Kp * Δq) when use_inertia_decoupling=True."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device, use_inertia=True)
+        ctrl = _make_mf(dofs_list=[2], kp=1.0, kd=0.0, device=device, use_inertia=True)
         M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 2.0, dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[1.0, 1.0], qd_des=[0.0, 0.0], device=device, mass_matrix=M
@@ -185,7 +183,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_gravity_compensation_adds_to_tau(self):
         """Verify gravity_force is added to τ when use_gravity_compensation=True."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_gravity=True)
+        ctrl = _make_mf(dofs_list=[2], kp=0.0, kd=0.0, device=device, use_gravity=True)
         grav = wp.array([3.0, 4.0], dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, gravity_force=grav
@@ -195,7 +193,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_coriolis_compensation_adds_to_tau(self):
         """Verify coriolis_force is added to τ when use_coriolis_compensation=True."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_coriolis=True)
+        ctrl = _make_mf(dofs_list=[2], kp=0.0, kd=0.0, device=device, use_coriolis=True)
         cor = wp.array([1.0, -1.0], dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, coriolis_force=cor
@@ -205,7 +203,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_qdd_feedforward_adds_before_inertia(self):
         """Verify qdd feedforward is included inside M @ (PD + qdd) when use_inertia=True."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_inertia=True, has_qdd=True)
+        ctrl = _make_mf(dofs_list=[2], kp=0.0, kd=0.0, device=device, use_inertia=True, has_qdd=True)
         M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 3.0, dtype=wp.float32, device=device)
         qdd = wp.array([1.0, 0.0], dtype=wp.float32, device=device)
         tau = _run_mf(
@@ -224,9 +222,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         """Verify stiffness supplied via inputs.stiffness each step is applied correctly."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
-            max_dofs=2,
             default_dof_indices=_iota(2, device),
             stiffness=None,
             damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
@@ -248,14 +244,13 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_is_graphable(self):
         """Verify the controller reports is_graphable() == True."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        ctrl = _make_mf(dofs_list=[2], kp=1.0, kd=0.0, device=device)
         self.assertTrue(ctrl.is_graphable())
 
     def test_inputs_has_required_fields(self):
         """Verify input() returns a namespace with all declared port fields present."""
         device = wp.get_device()
         ctrl = _make_mf(
-            robot_count=1,
             dofs_list=[3],
             kp=1.0,
             kd=0.0,
@@ -281,7 +276,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_outputs_has_joint_f(self):
         """Verify output() returns a flat array of size sum(dofs_per_robot)."""
         device = wp.get_device()
-        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        ctrl = _make_mf(dofs_list=[2], kp=1.0, kd=0.0, device=device)
         outs = ctrl.output()
         self.assertTrue(hasattr(outs, "joint_f"))
         self.assertEqual(outs.joint_f.shape, (2,))
@@ -290,9 +285,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         """Verify output() always returns a struct with joint_f."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
-            max_dofs=2,
             default_dof_indices=_iota(2, device),
             stiffness=wp.ones((1, 2), dtype=wp.float32, device=device),
             damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
@@ -306,9 +299,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         device = wp.get_device()
         indices = wp.array([1, 3], dtype=wp.uint32, device=device)
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
-            max_dofs=2,
             default_dof_indices=indices,
             stiffness=wp.ones((1, 2), dtype=wp.float32, device=device),
             damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
@@ -337,9 +328,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         duplicate_indices = wp.array([0, 0], dtype=wp.uint32, device=device)
         with self.assertRaises(ValueError):
             ControllerJointImpedanceModelFree(
-                robot_count=2,
                 dofs_per_robot=_dofs_arr([1, 1], device),
-                max_dofs=1,
                 default_dof_indices=duplicate_indices,
                 stiffness=_gains(2, 1, 1.0, device),
                 damping=_gains(2, 1, 0.0, device),
@@ -364,9 +353,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
-            max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),  # 2 + 1 = 3 total DOFs
             stiffness=_gains(2, max_dofs, 5.0, device),
             damping=_gains(2, max_dofs, 0.0, device),
@@ -391,9 +378,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
-            max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),
             stiffness=_gains(2, max_dofs, 1.0, device),
             damping=_gains(2, max_dofs, 0.0, device),
@@ -421,9 +406,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [3, 1]
         max_dofs = 3
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
-            max_dofs=max_dofs,
             default_dof_indices=_iota(4, device),
             stiffness=_gains(2, max_dofs, 1.0, device),
             damping=_gains(2, max_dofs, 0.0, device),
@@ -454,9 +437,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
-            max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),
             stiffness=_gains(2, max_dofs, 1.0, device),
             damping=_gains(2, max_dofs, 0.0, device),

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -700,6 +700,36 @@ class TestControllerJointImpedance(unittest.TestCase):
         )
         self.assertIsNotNone(ctrl)
 
+    def test_builder_reusable_after_construction(self):
+        """Verify construction snapshots the builder rather than consuming or modifying it.
+
+        The controller finalizes ``builder`` into a private model. That must
+        leave the caller's builder untouched and still independently usable, so
+        the same topology can also be built into the simulated model.
+        """
+        device = wp.get_device()
+        builder = _build_single_prismatic()
+        before = (builder.articulation_count, builder.joint_dof_count, list(builder.joint_type))
+
+        ControllerJointImpedance(
+            builder,
+            default_dof_indices=_iota(1, device),
+            stiffness=_gains(1, 1, 10.0, device),
+            damping=_gains(1, 1, 1.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+
+        after = (builder.articulation_count, builder.joint_dof_count, list(builder.joint_type))
+        self.assertEqual(before, after, "constructing the controller modified the builder")
+
+        # Snapshotted, not consumed: the builder can still be finalized on its own.
+        model = builder.finalize(device=device)
+        self.assertEqual(model.articulation_count, 1)
+        self.assertEqual(model.joint_dof_count, 1)
+
     def test_wrong_index_length_raises(self):
         """Verify that a mismatched default_dof_indices length raises ValueError."""
         device = wp.get_device()


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

This PR addresses the first two points of the issue #3826 

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

Upon adding max-dof checking, I discovered that this variable was not needed, given it can be derived from the `dofs_per_robot` input. For the same reasoning, `robot_count` was not needed in the constructor.

Other than this small change to the constructor API, this PR updates the class docstrings to clarify units, object life-cycles, and the relationship between the `ControllerJointImpedance` and `ControllerJointImpedanceModelFree` variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Simplified joint impedance controller setup by deriving robot count and maximum degrees of freedom from the provided configuration.
  - Added comprehensive validation for robot configurations, input arrays, devices, data types, shapes, gains, mass matrices, and indexed data.
  - Improved error detection for invalid or incomplete inputs before execution, including graph-capture scenarios.
- **Documentation**
  - Clarified dynamics requirements, gain shapes and units, and mass-matrix units for model-based and model-free controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->