### PR TITLE
Skip CUDA-only browser examples without CUDA

### DIFF
--- a/newton/tests/test_example_browser.py
+++ b/newton/tests/test_example_browser.py
@@ -32,10 +32,6 @@ import newton.viewer
 
 wp.init()
 
-SKIP_EXAMPLES = {
-    "robot_policy": "uses a non-standard constructor",
-}
-
 CUDA_REQUIRED_EXAMPLES = {
     "brick_stacking",
     "contacts_rj45_plug",
@@ -55,8 +51,6 @@ def _step_and_render(example, num_frames):
 
 
 def _get_skip_reason(name, cuda_available):
-    if name in SKIP_EXAMPLES:
-        return SKIP_EXAMPLES[name]
     if not cuda_available and name in CUDA_REQUIRED_EXAMPLES:
         return "requires CUDA"
     return None

--- a/newton/tests/test_example_browser.py
+++ b/newton/tests/test_example_browser.py
@@ -172,7 +172,7 @@ def main():
                 print(f"    {line}")
 
     if not switch_fail and not reset_fail:
-        print("\nAll examples passed!")
+        print("\nAll runnable examples passed!" if skipped else "\nAll examples passed!")
 
     return 1 if (switch_fail or reset_fail) else 0
 

--- a/newton/tests/test_example_browser.py
+++ b/newton/tests/test_example_browser.py
@@ -33,7 +33,16 @@ import newton.viewer
 wp.init()
 
 SKIP_EXAMPLES = {
-    "robot_policy",  # non-standard constructor: (viewer, config, asset_directory, mjc_to_physx, physx_to_mjc)
+    "robot_policy": "uses a non-standard constructor",
+}
+
+CUDA_REQUIRED_EXAMPLES = {
+    "brick_stacking",
+    "contacts_rj45_plug",
+    "mujoco_sleeping",
+    "nut_bolt_hydro",
+    "nut_bolt_sdf",
+    "robot_panda_hydro",
 }
 
 
@@ -43,6 +52,14 @@ def _step_and_render(example, num_frames):
             example.step()
         if hasattr(example, "render"):
             example.render()
+
+
+def _get_skip_reason(name, cuda_available):
+    if name in SKIP_EXAMPLES:
+        return SKIP_EXAMPLES[name]
+    if not cuda_available and name in CUDA_REQUIRED_EXAMPLES:
+        return "requires CUDA"
+    return None
 
 
 def main():
@@ -59,15 +76,29 @@ def main():
     create_parser = newton.examples.create_parser
     default_args = newton.examples.default_args
 
-    matched = {
-        name: mod
-        for name, mod in sorted(example_map.items())
-        if name not in SKIP_EXAMPLES and any(fnmatch.fnmatch(name, p) for p in cli_args.patterns)
+    selected = {
+        name: module_path
+        for name, module_path in sorted(example_map.items())
+        if any(fnmatch.fnmatch(name, pattern) for pattern in cli_args.patterns)
     }
 
-    if not matched:
+    if not selected:
         print(f"No examples matched patterns: {cli_args.patterns}")
         return 1
+
+    cuda_available = wp.is_cuda_available()
+    skipped = {name: reason for name in selected if (reason := _get_skip_reason(name, cuda_available)) is not None}
+    matched = {name: module_path for name, module_path in selected.items() if name not in skipped}
+
+    if skipped:
+        print(f"Skipping {len(skipped)} example(s):")
+        for name, reason in skipped.items():
+            print(f"  {name}: {reason}")
+        print()
+
+    if not matched:
+        print("No runnable examples matched.")
+        return 0
 
     viewer = newton.viewer.ViewerGL()
 
@@ -123,7 +154,7 @@ def main():
     reset_fail = [r for r in results if r["reset"] not in ("OK", None)]
 
     print("\n" + "=" * 70, flush=True)
-    print(f"RESULTS: {switch_ok}/{total} switch OK, {reset_ok}/{total} reset OK")
+    print(f"RESULTS: {switch_ok}/{total} switch OK, {reset_ok}/{total} reset OK, {len(skipped)} skipped")
     print("=" * 70)
 
     if switch_fail:


### PR DESCRIPTION
## Description

Skip examples with known CUDA requirements in the manual example-browser smoke test when CUDA is unavailable.

The regular example test suite already limits these examples to `cuda_test_devices`, but `test_example_browser.py` attempted to instantiate them on CPU-only systems. On macOS this produced six expected switch failures from the CUDA-only texture SDF pipeline and MuJoCo sleeping example.

The browser smoke test now reports capability-based skips explicitly, includes the skip count in its summary, and exits successfully when every selected example is unsupported. Unmatched patterns and unexpected runtime failures remain errors.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable; test-only behavior)

## Test plan

```bash
CUDA_VISIBLE_DEVICES=-1 uv run python newton/tests/test_example_browser.py brick_stacking contacts_rj45_plug mujoco_sleeping nut_bolt_hydro nut_bolt_sdf robot_panda_hydro
uvx --python 3.12 pre-commit run --files newton/tests/test_example_browser.py
```

The no-CUDA run reports all six examples as skipped and exits with status 0.

## Bug fix

**Steps to reproduce:**

1. Run on macOS or another system without a CUDA-capable device.
2. Run `uv run python newton/tests/test_example_browser.py`.
3. Observe six switch failures for examples that require CUDA.

**Minimal reproduction:**

```bash
CUDA_VISIBLE_DEVICES=-1 uv run python newton/tests/test_example_browser.py nut_bolt_sdf
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved example selection and skip handling in the smoke test.
  * Skip reasons are now reported clearly, including for CUDA-dependent examples.
  * Requests with no matching examples are handled before skip filtering.
  * When all selected examples are skipped, the test completes successfully without opening a viewer.
  * Final results now include skipped-example counts and distinguish between all examples passing and all runnable examples passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->