### PR TITLE
Scale PADMM warm-start forces

### DIFF
--- a/changelog/+padmm-warmstart-scale-a3f91c72.added.md
+++ b/changelog/+padmm-warmstart-scale-a3f91c72.added.md
@@ -1,1 +1,0 @@
-Add `PADMMSolverConfig.warmstart_scale` to dampen cached forces during warm-starting.

--- a/changelog/+padmm-warmstart-scale-a3f91c72.added.md
+++ b/changelog/+padmm-warmstart-scale-a3f91c72.added.md
@@ -1,0 +1,1 @@
+Add `PADMMSolverConfig.warmstart_scale` to dampen cached forces during warm-starting.

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -59,6 +59,7 @@ __all__ = [
     "_make_project_dual_convergence_accel_kernel",
     "_project_to_feasible_cone",
     "_reset_solver_data",
+    "_scale_warmstart_forces",
     "_update_delassus_proximal_regularization",
     "_update_delassus_proximal_regularization_sparse",
     "_warmstart_contact_constraints",
@@ -161,6 +162,27 @@ def _warmstart_desaxce_correction(
 
     # Store De Saxce correction for this block
     solver_z[ccio_k + 2] = vn + mu * vt_norm
+
+
+@wp.kernel
+def _scale_warmstart_forces(
+    # Inputs:
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    solver_config: wp.array[PADMMConfigStruct],
+    # Outputs:
+    solver_x: wp.array[wp.float32],
+    solver_y: wp.array[wp.float32],
+):
+    """Scale cached constraint forces copied into the primal and slack iterates."""
+    wid, tid = wp.tid()
+    if tid >= problem_dim[wid]:
+        return
+
+    index = problem_vio[wid] + tid
+    scale = solver_config[wid].warmstart_scale
+    solver_x[index] *= scale
+    solver_y[index] *= scale
 
 
 def make_initialize_solver_kernel(use_acceleration: bool = False):

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -34,6 +34,7 @@ from .kernels import (
     _make_project_dual_convergence_accel_kernel,
     _project_to_feasible_cone,
     _reset_solver_data,
+    _scale_warmstart_forces,
     _update_delassus_proximal_regularization,
     _update_delassus_proximal_regularization_sparse,
     _warmstart_contact_constraints,
@@ -355,6 +356,27 @@ class PADMMSolver:
                 self._warmstart_from_containers(problem, model, data, limits, contacts)
             case _:
                 raise ValueError(f"Invalid warmstart mode: {self._warmstart}")
+
+        self._scale_warmstart_forces(problem)
+
+    def _scale_warmstart_forces(self, problem: DualProblem):
+        """Scales the warm-started primal and slack force iterates."""
+        x_0 = self._data.state.x_p
+        y_0 = self._data.state.y_hat if self._use_acceleration else self._data.state.y_p
+        wp.launch(
+            kernel=_scale_warmstart_forces,
+            dim=(self._size.num_worlds, self._size.max_of_max_total_cts),
+            inputs=[
+                # Inputs:
+                problem.data.dim,
+                problem.data.vio,
+                self._data.config,
+                # Outputs:
+                x_0,
+                y_0,
+            ],
+            device=self.device,
+        )
 
     def solve(self, problem: DualProblem):
         """

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -270,6 +270,9 @@ class PADMMConfigStruct:
     Must be non-negative. Defaults to `0.0`.
     """
 
+    warmstart_scale: wp.float32
+    """Scale applied to cached constraint forces during warm-starting. Defaults to `0.9`."""
+
 
 @wp.struct
 class PADMMStatus:
@@ -1269,4 +1272,5 @@ def convert_config_to_struct(config: PADMMSolverConfig) -> PADMMConfigStruct:
     config_struct.penalty_update_method = PADMMPenaltyUpdate.from_string(config.penalty_update_method)
     config_struct.linear_solver_tolerance = config.linear_solver_tolerance
     config_struct.linear_solver_tolerance_ratio = config.linear_solver_tolerance_ratio
+    config_struct.warmstart_scale = config.warmstart_scale
     return config_struct

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -587,6 +587,16 @@ class PADMMSolverConfig:
     Defaults to `containers` to warmstart from the solver data containers.
     """
 
+    warmstart_scale: float = 0.9
+    """
+    Scale applied to cached constraint forces during warm-starting.\n
+    Must be in the range [0, 1]. Defaults to `0.9`.
+
+    PADMM converges to a minimum-norm deviation from its initial guess. Scaling
+    the warm-start forces makes null-space forces converge to the overall
+    minimum-norm solution.
+    """
+
     contact_warmstart_method: Literal[
         "key_and_position",
         "geom_pair_net_force",
@@ -763,6 +773,8 @@ class PADMMSolverConfig:
             raise ValueError(
                 f"Invalid linear solver tolerance ratio: {self.linear_solver_tolerance_ratio}. Must be non-negative."
             )
+        if not 0.0 <= self.warmstart_scale <= 1.0:
+            raise ValueError(f"Invalid warmstart scale: {self.warmstart_scale}. Must be in the range [0, 1].")
 
         # Ensure that the enum-valued parameters are valid options
         # Conversion to enum-type configs will raise an error

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -367,17 +367,25 @@ class TestSolverKaminoConfig(unittest.TestCase):
         self.assertEqual(config.rotation_correction, "twopi")
         self.assertEqual(config.dynamics.linear_solver_type, "LLTB")
         self.assertEqual(config.padmm.warmstart_mode, "containers")
+        self.assertEqual(config.padmm.warmstart_scale, 0.9)
 
     def test_01_make_explicit(self):
         config = SolverKaminoImpl.Config(
             dynamics=kamino_config.ConstrainedDynamicsConfig(linear_solver_type="CR"),
-            padmm=kamino_config.PADMMSolverConfig(warmstart_mode="internal"),
+            padmm=kamino_config.PADMMSolverConfig(warmstart_mode="internal", warmstart_scale=0.5),
             rotation_correction="continuous",
         )
         assert_solver_config(self, config)
         self.assertEqual(config.rotation_correction, "continuous")
         self.assertEqual(config.dynamics.linear_solver_type, "CR")
         self.assertEqual(config.padmm.warmstart_mode, "internal")
+        self.assertEqual(config.padmm.warmstart_scale, 0.5)
+
+    def test_02_validate_warmstart_scale(self):
+        """Reject PADMM warmstart scales outside the supported range."""
+        for scale in (-0.1, 1.1):
+            with self.assertRaises(ValueError):
+                kamino_config.PADMMSolverConfig(warmstart_scale=scale)
 
 
 class TestCollisionCapacityInitialization(unittest.TestCase):

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -505,6 +505,9 @@ class TestPADMMSolver(unittest.TestCase):
         # Second solve with warm-starting from previous solution
         test.build()
         solver.warmstart(test.problem, test.model, test.data)
+        expected_forces = solver.data.solution.lambdas.numpy() * config.warmstart_scale
+        np.testing.assert_allclose(solver.data.state.x_p.numpy(), expected_forces)
+        np.testing.assert_allclose(solver.data.state.y_p.numpy(), expected_forces)
         solver.solve(problem=test.problem)
         check_padmm_solution(self, test.model, test.problem, solver, verbose=self.verbose)
 


### PR DESCRIPTION
## Description

Add `PADMMSolverConfig.warmstart_scale`, defaulting to `0.9`, to dampen cached force iterates before PADMM warm-starting. Both primal and slack iterates are scaled to preserve their initial consensus.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- [x] `uv run --extra dev -m newton.tests -k test_04_padmm_solve_with_internal_warmstart`
- [x] `uvx --from towncrier==25.8.0 towncrier build --draft --version 0.0.0 --date 2026-08-07`

## New feature / API change

```python
config.padmm.warmstart_scale = 0.9
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable scaling for cached constraint forces during PADMM warm-starting.
  - Introduced a `warmstart_scale` setting with a default value of `0.9`.
  - Added validation requiring the setting to be between `0` and `1`, inclusive.

- **Tests**
  - Added coverage for default, custom, and invalid warm-start scale values.
  - Updated warm-start verification to confirm scaled solver state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->