### PR TITLE
Document ARM importer GLIBC requirement

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -29,7 +29,7 @@ Minimum Requirements
      - 3.11+ recommended
    * - OS
      - Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
-     - macOS has no GPU acceleration
+     - macOS has no GPU acceleration; see the ARM64 requirements below
    * - NVIDIA GPU
      - Compute capability 5.0+ (Maxwell)
      - Any GeForce GTX 9xx or newer
@@ -45,8 +45,16 @@ Platform-Specific Requirements
 
 **Linux aarch64 (ARM64)**
 
-On ARM64 Linux systems (such as NVIDIA Jetson Thor and DGX Spark), installing the ``examples`` extras currently requires
-X11 development libraries to build ``imgui_bundle`` from source:
+On ARM64 Linux, the ``importers`` extra requires GLIBC 2.35 or newer because
+`usd-exchange <https://pypi.org/project/usd-exchange/>`__ publishes its Linux
+ARM64 wheels for ``manylinux_2_35``. This also applies to extras that include
+``importers``, such as ``examples`` and ``dev``. Distributions with an older
+GLIBC, including RHEL 9 with GLIBC 2.34, can install the base Newton package but
+cannot install these extras from the published wheels.
+
+Installing the ``examples`` extra on ARM64 Linux systems such as NVIDIA Jetson
+Thor and DGX Spark also requires X11 development libraries to build
+``imgui_bundle`` from source:
 
 .. code-block:: console
 

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -29,7 +29,7 @@ Minimum Requirements
      - 3.11+ recommended
    * - OS
      - Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
-     - macOS has no GPU acceleration; see the ARM64 requirements below
+     - macOS has no GPU acceleration
    * - NVIDIA GPU
      - Compute capability 5.0+ (Maxwell)
      - Any GeForce GTX 9xx or newer


### PR DESCRIPTION
## Description

Document that ARM64 installations of the `importers` extra, and extras that include it, require GLIBC 2.35 or newer because of the published `usd-exchange` wheel baseline.

Clarify that the base Newton package remains installable on GLIBC 2.34, while distributions such as RHEL 9 cannot install importer-dependent extras from the published wheels.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] A changelog fragment is not required because this documents existing behavior

## Test plan

```console
uvx --python 3.12 pre-commit run -a
uv run --extra docs --extra sim sphinx-build -W -D nbsphinx_execute=never -b html docs /tmp/newton-arm-docs-html-noexec
```

Also verified on native ARM64 that the base Newton wheel resolves on UBI/RHEL 9.6 with GLIBC 2.34, while the full `dev` extra resolves on Ubuntu 24.04 with GLIBC 2.39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ARM64 Linux installation requirements for the `importers`, `examples`, and `dev` extras.
  * Documented the GLIBC 2.35 minimum for published ARM64 wheels and identified distributions with older GLIBC versions that are unsupported.
  * Added X11 development-library requirements for building on NVIDIA Jetson Thor and DGX Spark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->