### PR TITLE
Fix API review workflow permissions

### DIFF
--- a/.github/workflows/pr_api_changes.yml
+++ b/.github/workflows/pr_api_changes.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     if: github.repository == 'newton-physics/newton'
     steps:
       - name: Harden Runner

--- a/scripts/ci/tests/test_pr_api_changes_workflow.py
+++ b/scripts/ci/tests/test_pr_api_changes_workflow.py
@@ -63,6 +63,14 @@ class TestPrApiChangesWorkflow(unittest.TestCase):
         self.assertIn("github.rest.issues.updateComment", block)
         self.assertIn("github.rest.issues.createComment", block)
 
+    def test_api_review_can_update_pull_request_metadata(self):
+        """Grant write access for pull request labels and comments."""
+        self.assertIn(
+            "    permissions:\n      contents: read\n      pull-requests: write",
+            self.workflow,
+        )
+        self.assertNotIn("      issues: write", self.workflow)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Grant the API review job `pull-requests: write` instead of `issues: write` so GitHub Actions can synchronize labels and bot comments on pull requests.

The API detector itself succeeds, but the metadata step currently receives `403 Resource not accessible by integration` because its job-level permissions omit the pull-request scope. Job-level permissions set every unspecified scope to `none`.

Add regression coverage for the exact permission block so this cannot regress to the issue-only scope.

> [!NOTE]
> This PR's own `Public API Change Detection` check runs the workflow from the base branch under `pull_request_target`, so it still uses the broken permission from `main` and reproduces the same 403. Subsequent PR events will use the corrected workflow after this change is merged.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date; no user documentation is affected
- [x] This CI-only fix is not user-facing, so no changelog fragment is required

## Test plan

```console
uv run --no-project -m unittest scripts/ci/tests/test_pr_api_changes_workflow.py
uv run --no-project -m unittest discover -s scripts/ci/tests
uvx pre-commit run -a
```

The new regression test fails before the workflow permission change and passes afterward.

## Bug fix

**Steps to reproduce:**

1. Open or synchronize a pull request against `main`.
2. Let the `Public API Change Detection` workflow reach `Sync API review`.
3. Observe a 403 while adding or removing the `api-changes` label.

The workflow now requests the permission GitHub uses for pull-request labels and comments.
