### PR TITLE
Keep API detection advisory on metadata 403

### DIFF
--- a/.github/workflows/pr_api_changes.yml
+++ b/.github/workflows/pr_api_changes.yml
@@ -97,56 +97,64 @@ jobs:
               issue_number: context.issue.number,
             };
 
-            if (needsReview) {
-              await github.rest.issues.addLabels({
-                ...issue,
-                labels: ['api-changes'],
-              });
-            } else {
-              try {
-                await github.rest.issues.removeLabel({
+            try {
+              if (needsReview) {
+                await github.rest.issues.addLabels({
                   ...issue,
-                  name: 'api-changes',
+                  labels: ['api-changes'],
                 });
-              } catch (error) {
-                // The current state is already correct when the label is absent.
-                if (error.status !== 404) throw error;
+              } else {
+                try {
+                  await github.rest.issues.removeLabel({
+                    ...issue,
+                    name: 'api-changes',
+                  });
+                } catch (error) {
+                  // The current state is already correct when the label is absent.
+                  if (error.status !== 404) throw error;
+                }
               }
-            }
 
-            const marker = '<!-- newton-api-changes -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...issue,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.user?.type === 'Bot' &&
-              comment.body?.startsWith(marker)
-            );
+              const marker = '<!-- newton-api-changes -->';
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...issue,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.user?.type === 'Bot' &&
+                comment.body?.startsWith(marker)
+              );
 
-            if (!needsReview) {
+              if (!needsReview) {
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    ...repo,
+                    comment_id: existing.id,
+                  });
+                }
+                return;
+              }
+
+              const body = fs.readFileSync(process.env.API_COMMENT_PATH, 'utf8').trim();
+              if (!body) return;
+              const fullBody = `${marker}\n${body}`;
               if (existing) {
-                await github.rest.issues.deleteComment({
+                await github.rest.issues.updateComment({
                   ...repo,
                   comment_id: existing.id,
+                  body: fullBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  ...issue,
+                  body: fullBody,
                 });
               }
-              return;
-            }
-
-            const body = fs.readFileSync(process.env.API_COMMENT_PATH, 'utf8').trim();
-            if (!body) return;
-            const fullBody = `${marker}\n${body}`;
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...repo,
-                comment_id: existing.id,
-                body: fullBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...issue,
-                body: fullBody,
-              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(`Skipping API review metadata sync: ${error.message}`);
+                return;
+              }
+              throw error;
             }

--- a/changelog/+api-review-metadata-4f81c2a7.fixed.md
+++ b/changelog/+api-review-metadata-4f81c2a7.fixed.md
@@ -1,0 +1,1 @@
+Keep API-change detection advisory when metadata synchronization lacks write permission.

--- a/scripts/ci/tests/test_pr_api_changes_workflow.py
+++ b/scripts/ci/tests/test_pr_api_changes_workflow.py
@@ -70,7 +70,8 @@ class TestPrApiChangesWorkflow(unittest.TestCase):
         self.assertIn("if (error.status === 403)", block)
         self.assertIn("core.warning", block)
         self.assertIn("Skipping API review metadata sync", block)
-        self.assertIn("throw error", block)
+        permission_handler = block[block.index("if (error.status === 403)") :]
+        self.assertIn("throw error", permission_handler)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_pr_api_changes_workflow.py
+++ b/scripts/ci/tests/test_pr_api_changes_workflow.py
@@ -63,6 +63,15 @@ class TestPrApiChangesWorkflow(unittest.TestCase):
         self.assertIn("github.rest.issues.updateComment", block)
         self.assertIn("github.rest.issues.createComment", block)
 
+    def test_api_review_metadata_permissions_are_non_blocking(self):
+        """Keep advisory detection successful when metadata writes are forbidden."""
+        block = self._step_block("Sync API review")
+
+        self.assertIn("if (error.status === 403)", block)
+        self.assertIn("core.warning", block)
+        self.assertIn("Skipping API review metadata sync", block)
+        self.assertIn("throw error", block)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- keep API-change detection successful when repository policy denies label/comment writes
- emit a workflow warning for metadata-sync HTTP 403 responses
- continue failing on all other unexpected metadata errors
- preserve the existing missing-label HTTP 404 behavior

This fixes the `detect-api-changes` failures currently blocking #3831 and #3833. Both runs finish detection with `NEEDS_REVIEW=false`, then fail while removing the `api-changes` label because the workflow token receives `Resource not accessible by integration`. Since `pull_request_target` loads this workflow from the base branch, the affected PR branches cannot fix the failure themselves.

## Validation

- regression test failed before the workflow change
- `uv run --no-project -m unittest scripts/ci/tests/test_pr_api_changes_workflow.py` (6 passed)
- `uv run --no-project -m unittest discover -s scripts/ci/tests` (20 passed)
- `uvx pre-commit run -a` (passed)

## Risk

When repository policy denies metadata writes, the `api-changes` label and bot comment may remain stale or absent. The detector result remains available in the workflow log, and detector or non-permission failures are not suppressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API review metadata synchronization now continues safely when write permissions are insufficient.
  * Permission-related failures are reported as warnings without blocking the workflow.
  * Non-permission-related errors continue to be reported normally.
  * Synchronization warnings and skipped actions are surfaced clearly in workflow results.

* **Tests**
  * Added regression coverage for handling forbidden metadata permissions without blocking the workflow.

* **Documentation**
  * Documented that API-change detection remains advisory when metadata synchronization cannot update review information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->