### PR TITLE
Fix disabled USD collider approximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 ### Fixed
 
 - Fix MPR returning scale-dependent, excessively deep contacts for small convex shapes on large mesh triangles while preserving triangle-specific shared-edge manifold witnesses. (#3766)
+- Skip USD mesh approximation for disabled colliders. (#3830; fixes #3830)
 - Make deterministic collision pipelines cover hydroelastic contact generation and reduction, including unique reduced-contact sort keys and overflow-safe fixed-point pressure accumulation. (#3661)
 - Fix `SolverMuJoCo` retaining an invalid external-contact cache when its first step is captured in a CUDA graph. (#3768; fixes #3767)
 - Preserve box-box face contact manifolds under sub-microradian solver drift. (#3776)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,6 @@
 ### Fixed
 
 - Fix MPR returning scale-dependent, excessively deep contacts for small convex shapes on large mesh triangles while preserving triangle-specific shared-edge manifold witnesses. (#3766)
-- Skip USD mesh approximation for disabled colliders. (#3830; fixes #3830)
 - Make deterministic collision pipelines cover hydroelastic contact generation and reduction, including unique reduced-contact sort keys and overflow-safe fixed-point pressure accumulation. (#3661)
 - Fix `SolverMuJoCo` retaining an invalid external-contact cache when its first step is captured in a CUDA graph. (#3768; fixes #3767)
 - Preserve box-box face contact manifolds under sub-microradian solver drift. (#3776)

--- a/changelog/3830.fixed.md
+++ b/changelog/3830.fixed.md
@@ -1,0 +1,1 @@
+Skip USD mesh approximation for disabled colliders.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3882,7 +3882,7 @@ def parse_usd(
                     builder.shape_material_kh[shape_id] = kh
                     if is_hydroelastic:
                         builder.shape_flags[shape_id] |= ShapeFlags.HYDROELASTIC
-                    if not skip_mesh_approximation:
+                    if collider_is_enabled and not skip_mesh_approximation:
                         approximation = usd.get_attribute(prim, "physics:approximation", None)
                         if approximation is not None:
                             if has_sdf_api and approximation.lower() != "none":

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3053,6 +3053,46 @@ class TestImportUsdPhysics(unittest.TestCase):
             self.assertEqual(captured["threshold"], 0.5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_disabled_mesh_collider_skips_approximation(self):
+        """A disabled collider keeps its authored mesh without collision remeshing."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+        box = newton.Mesh.create_box(
+            1.0,
+            1.0,
+            1.0,
+            duplicate_vertices=False,
+            compute_normals=False,
+            compute_uvs=False,
+            compute_inertia=False,
+        )
+        mesh = UsdGeom.Mesh.Define(stage, "/Body/Mesh")
+        mesh.CreatePointsAttr().Set([Gf.Vec3f(*point) for point in box.vertices.tolist()])
+        mesh.CreateFaceVertexIndicesAttr().Set(box.indices.tolist())
+        mesh.CreateFaceVertexCountsAttr().Set([3] * (len(box.indices) // 3))
+        collision = UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
+        collision.GetCollisionEnabledAttr().Set(False)
+        UsdPhysics.MeshCollisionAPI.Apply(mesh.GetPrim()).GetApproximationAttr().Set(
+            UsdPhysics.Tokens.convexDecomposition
+        )
+
+        builder = newton.ModelBuilder()
+        with mock.patch.object(builder, "approximate_meshes") as approximate_meshes:
+            shape = builder.add_usd(stage, load_visual_shapes=False)["path_shape_map"]["/Body/Mesh"]
+
+        approximate_meshes.assert_not_called()
+        self.assertEqual(builder.shape_count, 1)
+        self.assertEqual(builder.shape_type[shape], newton.GeoType.MESH)
+        self.assertFalse(builder.shape_flags[shape] & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(builder.shape_flags[shape] & ShapeFlags.COLLIDE_PARTICLES)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_visual_match_collision_shapes(self):
         builder = newton.ModelBuilder()
         builder.add_usd(newton.examples.get_asset("humanoid.usda"))

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3054,7 +3054,7 @@ class TestImportUsdPhysics(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_disabled_mesh_collider_skips_approximation(self):
-        """A disabled collider keeps its authored mesh without collision remeshing."""
+        """Preserve the authored mesh for a disabled collider."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
         stage = Usd.Stage.CreateInMemory()
@@ -3089,6 +3089,8 @@ class TestImportUsdPhysics(unittest.TestCase):
         approximate_meshes.assert_not_called()
         self.assertEqual(builder.shape_count, 1)
         self.assertEqual(builder.shape_type[shape], newton.GeoType.MESH)
+        assert_np_equal(builder.shape_source[shape].vertices, box.vertices)
+        assert_np_equal(builder.shape_source[shape].indices, box.indices)
         self.assertFalse(builder.shape_flags[shape] & ShapeFlags.COLLIDE_SHAPES)
         self.assertFalse(builder.shape_flags[shape] & ShapeFlags.COLLIDE_PARTICLES)
 


### PR DESCRIPTION
## Description

Skip collision mesh approximation when `physics:collisionEnabled` is false. The importer previously queued disabled mesh shapes before clearing their collision flags, so a `convexDecomposition` token could still invoke CoACD for geometry that never participates in collision.

This preserves the existing imported shape, path mapping, and disabled collision flags while avoiding collision-only remeshing work.

Closes #3830.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] The user-facing fix is recorded in the Unreleased changelog

## Test plan

```bash
uv run --extra dev python -m unittest \
  newton.tests.test_import_usd.TestImportUsdPhysics.test_disabled_mesh_collider_skips_approximation \
  newton.tests.test_import_usd.TestImportUsdPhysics.test_mesh_approximation \
  newton.tests.test_import_usd.TestImportUsdPhysics.test_mesh_approximation_cfg
uvx pre-commit run -a
```

The new regression test was also run before the implementation change and failed because `approximate_meshes(method="coacd", ...)` was called once.

## Bug fix

**Steps to reproduce:**

1. Create a USD mesh below a `PhysicsRigidBodyAPI` prim.
2. Apply `PhysicsCollisionAPI` with `physics:collisionEnabled = false`.
3. Apply `PhysicsMeshCollisionAPI` with `physics:approximation = "convexDecomposition"`.
4. Import with `ModelBuilder.add_usd(stage, load_visual_shapes=False)`.
5. Observe CoACD being called for the disabled shape.

**Minimal reproduction:**

```python
from unittest import mock

import newton

builder = newton.ModelBuilder()
with mock.patch.object(builder, "approximate_meshes") as approximate_meshes:
    builder.add_usd(stage, load_visual_shapes=False)
approximate_meshes.assert_not_called()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled mesh colliders imported from USD no longer undergo mesh approximation.
  * Authored meshes and disabled collision settings are now preserved correctly.

* **Tests**
  * Added regression coverage for disabled colliders using convex-decomposition approximation.

* **Documentation**
  * Added a changelog entry describing the corrected USD import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->