### PR TITLE
Speed up MuJoCo collision mask compilation

### DIFF
--- a/changelog/+mujoco-mask-init-7c2f1a4e.fixed.md
+++ b/changelog/+mujoco-mask-init-7c2f1a4e.fixed.md
@@ -1,0 +1,1 @@
+Speed up :class:`~newton.solvers.SolverMuJoCo` initialization for replicated models by querying collision filters only for the selected MuJoCo template shapes.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5026,16 +5026,12 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         if selected_shapes.shape[0] > NEWTON_COLLISION_MASK_MAX_SHAPE_COUNT:
             return compile_newton_collision_graph(groups)
 
-        # The compiler derives group-based edges itself. Map only explicit
-        # exclusions whose two endpoints are in this solver's shape selection.
-        filter_pairs = model.shape_collision_filter_pairs_array()
-        if filter_pairs.shape[0]:
-            to_local = np.full(model.shape_count, -1, dtype=np.int64)
-            to_local[selected_shapes] = np.arange(selected_shapes.shape[0], dtype=np.int64)
-            local_filter_pairs = to_local[filter_pairs]
-            local_filter_pairs = local_filter_pairs[np.all(local_filter_pairs >= 0, axis=1)]
-        else:
-            local_filter_pairs = np.empty((0, 2), dtype=np.int64)
+        # Query only the bounded selected-shape graph. Materializing the global
+        # sparse pair array scales this template conversion with replicated worlds.
+        shape_a, shape_b = np.triu_indices(selected_shapes.shape[0], k=1)
+        candidate_pairs = np.column_stack((selected_shapes[shape_a], selected_shapes[shape_b]))
+        filtered = model.shape_collision_filter_mask(candidate_pairs)
+        local_filter_pairs = np.column_stack((shape_a[filtered], shape_b[filtered]))
         return compile_newton_collision_graph(groups, excluded_pairs=local_filter_pairs)
 
     @staticmethod

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2428,22 +2428,25 @@ class TestMuJoCoSolverCollisionMasks(unittest.TestCase):
 
         self.assertTrue(result.skipped)
 
-    def test_sparse_filters_map_without_pair_enumeration(self):
-        """Map sparse filters into a selected collision graph directly."""
+    def test_sparse_filters_query_only_selected_pairs(self):
+        """Query filters only for pairs in the selected collision graph."""
 
         class ShapeGroups:
             def numpy(self):
                 return np.ones(5, dtype=np.int32)
 
         class ModelStub:
-            shape_count = 5
             shape_collision_group = ShapeGroups()
 
             def shape_collision_filter_pairs_array(self):
-                return np.array([[0, 4], [1, 3]], dtype=np.int32)
+                raise AssertionError("selected graphs must not materialize every sparse filter")
 
-            def shape_collision_filter_mask(self, _pairs):
-                raise AssertionError("sparse filters must not require candidate-pair enumeration")
+            def shape_collision_filter_mask(self, pairs):
+                np.testing.assert_array_equal(
+                    pairs,
+                    np.array([[1, 3], [1, 4], [3, 4]], dtype=np.int32),
+                )
+                return np.array([True, False, False])
 
         result = SolverMuJoCo._compile_newton_collision_masks(
             ModelStub(),


### PR DESCRIPTION
## Description

Speed up `SolverMuJoCo` initialization for replicated models by querying collision exclusions only for the shapes selected for the MuJoCo template.

The reverse collision-mask compiler previously materialized every Newton shape-filter pair and then discarded pairs outside the selected template. For the G1 benchmark with 8,192 worlds, that expanded 11,173,888 filter pairs even though the generated MuJoCo model contains only five collision geoms.

This change instead enumerates the selected graph's upper triangle and queries those pairs through `Model.shape_collision_filter_mask()`. The work is bounded at 32,640 candidate pairs by the reverse compiler's existing 256-shape limit.

Focused measurements on an RTX 4090 Laptop GPU system:

| G1, 8,192 worlds | Before | After | Change |
|---|---:|---:|---:|
| Collision-mask compilation | 528 ms | 2.31 ms | 228x faster |
| `SolverMuJoCo` construction | 4.609 s | 4.268 s | -342 ms (-7.4%) |

The before/after mask arrays were verified to be exactly identical.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```text
uv run --extra dev -m unittest newton.tests.test_mujoco_solver.TestMuJoCoSolverCollisionMasks
# 4 passed

uv run --extra dev -m unittest newton.tests.test_collision_mask_compiler
# 21 passed

uvx --from towncrier==25.8.0 towncrier build --draft --version X.Y.Z --date 2026-08-07
# fragment rendered successfully

uvx pre-commit run -a
# all passed
```

The focused regression test was also run with the original global-scan implementation and failed as expected because it attempted to materialize the full sparse-filter array.

## Bug fix

**Steps to reproduce:**

1. Build the ASV G1 workload with 8,192 replicated worlds.
2. Construct `SolverMuJoCo` with MuJoCo contacts enabled.
3. Observe that reverse mask compilation scans every replicated-world filter pair to generate masks for the five selected template geoms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized MuJoCo solver initialization for replicated models by querying collision filters only for selected shapes.
  * Reduced unnecessary processing of model-wide collision-pair data.

* **Bug Fixes**
  * Improved collision-mask handling for selected shape pairs, ensuring filtering remains accurate during solver setup.

* **Tests**
  * Added coverage verifying that only relevant collision-graph pairs are queried and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->