### PR TITLE
Improve AWS runner attribution and watchdog coverage

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -34,6 +34,10 @@ on:
         required: false
         type: string
         default: ''
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: true
+        type: string
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
@@ -95,7 +99,11 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "created-by", "Value": "github-actions-newton-role"},
-              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"},
+              {"Key": "Newton-Trigger", "Value": ${{ toJSON(inputs['trigger-category']) }}},
+              {"Key": "Newton-Workload", "Value": "gpu-benchmarks"},
+              {"Key": "GitHub-Run-ID", "Value": "${{ github.run_id }}"},
+              {"Key": "GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"}
             ]
 
   gpu-benchmarks:

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -66,7 +66,10 @@ on:
       trigger-category:
         description: 'Normalized workflow trigger category'
         required: false
-        type: string
+        type: choice
+        options:
+          - manual
+          - scheduled-nightly
         default: 'manual'
 
 jobs:

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -42,6 +42,10 @@ on:
         required: false
         type: string
         default: ''
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: true
+        type: string
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
@@ -59,6 +63,11 @@ on:
         required: false
         type: string
         default: ''
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: false
+        type: string
+        default: 'manual'
 
 jobs:
   start-runner:
@@ -117,7 +126,11 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "created-by", "Value": "github-actions-newton-role"},
-              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"},
+              {"Key": "Newton-Trigger", "Value": ${{ toJSON(inputs['trigger-category']) }}},
+              {"Key": "Newton-Workload", "Value": "gpu-unit-tests"},
+              {"Key": "GitHub-Run-ID", "Value": "${{ github.run_id }}"},
+              {"Key": "GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"}
             ]
 
   gpu-unit-tests:

--- a/.github/workflows/merge_queue_aws_gpu.yml
+++ b/.github/workflows/merge_queue_aws_gpu.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/aws_gpu_tests.yml
     with:
       ref: ${{ github.sha }}
+      trigger-category: merge-queue
     secrets: inherit
     permissions:
       id-token: write   # Required for AWS OIDC authentication in start-runner/stop-runner

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -32,7 +32,10 @@ on:
       trigger-category:
         description: 'Normalized workflow trigger category'
         required: false
-        type: string
+        type: choice
+        options:
+          - manual
+          - scheduled-nightly
         default: 'manual'
 
 jobs:

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -17,12 +17,23 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: true
+        type: string
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
       CODECOV_TOKEN:
         required: true
   workflow_dispatch:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: false
+        type: string
+        default: 'manual'
 
 jobs:
   start-runner:
@@ -81,7 +92,11 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "created-by", "Value": "github-actions-newton-role"},
-              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"},
+              {"Key": "Newton-Trigger", "Value": ${{ toJSON(inputs['trigger-category']) }}},
+              {"Key": "Newton-Workload", "Value": "minimum-deps-tests"},
+              {"Key": "GitHub-Run-ID", "Value": "${{ github.run_id }}"},
+              {"Key": "GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"}
             ]
 
   minimum-deps-tests:

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -31,7 +31,10 @@ on:
       trigger-category:
         description: 'Normalized workflow trigger category'
         required: false
-        type: string
+        type: choice
+        options:
+          - manual
+          - scheduled-nightly
         default: 'manual'
 
 jobs:

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -16,12 +16,23 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: true
+        type: string
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
       CODECOV_TOKEN:
         required: true
   workflow_dispatch:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: false
+        type: string
+        default: 'manual'
 
 jobs:
   start-runner:
@@ -80,7 +91,11 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "created-by", "Value": "github-actions-newton-role"},
-              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"},
+              {"Key": "Newton-Trigger", "Value": ${{ toJSON(inputs['trigger-category']) }}},
+              {"Key": "Newton-Workload", "Value": "mujoco-warp-tests"},
+              {"Key": "GitHub-Run-ID", "Value": "${{ github.run_id }}"},
+              {"Key": "GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"}
             ]
 
   mujoco-warp-tests:

--- a/.github/workflows/pr_target_aws_gpu_benchmarks.yml
+++ b/.github/workflows/pr_target_aws_gpu_benchmarks.yml
@@ -111,6 +111,7 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.event.pull_request.base.sha }}
+      trigger-category: pull-request
     secrets: inherit
     permissions:
       id-token: write   # Required for AWS OIDC authentication in start-runner/stop-runner

--- a/.github/workflows/pr_target_aws_gpu_tests.yml
+++ b/.github/workflows/pr_target_aws_gpu_tests.yml
@@ -110,6 +110,7 @@ jobs:
     uses: ./.github/workflows/aws_gpu_tests.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+      trigger-category: pull-request
     secrets: inherit
     permissions:
       id-token: write   # Required for AWS OIDC authentication in start-runner/stop-runner

--- a/.github/workflows/push_aws_gpu.yml
+++ b/.github/workflows/push_aws_gpu.yml
@@ -15,6 +15,8 @@ jobs:
   run-tests:
     if: github.repository == 'newton-physics/newton'
     uses: ./.github/workflows/aws_gpu_tests.yml
+    with:
+      trigger-category: push
     secrets: inherit
     permissions:
       id-token: write   # Required for AWS OIDC authentication in start-runner/stop-runner

--- a/.github/workflows/scheduled_nightly.yml
+++ b/.github/workflows/scheduled_nightly.yml
@@ -90,16 +90,16 @@ jobs:
 
       - name: Dispatch and wait for GPU tests
         id: gpu-tests
-        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py aws_gpu_tests.yml -f "inputs[instance-type]=g7e.12xlarge"
+        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py aws_gpu_tests.yml -f "inputs[instance-type]=g7e.12xlarge" -f "inputs[trigger-category]=scheduled-nightly"
 
       - name: Dispatch and wait for Minimum Deps tests
         id: minimum-deps-tests
-        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py minimum_deps_tests.yml
+        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py minimum_deps_tests.yml -f "inputs[trigger-category]=scheduled-nightly"
 
       - name: Dispatch and wait for Warp Nightly tests
         id: warp-nightly-tests
         if: needs.check-warp-update.result == 'success' && needs.check-warp-update.outputs.warp-updated == 'true'
-        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py warp_nightly_tests.yml
+        run: uv run --no-project scripts/ci/dispatch_workflow_and_wait.py warp_nightly_tests.yml -f "inputs[trigger-category]=scheduled-nightly"
 
   notify-on-failure:
     name: Notify on failure

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -16,12 +16,23 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: true
+        type: string
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
       CODECOV_TOKEN:
         required: true
   workflow_dispatch:
+    inputs:
+      trigger-category:
+        description: 'Normalized workflow trigger category'
+        required: false
+        type: string
+        default: 'manual'
 
 jobs:
   start-runner:
@@ -80,7 +91,11 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "created-by", "Value": "github-actions-newton-role"},
-              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"},
+              {"Key": "Newton-Trigger", "Value": ${{ toJSON(inputs['trigger-category']) }}},
+              {"Key": "Newton-Workload", "Value": "warp-nightly-tests"},
+              {"Key": "GitHub-Run-ID", "Value": "${{ github.run_id }}"},
+              {"Key": "GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"}
             ]
 
   warp-nightly-tests:

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -31,7 +31,10 @@ on:
       trigger-category:
         description: 'Normalized workflow trigger category'
         required: false
-        type: string
+        type: choice
+        options:
+          - manual
+          - scheduled-nightly
         default: 'manual'
 
 jobs:

--- a/scripts/ci/aws/README.md
+++ b/scripts/ci/aws/README.md
@@ -1,0 +1,104 @@
+# AWS CI infrastructure
+
+This directory contains the source templates for AWS resources used by Newton
+CI. If the templates exist only in AWS, maintainers have to reconstruct the
+deployed configuration from console history during an incident. Checking them
+into Git gives us a reviewable change history and a known version to restore.
+
+That history is why these files belong in the repository. They are source files,
+not examples or generated output. The templates contain no credentials,
+secrets, private endpoints, or notification subscribers. They do not grant
+access to AWS, and commits to this directory do not deploy automatically.
+
+Put future AWS CI templates here too. This gives the small group that maintains
+the infrastructure one place to look and keeps AWS details out of the rest of
+the project.
+
+## Inventory
+
+| Template | Stack | Region | Required parameters |
+| --- | --- | --- | --- |
+| `overdue-newton-github-runner-watchdog.yaml` | `overdue-newton-github-runner-watchdog` | `us-east-1` | `AlertTopicArn` |
+
+The deployer must supply `AlertTopicArn` because the template has no default.
+This keeps notification routing and subscriber details outside the repository.
+
+## Validate and review a change
+
+Authenticate the AWS CLI, check that the selected profile points to the intended
+account, then validate the template:
+
+```bash
+NEWTON_AWS_PROFILE=isaac-sim-CS-Admin
+NEWTON_AWS_REGION=us-east-1
+NEWTON_WATCHDOG_STACK=overdue-newton-github-runner-watchdog
+NEWTON_CHANGE_SET=aws-runner-watchdog-update
+
+aws --profile "$NEWTON_AWS_PROFILE" sts get-caller-identity
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation validate-template \
+  --region "$NEWTON_AWS_REGION" \
+  --template-body file://scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
+```
+
+Before creating a change set, save the stack's current template and parameters
+outside the repository in case you need to roll back. Read the alert action on
+the deployed alarm and verify that it points to the intended SNS topic:
+
+```bash
+NEWTON_ALERT_TOPIC_ARN="$(
+  aws --profile "$NEWTON_AWS_PROFILE" cloudwatch describe-alarms \
+    --region "$NEWTON_AWS_REGION" \
+    --alarm-names overdue-newton-github-runner-watchdog \
+    --query 'MetricAlarms[0].AlarmActions[0]' \
+    --output text
+)"
+
+case "$NEWTON_ALERT_TOPIC_ARN" in
+  arn:aws:sns:us-east-1:*) ;;
+  *) echo "Unexpected alert topic ARN" >&2; exit 1 ;;
+esac
+
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation create-change-set \
+  --region "$NEWTON_AWS_REGION" \
+  --stack-name "$NEWTON_WATCHDOG_STACK" \
+  --change-set-name "$NEWTON_CHANGE_SET" \
+  --change-set-type UPDATE \
+  --template-body file://scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml \
+  --parameters "ParameterKey=AlertTopicArn,ParameterValue=$NEWTON_ALERT_TOPIC_ARN" \
+  --capabilities CAPABILITY_NAMED_IAM
+
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation wait change-set-create-complete \
+  --region "$NEWTON_AWS_REGION" \
+  --stack-name "$NEWTON_WATCHDOG_STACK" \
+  --change-set-name "$NEWTON_CHANGE_SET"
+
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation describe-change-set \
+  --region "$NEWTON_AWS_REGION" \
+  --stack-name "$NEWTON_WATCHDOG_STACK" \
+  --change-set-name "$NEWTON_CHANGE_SET"
+```
+
+Read the complete change set before executing it. This stack has a named IAM
+role, so the update requires `CAPABILITY_NAMED_IAM`. Pay close attention to IAM
+changes, and stop if the change set contains an unexpected replacement,
+deletion, resource, or permission change.
+
+Execute only after review:
+
+```bash
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation execute-change-set \
+  --region "$NEWTON_AWS_REGION" \
+  --stack-name "$NEWTON_WATCHDOG_STACK" \
+  --change-set-name "$NEWTON_CHANGE_SET"
+
+aws --profile "$NEWTON_AWS_PROFILE" cloudformation wait stack-update-complete \
+  --region "$NEWTON_AWS_REGION" \
+  --stack-name "$NEWTON_WATCHDOG_STACK"
+```
+
+After deployment, invoke the watchdog, confirm that it emits fresh metrics and
+logs, then check the alarm state. Investigate any stack drift before making
+another change. If verification fails, restore the saved template and parameters
+with a reviewed reverse change set. Do not update stack-managed resources
+directly because CloudFormation will no longer have an accurate record of their
+configuration.

--- a/scripts/ci/aws/README.md
+++ b/scripts/ci/aws/README.md
@@ -14,6 +14,14 @@ Put future AWS CI templates here too. This gives the small group that maintains
 the infrastructure one place to look and keeps AWS details out of the rest of
 the project.
 
+## Runner attribution tags
+
+The runner workflows apply repository, trigger, workload, and run identifiers
+as resource tags on EC2 instances and attached EBS volumes. These tags support
+resource-level attribution through the EC2 console and APIs. The AWS account
+used by Newton CI does not allow user-defined cost-allocation tags, so these
+keys cannot be activated as Cost Explorer or Cost and Usage Report dimensions.
+
 ## Inventory
 
 | Template | Stack | Region | Required parameters |

--- a/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
+++ b/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
@@ -1,0 +1,242 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Alert when tagged Newton GitHub runners remain active too long.
+
+Parameters:
+  AlertTopicArn:
+    Type: String
+    Description: Existing SNS topic ARN for watchdog alarm transitions.
+
+Resources:
+  WatchdogRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: overdue-newton-github-runner-watchdog-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: overdue-newton-github-runner-watchdog-read
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: DiscoverInstances
+                Effect: Allow
+                Action:
+                  - ec2:DescribeRegions
+                  - ec2:DescribeInstances
+                Resource: "*"
+              - Sid: PublishWatchdogMetrics
+                Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    cloudwatch:namespace: Newton/GitHubRunnerWatchdog
+      Tags:
+        - Key: Project
+          Value: Newton
+        - Key: Purpose
+          Value: RunnerCostGuard
+
+  WatchdogFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: overdue-newton-github-runner-watchdog
+      Description: Report tagged Newton runners active for at least 60 minutes.
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Role:
+        Fn::GetAtt:
+          - WatchdogRole
+          - Arn
+      Timeout: 60
+      MemorySize: 128
+      Environment:
+        Variables:
+          MAX_AGE_MINUTES: "60"
+      Code:
+        ZipFile: |
+          """Report overdue Newton GitHub runner instances across AWS regions."""
+
+          from __future__ import annotations
+
+          import json
+          import os
+          from datetime import datetime, timezone
+
+
+          CREATED_BY = "github-actions-newton-role"
+          METRIC_NAMESPACE = "Newton/GitHubRunnerWatchdog"
+
+
+          def find_overdue_instances(region_names, ec2_factory, now, max_age_minutes):
+              """Return matching running instances at least the maximum age."""
+              filters = [
+                  {"Name": "tag:created-by", "Values": [CREATED_BY]},
+                  {"Name": "instance-state-name", "Values": ["running"]},
+              ]
+              overdue = []
+
+              for region in region_names:
+                  try:
+                      paginator = ec2_factory(region).get_paginator("describe_instances")
+                      for page in paginator.paginate(Filters=filters):
+                          for reservation in page.get("Reservations", []):
+                              for instance in reservation.get("Instances", []):
+                                  launch_time = instance["LaunchTime"]
+                                  age_minutes = int((now - launch_time).total_seconds() // 60)
+                                  if age_minutes < max_age_minutes:
+                                      continue
+                                  tags = {tag["Key"]: tag["Value"] for tag in instance.get("Tags", [])}
+                                  overdue.append(
+                                      {
+                                          "instance_id": instance["InstanceId"],
+                                          "instance_type": instance["InstanceType"],
+                                          "region": region,
+                                          "launch_time": launch_time.isoformat(),
+                                          "age_minutes": age_minutes,
+                                          "repository": tags.get("GitHub-Repository", "unknown"),
+                                          "trigger": tags.get("Newton-Trigger", "unknown"),
+                                          "workload": tags.get("Newton-Workload", "unknown"),
+                                          "run_id": tags.get("GitHub-Run-ID", "unknown"),
+                                          "run_attempt": tags.get("GitHub-Run-Attempt", "unknown"),
+                                      }
+                                  )
+                  except Exception as error:
+                      raise RuntimeError(f"Failed to scan region {region}") from error
+
+              overdue.sort(key=lambda item: (-item["age_minutes"], item["region"], item["instance_id"]))
+              return overdue
+
+
+          def publish_metrics(cloudwatch, overdue_instances):
+              """Publish aggregate overdue-runner metrics."""
+              oldest_age = max(
+                  (instance["age_minutes"] for instance in overdue_instances),
+                  default=0,
+              )
+              cloudwatch.put_metric_data(
+                  Namespace=METRIC_NAMESPACE,
+                  MetricData=[
+                      {
+                          "MetricName": "OverdueRunnerCount",
+                          "Value": float(len(overdue_instances)),
+                          "Unit": "Count",
+                      },
+                      {
+                          "MetricName": "OldestRunnerAgeMinutes",
+                          "Value": float(oldest_age),
+                          "Unit": "Count",
+                      },
+                  ],
+              )
+
+
+          def lambda_handler(event, context):
+              """Scan enabled regions and publish global overdue-runner metrics."""
+              import boto3
+
+              home_region = os.environ.get("AWS_REGION", "us-east-1")
+              max_age_minutes = int(os.environ.get("MAX_AGE_MINUTES", "60"))
+              home_ec2 = boto3.client("ec2", region_name=home_region)
+              region_names = sorted(
+                  region["RegionName"]
+                  for region in home_ec2.describe_regions(AllRegions=False)["Regions"]
+              )
+              now = datetime.now(timezone.utc)
+              overdue = find_overdue_instances(
+                  region_names,
+                  lambda region: boto3.client("ec2", region_name=region),
+                  now,
+                  max_age_minutes,
+              )
+              publish_metrics(
+                  boto3.client("cloudwatch", region_name=home_region),
+                  overdue,
+              )
+
+              summary = {
+                  "scan_time": now.isoformat(),
+                  "scanned_region_count": len(region_names),
+                  "max_age_minutes": max_age_minutes,
+                  "overdue_count": len(overdue),
+                  "overdue_instances": overdue,
+              }
+              print(json.dumps(summary, sort_keys=True))
+              return summary
+      Tags:
+        - Key: Project
+          Value: Newton
+        - Key: Purpose
+          Value: RunnerCostGuard
+
+  WatchdogSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: overdue-newton-github-runner-watchdog-schedule
+      Description: Scan for overdue Newton GitHub runners every four hours.
+      ScheduleExpression: rate(4 hours)
+      State: ENABLED
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - WatchdogFunction
+              - Arn
+          Id: WatchdogLambda
+      Tags:
+        - Key: Project
+          Value: Newton
+        - Key: Purpose
+          Value: RunnerCostGuard
+
+  WatchdogInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: WatchdogFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt:
+          - WatchdogSchedule
+          - Arn
+
+  WatchdogAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: overdue-newton-github-runner-watchdog
+      AlarmDescription: A tagged Newton GitHub runner is at least 60 minutes old, or the watchdog has stopped reporting.
+      Namespace: Newton/GitHubRunnerWatchdog
+      MetricName: OverdueRunnerCount
+      Statistic: Maximum
+      Period: 21600
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - Ref: AlertTopicArn
+      OKActions:
+        - Ref: AlertTopicArn
+      Tags:
+        - Key: Project
+          Value: Newton
+        - Key: Purpose
+          Value: RunnerCostGuard
+
+Outputs:
+  FunctionName:
+    Value:
+      Ref: WatchdogFunction
+  AlarmName:
+    Value:
+      Ref: WatchdogAlarm

--- a/scripts/ci/tests/test_runner_workflow_contract.py
+++ b/scripts/ci/tests/test_runner_workflow_contract.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check runner attribution contracts using local workflow source.
+
+These tests catch missing tags and incorrect trigger-category wiring across
+duplicated workflow definitions and callers. They do not contact GitHub or
+AWS, launch an EC2 instance, or verify that AWS applies the requested tags.
+Those behaviors require a live smoke test.
+"""
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKLOADS = {
+    ".github/workflows/aws_gpu_tests.yml": "gpu-unit-tests",
+    ".github/workflows/aws_gpu_benchmarks.yml": "gpu-benchmarks",
+    ".github/workflows/minimum_deps_tests.yml": "minimum-deps-tests",
+    ".github/workflows/warp_nightly_tests.yml": "warp-nightly-tests",
+    ".github/workflows/mujoco_warp_tests.yml": "mujoco-warp-tests",
+}
+DIRECT_DISPATCH_WORKFLOWS = WORKLOADS.keys() - {".github/workflows/aws_gpu_benchmarks.yml"}
+REUSABLE_CALLERS = {
+    ".github/workflows/pr_target_aws_gpu_tests.yml": ("./.github/workflows/aws_gpu_tests.yml", "pull-request"),
+    ".github/workflows/pr_target_aws_gpu_benchmarks.yml": (
+        "./.github/workflows/aws_gpu_benchmarks.yml",
+        "pull-request",
+    ),
+    ".github/workflows/merge_queue_aws_gpu.yml": ("./.github/workflows/aws_gpu_tests.yml", "merge-queue"),
+    ".github/workflows/push_aws_gpu.yml": ("./.github/workflows/aws_gpu_tests.yml", "push"),
+}
+SCHEDULED_CALLERS = (
+    "aws_gpu_tests.yml",
+    "minimum_deps_tests.yml",
+    "warp_nightly_tests.yml",
+)
+
+
+class TestRunnerWorkflowContract(unittest.TestCase):
+    @staticmethod
+    def _event_block(workflow: str, event: str, next_marker: str) -> str:
+        start = workflow.index(f"  {event}:")
+        end = workflow.index(next_marker, start)
+        return workflow[start:end]
+
+    @staticmethod
+    def _input_block(event_block: str, name: str) -> str:
+        start = event_block.index(f"      {name}:\n")
+        lines = event_block[start:].splitlines(keepends=True)
+        block = [lines[0]]
+        for line in lines[1:]:
+            indentation = len(line) - len(line.lstrip())
+            if line.strip() and indentation <= 6:
+                break
+            block.append(line)
+        return "".join(block)
+
+    @staticmethod
+    def _resource_tag_block(workflow: str) -> str:
+        start = workflow.index("          aws-resource-tags: >\n")
+        end = workflow.index("\n            ]", start) + len("\n            ]")
+        return workflow[start:end]
+
+    @classmethod
+    def _parse_resource_tags(cls, workflow: str, trigger_category: str) -> list[dict[str, str]]:
+        tags = cls._resource_tag_block(workflow)
+        substitutions = {
+            "${{ github.repository }}": "newton-physics/newton",
+            "${{ toJSON(inputs['trigger-category']) }}": json.dumps(trigger_category),
+            "${{ github.run_id }}": "123456",
+            "${{ github.run_attempt }}": "2",
+        }
+        for expression, value in substitutions.items():
+            tags = tags.replace(expression, value)
+        return json.loads(tags[tags.index("[") :])
+
+    def test_leaf_workflows_define_attribution_contract(self):
+        """Require each runner workflow to supply its attribution metadata."""
+        for path, workload in WORKLOADS.items():
+            with self.subTest(path=path):
+                workflow = (ROOT / path).read_text(encoding="utf-8")
+                call_end = "  workflow_dispatch:" if path in DIRECT_DISPATCH_WORKFLOWS else "jobs:"
+                call = self._event_block(workflow, "workflow_call", call_end)
+                call_input = self._input_block(call, "trigger-category")
+                self.assertIn("        required: true\n", call_input)
+                self.assertIn("        type: string\n", call_input)
+
+                if path in DIRECT_DISPATCH_WORKFLOWS:
+                    dispatch = self._event_block(workflow, "workflow_dispatch", "\njobs:")
+                    dispatch_input = self._input_block(dispatch, "trigger-category")
+                    self.assertIn("        default: 'manual'\n", dispatch_input)
+
+                tags = self._resource_tag_block(workflow)
+                expected_tags = (
+                    '"created-by", "Value": "github-actions-newton-role"',
+                    '"GitHub-Repository", "Value": "${{ github.repository }}"',
+                    f'"Newton-Workload", "Value": "{workload}"',
+                    '"GitHub-Run-ID", "Value": "${{ github.run_id }}"',
+                    '"GitHub-Run-Attempt", "Value": "${{ github.run_attempt }}"',
+                )
+                for expected_tag in expected_tags:
+                    self.assertIn(expected_tag, tags)
+
+    def test_trigger_category_is_json_encoded(self):
+        """Preserve arbitrary trigger-category strings in resource tag JSON."""
+        trigger_category = 'manual "quoted"\ncategory'
+        for path in WORKLOADS:
+            with self.subTest(path=path):
+                workflow = (ROOT / path).read_text(encoding="utf-8")
+                tags = self._parse_resource_tags(workflow, trigger_category)
+                trigger_tag = next(tag for tag in tags if tag["Key"] == "Newton-Trigger")
+                self.assertEqual(trigger_tag["Value"], trigger_category)
+
+    def test_callers_pass_expected_trigger_categories(self):
+        """Map each runner caller to its normalized trigger category."""
+        for path, (called_workflow, trigger) in REUSABLE_CALLERS.items():
+            with self.subTest(path=path):
+                workflow = (ROOT / path).read_text(encoding="utf-8")
+                start = workflow.index(f"    uses: {called_workflow}\n")
+                end = workflow.index("    secrets:", start)
+                self.assertIn(f"      trigger-category: {trigger}\n", workflow[start:end])
+
+        scheduled = (ROOT / ".github/workflows/scheduled_nightly.yml").read_text(encoding="utf-8")
+        for called_workflow in SCHEDULED_CALLERS:
+            with self.subTest(path=".github/workflows/scheduled_nightly.yml", workflow=called_workflow):
+                dispatch = next(
+                    line
+                    for line in scheduled.splitlines()
+                    if f"dispatch_workflow_and_wait.py {called_workflow}" in line
+                )
+                self.assertIn('-f "inputs[trigger-category]=scheduled-nightly"', dispatch)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/tests/test_runner_workflow_contract.py
+++ b/scripts/ci/tests/test_runner_workflow_contract.py
@@ -90,6 +90,11 @@ class TestRunnerWorkflowContract(unittest.TestCase):
                 if path in DIRECT_DISPATCH_WORKFLOWS:
                     dispatch = self._event_block(workflow, "workflow_dispatch", "\njobs:")
                     dispatch_input = self._input_block(dispatch, "trigger-category")
+                    self.assertIn("        type: choice\n", dispatch_input)
+                    self.assertIn(
+                        "        options:\n          - manual\n          - scheduled-nightly\n",
+                        dispatch_input,
+                    )
                     self.assertIn("        default: 'manual'\n", dispatch_input)
 
                 tags = self._resource_tag_block(workflow)

--- a/scripts/ci/tests/test_watchdog_logic.py
+++ b/scripts/ci/tests/test_watchdog_logic.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the watchdog's instance-selection and attribution logic locally.
+
+These tests execute the Lambda source embedded in the CloudFormation template
+with a fake EC2 paginator. They catch repository-filter regressions and missing
+attribution-tag handling, but do not call AWS or validate CloudFormation, IAM,
+or boto3 behavior. Those behaviors require deployment and live smoke checks.
+"""
+
+import textwrap
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+TEMPLATE = ROOT / "scripts" / "ci" / "aws" / "overdue-newton-github-runner-watchdog.yaml"
+
+
+class FilteringPaginator:
+    def __init__(self, instances):
+        self.instances = instances
+
+    def paginate(self, Filters):
+        matching = self.instances
+        for item in Filters:
+            name = item["Name"]
+            values = item["Values"]
+            if name == "instance-state-name":
+                matching = [instance for instance in matching if instance["State"]["Name"] in values]
+            elif name.startswith("tag:"):
+                key = name.removeprefix("tag:")
+                matching = [
+                    instance
+                    for instance in matching
+                    if {tag["Key"]: tag["Value"] for tag in instance.get("Tags", [])}.get(key) in values
+                ]
+        yield {"Reservations": [{"Instances": matching}]}
+
+
+class FakeEc2:
+    def __init__(self, instances):
+        self.instances = instances
+
+    def get_paginator(self, operation):
+        if operation != "describe_instances":
+            raise AssertionError(f"Unexpected operation: {operation}")
+        return FilteringPaginator(self.instances)
+
+
+class TestWatchdogLogic(unittest.TestCase):
+    def _lambda_namespace(self) -> dict:
+        self.assertTrue(TEMPLATE.is_file(), f"Missing watchdog template: {TEMPLATE}")
+        template = TEMPLATE.read_text(encoding="utf-8")
+        marker = "        ZipFile: |\n"
+        self.assertIn(marker, template)
+        source_lines = []
+        for line in template[template.index(marker) + len(marker) :].splitlines(keepends=True):
+            if line.strip() and not line.startswith("          "):
+                break
+            source_lines.append(line)
+        source = textwrap.dedent("".join(source_lines))
+        namespace = {}
+        exec(compile(source, str(TEMPLATE), "exec"), namespace)
+        return namespace
+
+    @staticmethod
+    def _instance(now, *, repository=None, include_attribution=True):
+        tags = [{"Key": "created-by", "Value": "github-actions-newton-role"}]
+        if repository is not None:
+            tags.append({"Key": "GitHub-Repository", "Value": repository})
+        if include_attribution:
+            tags.extend(
+                [
+                    {"Key": "Newton-Trigger", "Value": "manual"},
+                    {"Key": "Newton-Workload", "Value": "gpu-unit-tests"},
+                    {"Key": "GitHub-Run-ID", "Value": "123456"},
+                    {"Key": "GitHub-Run-Attempt", "Value": "2"},
+                ]
+            )
+        return {
+            "InstanceId": "i-0123456789abcdef0",
+            "InstanceType": "g7e.2xlarge",
+            "LaunchTime": now - timedelta(minutes=90),
+            "State": {"Name": "running"},
+            "Tags": tags,
+        }
+
+    def test_watchdog_finds_owned_runners_from_any_repository(self):
+        """Report an overdue owned runner regardless of repository tag value."""
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        instance = self._instance(now, repository="example/newton")
+
+        overdue = namespace["find_overdue_instances"](
+            ["us-east-2"],
+            lambda region: FakeEc2([instance]),
+            now,
+            60,
+        )
+
+        self.assertEqual(
+            overdue,
+            [
+                {
+                    "instance_id": "i-0123456789abcdef0",
+                    "instance_type": "g7e.2xlarge",
+                    "region": "us-east-2",
+                    "launch_time": "2026-08-08T10:30:00+00:00",
+                    "age_minutes": 90,
+                    "repository": "example/newton",
+                    "trigger": "manual",
+                    "workload": "gpu-unit-tests",
+                    "run_id": "123456",
+                    "run_attempt": "2",
+                }
+            ],
+        )
+
+    def test_watchdog_tolerates_missing_attribution_tags(self):
+        """Report unknown metadata for runners created before attribution tags."""
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        instance = self._instance(now, include_attribution=False)
+
+        overdue = namespace["find_overdue_instances"](
+            ["us-west-2"],
+            lambda region: FakeEc2([instance]),
+            now,
+            60,
+        )
+
+        self.assertEqual(
+            {key: overdue[0][key] for key in ("repository", "trigger", "workload", "run_id", "run_attempt")},
+            {
+                "repository": "unknown",
+                "trigger": "unknown",
+                "workload": "unknown",
+                "run_id": "unknown",
+                "run_attempt": "unknown",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/tests/test_watchdog_logic.py
+++ b/scripts/ci/tests/test_watchdog_logic.py
@@ -118,6 +118,22 @@ class TestWatchdogLogic(unittest.TestCase):
             ],
         )
 
+    def test_watchdog_excludes_unowned_instances(self):
+        """Exclude overdue instances not owned by Newton."""
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        instance = self._instance(now)
+        instance["Tags"][0]["Value"] = "other-runner-role"
+
+        overdue = namespace["find_overdue_instances"](
+            ["us-east-2"],
+            lambda region: FakeEc2([instance]),
+            now,
+            60,
+        )
+
+        self.assertEqual(overdue, [])
+
     def test_watchdog_tolerates_missing_attribution_tags(self):
         """Report unknown metadata for runners created before attribution tags."""
         namespace = self._lambda_namespace()


### PR DESCRIPTION
## Description

EC2 instances and attached EBS volumes created by Newton's AWS runner workflows now receive launch-time tags for the repository, normalized trigger category, workload, GitHub run ID, and run attempt. The repository tag uses `${{ github.repository }}` so authorized fork runs remain attributable.

Caller workflows explicitly classify pull requests, merge queue runs, pushes, scheduled nightly runs, and manual dispatches. This makes AWS Console spend easier to map back to the CI activity that created it.

This PR also checks the existing overdue-runner watchdog CloudFormation template into `scripts/ci/aws` with deployment instructions. The watchdog scans all running instances with Newton's ownership tag instead of filtering on a single repository, closing the monitoring gap for temporary development runs from authorized forks. Instances created before the new attribution tags are still reported with unknown metadata rather than ignored.

The watchdog continues to calculate runner age from the EC2 launch time, so this change does not add an expiration tag. It implements the attribution portion of the [Newton AWS EC2 runner mitigation plan](https://gist.github.com/shi-eric/92509b1b263c7bf398c4752729e06a48) without changing the runner provisioning or cleanup mechanism.

This is a CI infrastructure change and does not affect Newton's public API.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] No changelog fragment is needed because this change affects CI infrastructure only

## Test plan

- [x] `uv run --no-project -m unittest discover -s scripts/ci/tests -v`
- [x] `uvx pre-commit run -a`
- [x] Ran the AWS GPU workflow from `shi-eric/newton` and confirmed that the EC2 instance and attached EBS volume received the expected dynamic repository, trigger, workload, run ID, and run-attempt tags before cleanup: https://github.com/shi-eric/newton/actions/runs/31274733298
- [x] Validated and deployed the committed CloudFormation template to the existing watchdog stack, invoked the Lambda function, and confirmed the stack was `UPDATE_COMPLETE`, drift status was `IN_SYNC`, and the alarm was `OK`

The local tests cover workflow configuration contracts and watchdog logic. They do not call AWS; the fork workflow run and watchdog deployment provide the live AWS verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated monitoring for overdue CI runners, including scheduled checks, metrics, alarms, and notifications.
  * Added normalized workflow trigger categories and detailed attribution metadata to CI runner resources across benchmark, test, pull-request, push, and scheduled runs.
* **Documentation**
  * Added AWS CI infrastructure setup, validation, deployment, and rollback guidance.
* **Tests**
  * Added validation for workflow metadata, trigger configuration, runner tagging, and watchdog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->