### PR TITLE
Fix accelerated PADMM restarts and per-world iteration budgets

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/padmm/__init__.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/__init__.py
@@ -11,7 +11,7 @@ et al in [2]. It solves the Lagrange dual of the constrained forward dynamics pr
 in constraint reactions (i.e. impulses) and post-event constraint-space velocities. The
 diagonal preconditioner strategy described in [3] is also implemented to improve
 numerical conditioning. This version also incorporates Nesterov-style gradient
-acceleration with adaptive restarts based on the work of O'Donoghue and Candes in [4].
+acceleration with the Fast ADMM restart rule of Goldstein et al. in [4].
 
 Notes
 ----

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -83,6 +83,20 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 
 
 ###
+# Constants
+###
+
+# Bit flags packed into the per-world control code that the accelerated projection kernel
+# broadcasts from its leader thread to the whole block before the state writeback.
+
+CONTROL_RESTART = wp.constant(wp.int32(1))
+"""Control bit set when the restart criterion rejected the accelerated step."""
+
+CONTROL_CONVERGED = wp.constant(wp.int32(2))
+"""Control bit set when the world met all convergence tolerances."""
+
+
+###
 # Kernels
 ###
 
@@ -802,10 +816,13 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
         ncts = problem_dim[wid]
         vio = problem_vio[wid]
         status = solver_status[wid]
+        config = solver_config[wid]
 
-        # Already-converged worlds still refresh previous-state buffers so
-        # later status and info collection observe consistent iterates.
-        if status.converged:
+        # Worlds that converged or exhausted their iteration budget are frozen: they still
+        # refresh the previous-state buffers so later status and info collection observe
+        # consistent iterates, but skip the bookkeeping below so that the terminal state is
+        # never overwritten and `solver_state_done` is decremented exactly once per world.
+        if status.converged or status.iterations >= config.max_iterations:
             num_cache_iterations = (ncts + num_threads_per_block - 1) // num_threads_per_block
             for ii in range(num_cache_iterations):
                 local_id = tid + ii * num_threads_per_block
@@ -823,7 +840,6 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
         lcgo = problem_lcgo[wid]
         ccgo = problem_ccgo[wid]
         cio = problem_cio[wid]
-        config = solver_config[wid]
         pen = solver_penalty[wid]
         rho = pen.rho
         inv_rho = 1.0 / rho
@@ -957,7 +973,7 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
             status.r_dx = wp.sqrt(r_dx_l2_sum)
             status.r_dy = wp.sqrt(r_dy_l2_sum)
             status.r_dz = wp.sqrt(r_dz_l2_sum)
-            status.r_a = rho * status.r_dy + (1.0 / rho) * status.r_dz
+            status.r_a = rho * r_dy_l2_sum + (1.0 / rho) * r_dz_l2_sum
 
             if (
                 status.iterations > 1
@@ -970,7 +986,9 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
             if status.converged or status.iterations >= config.max_iterations:
                 solver_state_done[0] -= 1
 
-            if status.r_a < config.restart_tolerance * status.r_a_p:
+            if status.converged:
+                status.restart = 0
+            elif status.r_a < config.restart_tolerance * status.r_a_p:
                 status.restart = 0
                 a_p = solver_state_a_p[wid]
                 a = (1.0 + wp.sqrt(1.0 + 4.0 * a_p * a_p)) / 2.0
@@ -995,7 +1013,7 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
         control_value = wp.int32(0)
         a_factor_value = wp.float32(0.0)
         if tid == 0:
-            control_value = status.restart + wp.int32(2) * status.converged
+            control_value = CONTROL_RESTART * status.restart + CONTROL_CONVERGED * status.converged
             a_factor_value = solver_state_a_factor[wid]
 
         wp.tile_scatter_masked(control_sync, 0, control_value, tid == 0)
@@ -1003,6 +1021,9 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
 
         control = control_sync[0]
         a_factor = a_factor_sync[0]
+
+        restarted = (control & CONTROL_RESTART) != 0
+        converged = (control & CONTROL_CONVERGED) != 0
 
         # Update accelerated auxiliary variables for active worlds, then cache
         # current iterates as the previous state for the next iteration.
@@ -1016,11 +1037,14 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
                 y_p = solver_state_y_p[vid]
                 z_p = solver_state_z_p[vid]
 
-                if control < wp.int32(2):
-                    if control == wp.int32(0):
+                if not converged:
+                    if not restarted:
                         solver_state_y_hat_out[vid] = y + a_factor * (y - y_p)
                         solver_state_z_hat_out[vid] = z + a_factor * (z - z_p)
                     else:
+                        # Drop the momentum by rewinding the extrapolation to the previous
+                        # iterate. The current iterate is still kept, as in the Fast ADMM
+                        # restart rule of Goldstein et al. cited in the module docstring.
                         solver_state_y_hat_out[vid] = y_p
                         solver_state_z_hat_out[vid] = z_p
 

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -303,7 +303,7 @@ class PADMMStatus:
         r_dz: The total dual iterate residual.
             Computed as the L2-norm `r_dz := || z - z_p ||_2`.
         r_a: The total combined primal-dual residual used for acceleration restart checks.
-            Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
+            Computed as `r_a := rho * r_dy^2 + (1.0 / rho) * r_dz^2`.
         r_a_p: The previous total combined primal-dual residual.
         r_a_pp: An auxiliary cache of the previous total combined primal-dual residual.
         restart: A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).
@@ -366,7 +366,7 @@ class PADMMStatus:
     r_a: wp.float32
     """
     The total combined primal-dual residual used for acceleration restart checks.
-    Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
+    Computed as `r_a := rho * r_dy^2 + (1.0 / rho) * r_dz^2`.
     """
 
     r_a_p: wp.float32

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -4,6 +4,7 @@
 """Unit tests for the Proximal-ADMM Solver."""
 
 import unittest
+from typing import Any
 
 import numpy as np
 import warp as wp
@@ -16,6 +17,7 @@ from newton._src.solvers.kamino._src.linalg import ConjugateResidualSolver, LLTB
 from newton._src.solvers.kamino._src.linalg.utils.matrix import SquareSymmetricMatrixProperties
 from newton._src.solvers.kamino._src.linalg.utils.range import in_range_via_gaussian_elimination
 from newton._src.solvers.kamino._src.models.builders import basics
+from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.solvers.padmm import PADMMSolver, PADMMWarmStartMode
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton.tests.kamino import setup_tests, test_context
@@ -185,6 +187,126 @@ def check_padmm_solution(
         # between in-solver residual and true residual.
         test.assertLessEqual(error_dual_abs_l2, solver.config[w].dual_tolerance * 4.0)
         test.assertLessEqual(error_dual_abs_inf, solver.config[w].dual_tolerance * 4.0)
+
+
+def solve_apadmm_bilateral_reference(
+    D: np.ndarray,
+    v_f: np.ndarray,
+    P: np.ndarray,
+    config: PADMMSolver.Config,
+) -> dict[str, Any]:
+    """Solve a bilateral APADMM problem with a NumPy iteration reference.
+
+    This mirrors the accelerated PADMM state transitions for one dense,
+    preconditioned bilateral problem. The bilateral feasible set is all of
+    :math:`R^n`, so the production solver's projection is the identity:
+    ``y = x - z_hat / rho``. It consequently does not model unilateral limit
+    or contact projection, De Saxce corrections, or complementarity residuals.
+
+    The reference also omits production features that are irrelevant to this
+    fixed-iteration regression: multiple worlds, sparse/iterative linear
+    solves, adaptive penalty updates, and convergence-based early termination.
+    It instead solves the fixed dense system with NumPy and executes exactly
+    ``max_iterations`` iterations, recording the state-derived quantities
+    exposed through ``PADMMInfo`` for comparison.
+    """
+    dtype = D.dtype
+    eta = dtype.type(config.eta)
+    rho = dtype.type(config.rho_0)
+    restart_tolerance = dtype.type(config.restart_tolerance)
+    a_0 = dtype.type(config.a_0)
+    lhs = D + (eta + rho) * np.eye(D.shape[0], dtype=dtype)
+
+    x = np.zeros_like(v_f)
+    y = np.zeros_like(v_f)
+    z = np.zeros_like(v_f)
+    x_p = np.zeros_like(v_f)
+    y_p = np.zeros_like(v_f)
+    z_p = np.zeros_like(v_f)
+    y_hat = np.zeros_like(v_f)
+    z_hat = np.zeros_like(v_f)
+    a_p = a_0
+    r_a_p = dtype.type(np.finfo(dtype).max)
+    restart = 0
+    num_restarts = 0
+    history = {
+        "a": [],
+        "norm_x": [],
+        "norm_y": [],
+        "norm_z": [],
+        "r_dx": [],
+        "r_dy": [],
+        "r_dz": [],
+        "r_comb": [],
+        "r_comb_ratio": [],
+        "num_restarts": [],
+    }
+
+    for _ in range(config.max_iterations):
+        x_candidate = np.linalg.solve(lhs, -v_f + eta * x_p + rho * y_hat + z_hat)
+        y_candidate = x_candidate - z_hat / rho
+        z_candidate = z_hat + rho * (y_candidate - x_candidate)
+
+        dx = P * (x_candidate - x_p)
+        dy = P * (y_candidate - y_hat)
+        dz = (z_candidate - z_hat) / P
+        r_a = rho * np.dot(dy, dy) + np.dot(dz, dz) / rho
+
+        if r_a < restart_tolerance * r_a_p:
+            restart = 0
+            a = dtype.type((1.0 + np.sqrt(1.0 + 4.0 * a_p * a_p)) / 2.0)
+            factor = dtype.type((a_p - 1.0) / a)
+            x = x_candidate
+            y = y_candidate
+            z = z_candidate
+            y_hat = y + factor * (y - y_p)
+            z_hat = z + factor * (z - z_p)
+            x_p = x.copy()
+            y_p = y.copy()
+            z_p = z.copy()
+        else:
+            # A restart drops the momentum but keeps the current iterate.
+            restart = 1
+            num_restarts += 1
+            r_a = r_a_p / restart_tolerance
+            a = a_0
+            y_hat = y_p.copy()
+            z_hat = z_p.copy()
+            x = x_candidate
+            y = y_candidate
+            z = z_candidate
+            x_p = x.copy()
+            y_p = y.copy()
+            z_p = z.copy()
+
+        a_p = a
+        r_a_pp = r_a_p
+        r_a_p = dtype.type(r_a)
+
+        history["a"].append(a)
+        history["norm_x"].append(np.linalg.norm(x))
+        history["norm_y"].append(np.linalg.norm(y))
+        history["norm_z"].append(np.linalg.norm(z))
+        history["r_dx"].append(np.linalg.norm(dx))
+        history["r_dy"].append(np.linalg.norm(dy))
+        history["r_dz"].append(np.linalg.norm(dz))
+        history["r_comb"].append(r_a)
+        history["r_comb_ratio"].append(r_a / r_a_pp)
+        history["num_restarts"].append(num_restarts)
+
+    return {
+        "x": x,
+        "y": y,
+        "z": z,
+        "x_p": x_p,
+        "y_p": y_p,
+        "z_p": z_p,
+        "y_hat": y_hat,
+        "z_hat": z_hat,
+        "restart": restart,
+        "num_restarts": num_restarts,
+        "history": {key: np.asarray(values, dtype=dtype) for key, values in history.items()},
+    }
 
 
 def save_solver_info(solver: PADMMSolver, path: str | None = None, verbose: bool = False):
@@ -687,6 +809,181 @@ class TestPADMMSolver(unittest.TestCase):
 
         # Check solution
         check_padmm_solution(self, test.model, test.problem, solver, verbose=self.verbose)
+
+    def test_09_apadmm_restart_matches_bilateral_reference(self):
+        """Match a NumPy reference across an APADMM solve whose final iteration restarts.
+
+        The restart tolerance is tight enough to reject every step, so this pins the
+        combined-residual formula, the restart bookkeeping, and the rule that a restart
+        rewinds only the extrapolation while keeping the current iterate.
+        """
+        test = TestSetup(
+            builder_fn=basics.build_box_pendulum,
+            max_world_contacts=1,
+            device=self.default_device,
+            ground=False,
+        )
+        config = PADMMSolver.Config(
+            primal_tolerance=0.0,
+            dual_tolerance=0.0,
+            compl_tolerance=0.0,
+            restart_tolerance=1.0e-6,
+            max_iterations=6,
+        )
+
+        test.build()
+        D = extract_delassus(test.problem.delassus, only_active_dims=True)[0]
+        v_f = extract_problem_vector(
+            test.problem.delassus,
+            test.problem.data.v_f.numpy(),
+            only_active_dims=True,
+        )[0]
+        P = extract_problem_vector(
+            test.problem.delassus,
+            test.problem.data.P.numpy(),
+            only_active_dims=True,
+        )[0]
+        reference = solve_apadmm_bilateral_reference(D, v_f, P, config)
+
+        solver = PADMMSolver(
+            model=test.model,
+            config=config,
+            warmstart=PADMMWarmStartMode.NONE,
+            use_acceleration=True,
+            use_graph_conditionals=False,
+            collect_info=True,
+        )
+        solver.coldstart()
+        solver.solve(problem=test.problem)
+
+        status = solver.data.status.numpy()[0]
+        self.assertEqual(int(status[11]), reference["restart"])
+        self.assertEqual(int(status[12]), reference["num_restarts"])
+
+        # The tight restart tolerance makes the solve alternate between accepted and
+        # restarted steps, so both writeback branches run and the run ends on a restart.
+        self.assertEqual(reference["restart"], 1)
+        self.assertEqual(reference["num_restarts"], 3)
+
+        iterations = int(status[1])
+        reference_history = reference["history"]
+        solver_history = {
+            "a": solver.data.info.a.numpy()[:iterations],
+            "norm_x": solver.data.info.norm_x.numpy()[:iterations],
+            "norm_y": solver.data.info.norm_y.numpy()[:iterations],
+            "norm_z": solver.data.info.norm_z.numpy()[:iterations],
+            "r_dx": solver.data.info.r_dx.numpy()[:iterations],
+            "r_dy": solver.data.info.r_dy.numpy()[:iterations],
+            "r_dz": solver.data.info.r_dz.numpy()[:iterations],
+            "r_comb": solver.data.info.r_comb.numpy()[:iterations],
+            "r_comb_ratio": solver.data.info.r_comb_ratio.numpy()[:iterations],
+            "num_restarts": solver.data.info.num_restarts.numpy()[:iterations],
+        }
+        for name, values in solver_history.items():
+            np.testing.assert_allclose(values, reference_history[name], rtol=1e-5, atol=1e-6, err_msg=name)
+
+        ncts = D.shape[0]
+        np.testing.assert_allclose(solver.data.state.x_p.numpy()[:ncts], reference["x_p"], rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(solver.data.state.y_p.numpy()[:ncts], reference["y_p"], rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(solver.data.state.z_p.numpy()[:ncts], reference["z_p"], rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(solver.data.state.y_hat.numpy()[:ncts], reference["y_hat"], rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(solver.data.state.z_hat.numpy()[:ncts], reference["z_hat"], rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(
+            solver.data.solution.lambdas.numpy()[:ncts],
+            P * reference["y"],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        np.testing.assert_allclose(
+            solver.data.solution.v_plus.numpy()[:ncts],
+            reference["z"] / P,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    def test_10_apadmm_converged_iteration_does_not_restart(self):
+        """Suppress the acceleration restart on the iteration that converges.
+
+        The restart tolerance is tight enough that every iteration past the first fails the
+        combined-residual test, while the convergence tolerances are loose enough that the
+        solve converges on that same iteration. The restart must then be suppressed, so that
+        a solve reported as converged never also reports a restart it never acted on.
+        """
+        test = TestSetup(
+            builder_fn=basics.build_box_pendulum,
+            max_world_contacts=1,
+            device=self.default_device,
+            ground=False,
+        )
+        config = PADMMSolver.Config(
+            primal_tolerance=1.0e3,
+            dual_tolerance=1.0e3,
+            compl_tolerance=1.0e3,
+            restart_tolerance=1.0e-6,
+            max_iterations=8,
+        )
+
+        test.build()
+        solver = PADMMSolver(
+            model=test.model,
+            config=config,
+            warmstart=PADMMWarmStartMode.NONE,
+            use_acceleration=True,
+            use_graph_conditionals=False,
+        )
+        solver.coldstart()
+        solver.solve(problem=test.problem)
+
+        status = solver.data.status.numpy()[0]
+        self.assertEqual(int(status[0]), 1)
+        # Convergence is gated on having completed more than one iteration.
+        self.assertEqual(int(status[1]), 2)
+        self.assertEqual(int(status[11]), 0)
+        self.assertEqual(int(status[12]), 0)
+
+    def test_11_apadmm_honors_per_world_iteration_budgets(self):
+        """Give each world exactly its own iteration budget when the budgets differ.
+
+        A world that exhausts its budget must stop advancing rather than keep stepping on
+        the shared loop, and must release the shared completion counter only once, so that
+        a world with a larger budget is not terminated early alongside it.
+        """
+        budgets = [3, 8]
+        modes = [False, True] if self.default_device.is_cuda else [False]
+
+        for use_graph_conditionals in modes:
+            with self.subTest(use_graph_conditionals=use_graph_conditionals):
+                test = TestSetup(
+                    builder_fn=make_homogeneous_builder,
+                    max_world_contacts=1,
+                    device=self.default_device,
+                    num_worlds=len(budgets),
+                    build_fn=basics.build_box_pendulum,
+                    ground=False,
+                )
+                configs = [
+                    PADMMSolver.Config(
+                        primal_tolerance=0.0,
+                        dual_tolerance=0.0,
+                        compl_tolerance=0.0,
+                        max_iterations=budget,
+                    )
+                    for budget in budgets
+                ]
+
+                test.build()
+                solver = PADMMSolver(
+                    model=test.model,
+                    config=configs,
+                    warmstart=PADMMWarmStartMode.NONE,
+                    use_acceleration=True,
+                    use_graph_conditionals=use_graph_conditionals,
+                )
+                solver.coldstart()
+                solver.solve(problem=test.problem)
+
+                status = solver.data.status.numpy()
+                self.assertEqual([int(status[w][1]) for w in range(len(budgets))], budgets)
 
 
 ###


### PR DESCRIPTION
Closes disneyresearch/newton#419.

## Description

Fixes three defects in the Nesterov acceleration of the Kamino PADMM solver.
Only the first one affects solver performance in practice though. The other 2 are rather corner cases.

**The combined restart residual used the wrong power.** `status.r_a` summed the
primal and dual L2 *norms* where the Fast ADMM restart criterion it implements
(Goldstein et al., Eq. 30) calls for squared norms, and it read them back from
the already-square-rooted `status.r_dy` / `status.r_dz`. It now reads the
squared sums directly. Because `r_a` drives the restart decision, this changes
convergence: on `box_on_plane` the accelerated solve goes from 57 to 43
iterations against 52 unaccelerated, so acceleration turns from a net
loss into a net win on that fixture. `box_pendulum` and `boxes_hinged`
are unchanged.

**A converged iteration could also report a restart.** The writeback already
skips the extrapolation update once a world converges, so the restart was
counted but never acted on, inflating the reported `num_restarts`. It is now
suppressed.

**The kernel early-out only froze converged worlds.** A world that exhausted
its `max_iterations` kept stepping and kept decrementing the shared completion
counter. With per-world budgets of `[3, 8]` the plain path ran `[8, 8]`, and
the graph-conditional path ran `[4, 4]` — the over-decrementing drove the
counter to zero early and cut the larger-budget world off at half its
requested iterations. This path is reachable through the per-world config list
on `PADMMSolver`; `SolverKamino` currently passes a single config for all
worlds.

Alongside these, the writeback control code is now two named `wp.constant` bit
flags unpacked into booleans, replacing the raw `control < 2` / `control == 0`
comparisons. The branch bodies are untouched, so that hunk is a rename only.

The module docstring attribution moves from O'Donoghue and Candes to Goldstein
et al., matching reference [4] and the Algorithm 8 restart rule actually
implemented, and the `PADMMStatus.r_a` docstring is updated to the squared
form.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

The Kamino tests are part of the internal Kamino suite and are not
discoverable through `newton.tests`:

```
uv run --extra dev python -m newton._src.solvers.kamino.tests.test_solvers_padmm
uv run --extra dev python -m newton._src.solvers.kamino.tests.test_solver_kamino
uv run --extra dev python -m newton._src.solvers.kamino.tests.test_solvers_dvi
uv run --extra dev python -m newton._src.solvers.kamino.tests.test_solvers_metrics
```

All pass (12 + 18 + 51 + 9). Three new tests, backed by a NumPy reference
(`solve_apadmm_bilateral_reference`) that mirrors the accelerated state
transitions for a dense bilateral problem:

- `test_09_apadmm_restart_matches_bilateral_reference` matches the full solver
  history and terminal state against the reference over six iterations that
  alternate accepted and restarted steps, pinning the residual formula, the
  restart bookkeeping, and the rule that a restart rewinds only the
  extrapolation while keeping the current iterate.
- `test_10_apadmm_converged_iteration_does_not_restart`
- `test_11_apadmm_honors_per_world_iteration_budgets`, over both
  graph-conditional modes.

Each fix was verified by reverting it individually and confirming its test
fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accelerated solver restart and convergence handling.
  * Prevented additional processing for completed or iteration-limited calculations.
  * Ensured restarted calculations correctly resume from their previous state.
  * Corrected combined residual documentation.

* **Tests**
  * Added regression coverage for restart behavior, convergence handling, residual tracking, and independent iteration limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->