### PR TITLE
Apply hide_collision_shapes to approximated colliders

### DIFF
--- a/changelog/+hide-collision-approx-3b8e5c2a.fixed.md
+++ b/changelog/+hide-collision-approx-3b8e5c2a.fixed.md
@@ -1,0 +1,1 @@
+Fix `hide_collision_shapes=True` in `ModelBuilder.add_usd()` not hiding viewport-drawn colliders that carry `physics:approximation`. Approximating such a collider splits its authored topology off as a separate visual shape, and that copy was produced regardless of the flag, so it stayed drawn and could not be hidden by the viewer's "Show Collision" toggle either.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3516,6 +3516,11 @@ def parse_usd(
                 # geometry, and an empty viewport is the honest result of that. Reach for
                 # ``force_show_colliders`` to inspect such a scene.
                 collider_is_visible = (force_show_colliders or _is_viewport_drawn(prim)) and not hide_collider_for_body
+                # Approximating a viewport-drawn collider splits off its authored topology
+                # as a visual shape (see the approximation pass below). That copy is subject
+                # to ``hide_collision_shapes`` as well, so that the flag does not turn into a
+                # no-op for exactly those colliders that carry ``physics:approximation``.
+                splits_off_visual_copy = load_visual_shapes and _is_viewport_drawn(prim) and not hide_collider_for_body
 
                 # Contact response precedence:
                 #   per-shape mjc:solref (non-legacy) > material > legacy per-shape > default
@@ -3826,10 +3831,8 @@ def parse_usd(
                     # Resolve mesh hull vertex limit from schema with fallback to parameter
                     # The mesh needs its render material when anything will draw it: either
                     # the collider itself is visible, or it is viewport geometry whose
-                    # authored topology is about to be split off as a visual shape. The
-                    # latter is not covered by collider_is_visible, which hide_collision_shapes
-                    # can clear while the visual copy is still produced.
-                    if collider_is_visible or (load_visual_shapes and _is_viewport_drawn(prim)):
+                    # authored topology is about to be split off as a visual shape.
+                    if collider_is_visible or splits_off_visual_copy:
                         # Drawn colliders should render with the same visual material metadata
                         # as visual-only mesh imports.
                         mesh = _get_mesh_with_visual_material(prim, path_name=path)
@@ -3890,7 +3893,7 @@ def parse_usd(
                                     if remeshing_method not in remeshing_queue:
                                         remeshing_queue[remeshing_method] = []
                                     remeshing_queue[remeshing_method].append(shape_id)
-                                    if _is_viewport_drawn(prim):
+                                    if splits_off_visual_copy:
                                         approximated_viewport_shapes.add(shape_id)
 
                 elif key == UsdPhysics.ObjectType.PlaneShape:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12239,7 +12239,7 @@ def Xform "Body" (
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_suppresses_approximated_visual_copy(self):
-        """hide_collision_shapes=True also suppresses the visual split off by approximation.
+        """Verify hide_collision_shapes=True also suppresses the visual split off by approximation.
 
         Approximating a viewport-drawn collider preserves its authored topology as a
         separate visual shape. That copy carries VISIBLE without COLLIDE_SHAPES, so the
@@ -12264,8 +12264,10 @@ def Xform "Body" (
         self.assertTrue(flags & ShapeFlags.COLLIDE_SHAPES)
         self.assertFalse(flags & ShapeFlags.VISIBLE)
 
-        # The visual sphere is the only thing left drawn: the collider contributed no
-        # split-off copy, matching the same asset without ``physics:approximation``.
+        # The copy must not be produced at all, not merely produced and hidden: only the
+        # visual sphere and the collider itself remain, matching the same asset without
+        # ``physics:approximation``.
+        self.assertEqual(builder.shape_count, 2)
         drawn = [s for s in range(builder.shape_count) if builder.shape_flags[s] & ShapeFlags.VISIBLE]
         self.assertEqual(drawn, [path_shape_map["/Body/VisualSphere"]])
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12238,6 +12238,38 @@ def Xform "Body" (
         self.assertFalse(flags & ShapeFlags.VISIBLE)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_hide_collision_shapes_suppresses_approximated_visual_copy(self):
+        """hide_collision_shapes=True also suppresses the visual split off by approximation.
+
+        Approximating a viewport-drawn collider preserves its authored topology as a
+        separate visual shape. That copy carries VISIBLE without COLLIDE_SHAPES, so the
+        viewer's collision toggle cannot reach it. ``hide_collision_shapes`` must
+        suppress it too, otherwise the flag silently does nothing for exactly those
+        colliders that carry ``physics:approximation``.
+        """
+        from pxr import UsdPhysics
+
+        stage = self._create_stage_with_pbr_collision_mesh(
+            color=(0.9, 0.1, 0.2), roughness=0.55, metallic=0.25, add_visual_sphere=True
+        )
+        collision_prim = stage.GetPrimAtPath("/Body/CollisionMesh")
+        UsdPhysics.MeshCollisionAPI.Apply(collision_prim).GetApproximationAttr().Set("convexHull")
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage, hide_collision_shapes=True)
+        path_shape_map = result["path_shape_map"]
+
+        collision_shape = path_shape_map["/Body/CollisionMesh"]
+        flags = builder.shape_flags[collision_shape]
+        self.assertTrue(flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags & ShapeFlags.VISIBLE)
+
+        # The visual sphere is the only thing left drawn: the collider contributed no
+        # split-off copy, matching the same asset without ``physics:approximation``.
+        drawn = [s for s in range(builder.shape_count) if builder.shape_flags[s] & ShapeFlags.VISIBLE]
+        self.assertEqual(drawn, [path_shape_map["/Body/VisualSphere"]])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_fallback_with_material(self):
         """Colliders with material stay visible when the body has no other visual shapes."""
         stage = self._create_stage_with_pbr_collision_mesh(


### PR DESCRIPTION
## Description

`hide_collision_shapes=True` had no effect on a viewport-drawn collider that carries
`physics:approximation`.

Approximating such a collider splits it in two — an approximated collider plus a visual
shape carrying the authored topology — so that a collision-scoped attribute does not
change what is drawn. That split was decided by `_is_viewport_drawn()` alone, so
`hide_collision_shapes` never reached it: the collider lost `VISIBLE` as asked, but the
visual copy was still produced and stayed on screen. Because the copy carries `VISIBLE`
without `COLLIDE_SHAPES`, the viewer's "Show Collision" toggle could not hide it either,
leaving no way to turn the geometry off.

So the same flag, on the same authored intent, worked or silently did nothing depending
on whether the prim happened to carry `physics:approximation`:

| collider prim (`purpose` composing to `default`) | `hide_collision_shapes=False` | `hide_collision_shapes=True` |
| --- | --- | --- |
| no `physics:approximation` | 2 shapes drawn | 1 shape drawn |
| `physics:approximation="convexHull"` | 2 shapes drawn | 2 shapes drawn |

This hoists the condition into `splits_off_visual_copy`, next to the existing
`collider_is_visible`, and gates both the split and the render-material load on it.

### This does not widen what the flag may override

The row above that already worked is a `default`-purpose collider — the strongest "draw
me" USD has. `hide_collision_shapes` has always overridden USD purpose on request; that
is what the flag is for, and `test_hide_collision_shapes_overrides_visual_material`
covers it. This PR does not extend that policy to anything new. It removes an exception
to it, so that a collision-scoped attribute stops deciding whether a visibility flag
applies.

Worth being explicit about the one judgement call here: the split-off copy is *render*
geometry rather than a collider, so suppressing it under a flag named
`hide_collision_shapes` is arguably a category stretch. The copy only exists because the
prim is a collider — no `PhysicsCollisionAPI`, no split, no copy — so it is
collider-derived geometry and the flag should reach it. Happy to be argued out of this.

### What is unchanged

Default behavior. A viewport-drawn collider is still drawn with
`hide_collision_shapes=False`, including `purpose="proxy"` colliders, which USD viewports
draw alongside `default`. `test_approximated_viewport_collider_keeps_its_render_mesh`
still covers the split.

`force_show_colliders` is deliberately *not* folded into the new condition. A collider on
screen because the display policy put it there should show the collider, not the authored
mesh — matching the existing comment on the approximation pass.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

New regression test, verified to fail without the source change (`AssertionError: 3 != 2`
— the split-off copy is built) and pass with it:

```
uv run --extra dev -m unittest newton.tests.test_import_usd -k test_hide_collision_shapes_suppresses_approximated_visual_copy
```

It asserts the shape count, so an implementation that still built the copy and merely hid
it would fail.

Full suite for the touched importer plus neighboring import/USD modules, all passing:

```
uv run --extra dev -m unittest newton.tests.test_import_usd            # 308 tests
uv run --extra dev -m unittest newton.tests.test_import_mjcf           # 263 tests
uv run --extra dev -m unittest newton.tests.test_import_urdf           # 63 tests
uv run --extra dev -m unittest newton.tests.test_import_usd_multi_dof
uv run --extra dev -m unittest newton.tests.test_usd_mesh_loading
uv run --extra dev -m unittest newton.tests.test_viewer_usd
uv run --extra dev -m unittest newton.tests.test_sdf_usd
uv run --extra dev -m unittest newton.tests.test_sites_usd_import
```

### Found on a real asset

An Isaac prop (`Isaac/Props/Mounts/SeattleLabTable/table.usd`) whose collision geometry is
authored under a `/Collisions` scope with `purpose="proxy"`. It imports as:

| idx | flags | geo type | color | prim |
| --- | --- | --- | --- | --- |
| 0, 1 | `VISIBLE` | MESH | white | `/DemoTable/Visuals/TableGeom` (+ subset) |
| 2 | `COLLIDE_SHAPES` | CONVEX_MESH | (34, 136, 51) | `/DemoTable/Collisions/Cube` |
| 3 | `VISIBLE` | MESH | (34, 136, 51) | *split-off copy, absent from `path_shape_map`* |

Shape 3 renders as a bright green box (the default palette color, since the collision prim
has no bound render material) sitting inside the white table. With
`--hide-collision-shapes` it stayed drawn before this PR and is gone after, while the
default view is identical either way.

## Bug fix

**Steps to reproduce:**

1. Import a USD whose collider is viewport-drawn (`purpose` resolving to `default` or
   `proxy`) and carries `physics:approximation`, on a body that also has visual-only
   geometry.
2. Pass `hide_collision_shapes=True`.
3. Observe the collider geometry is still drawn, and that neither "Show Collision" nor
   `hide_collision_shapes` can hide it.

**Minimal reproduction:**

```python
from pxr import Usd, UsdGeom, UsdPhysics

import newton

stage = Usd.Stage.CreateInMemory()
UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
body = UsdGeom.Xform.Define(stage, "/Body")
UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())

# visual-only geometry, so the body qualifies for hide_collision_shapes
UsdGeom.Sphere.Define(stage, "/Body/VisualSphere").CreateRadiusAttr().Set(0.1)

mesh = UsdGeom.Mesh.Define(stage, "/Body/CollisionMesh")
mesh.CreatePointsAttr().Set([(-0.5, 0, 0), (0.5, 0, 0), (0, 0.5, 0), (0, 0, 0.5)])
mesh.CreateFaceVertexCountsAttr().Set([3, 3, 3, 3])
mesh.CreateFaceVertexIndicesAttr().Set([0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3])
UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
# purpose left unauthored, so it composes to "default" and is viewport-drawn
UsdPhysics.MeshCollisionAPI.Apply(mesh.GetPrim()).GetApproximationAttr().Set("convexHull")

builder = newton.ModelBuilder()
builder.add_usd(stage, hide_collision_shapes=True)
model = builder.finalize()

drawn = sum(1 for f in model.shape_flags.numpy() if f & int(newton.ShapeFlags.VISIBLE))
print(drawn)  # 2 before this PR, 1 after -- only the visual sphere
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD imports so enabling “hide collision shapes” also hides viewport-drawn approximated colliders and their generated visual copies.
  * Prevented hidden collision geometry from appearing as visual output.

* **Tests**
  * Added regression coverage to verify that hidden approximated colliders are excluded while independent visual geometry remains visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->