### PR TITLE
[Kamino] check massless runtime update

### DIFF
--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -13,12 +13,12 @@ from .core.bodies import (
 )
 from .core.control import ControlKamino
 from .core.conversions import (
-    JointUpdateViolation,
+    StructuralUpdateViolation,
     compute_material_first_shape,
     convert_model_joint_actuation,
     convert_model_joint_transforms,
     convert_model_materials,
-    validate_model_joint_updates,
+    validate_model_structural_updates,
 )
 from .core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType
 from .core.model import ModelKamino
@@ -43,10 +43,10 @@ __all__ = [
     "ContactsKamino",
     "ControlKamino",
     "JointActuationType",
-    "JointUpdateViolation",
     "ModelKamino",
     "SolverKaminoImpl",
     "StateKamino",
+    "StructuralUpdateViolation",
     "compute_material_first_shape",
     "convert_base_origin_to_com",
     "convert_body_com_to_origin",
@@ -58,5 +58,5 @@ __all__ = [
     "convert_model_joint_transforms",
     "convert_model_materials",
     "msg",
-    "validate_model_joint_updates",
+    "validate_model_structural_updates",
 ]

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 ###
 
 __all__ = [
-    "JointUpdateViolation",
+    "StructuralUpdateViolation",
     "convert_geometries",
     "convert_joints",
     "convert_model_joint_actuation",
@@ -49,7 +49,7 @@ __all__ = [
     "convert_rigid_bodies",
     "convert_target_coords_to_target_dofs",
     "convert_target_dofs_to_target_coords",
-    "validate_model_joint_updates",
+    "validate_model_structural_updates",
 ]
 
 
@@ -60,8 +60,8 @@ __all__ = [
 wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 
 
-class JointUpdateViolation(IntEnum):
-    """Indices into the joint-update validation violations array."""
+class StructuralUpdateViolation(IntEnum):
+    """Indices into the structural-update validation violations array."""
 
     DYNAMIC_CTS = 0
     LIMIT_FINITE = 1
@@ -69,6 +69,7 @@ class JointUpdateViolation(IntEnum):
     INVALID_TARGET_MODE = 3
     NONORTHONORMAL_AXES = 4
     GIMBAL_HANDEDNESS = 5
+    MASSLESS = 6
 
 
 ###
@@ -241,12 +242,12 @@ def validate_joint_dof_updates_kernel(
             joint_target_ke,
             joint_target_kd,
         ) != (num_dynamic_cts[tid] > 0):
-            wp.atomic_min(violations, JointUpdateViolation.DYNAMIC_CTS, tid)
+            wp.atomic_min(violations, StructuralUpdateViolation.DYNAMIC_CTS, tid)
 
     if tid < dof_count:
         current_finite = joint_limit_lower[tid] > JOINT_QMIN or joint_limit_upper[tid] < JOINT_QMAX
         if current_finite != (built_limit_finite[tid] != 0):
-            wp.atomic_min(violations, JointUpdateViolation.LIMIT_FINITE, tid)
+            wp.atomic_min(violations, StructuralUpdateViolation.LIMIT_FINITE, tid)
 
 
 @wp.kernel
@@ -266,9 +267,9 @@ def validate_joint_actuation_updates_kernel(
         joint_target_mode,
     )
     if current_actuation < 0:
-        wp.atomic_min(violations, JointUpdateViolation.INVALID_TARGET_MODE, joint)
+        wp.atomic_min(violations, StructuralUpdateViolation.INVALID_TARGET_MODE, joint)
     elif (current_actuation == JointActuationType.PASSIVE) != (act_type[joint] == JointActuationType.PASSIVE):
-        wp.atomic_min(violations, JointUpdateViolation.ACTUATION_PARTITION, joint)
+        wp.atomic_min(violations, StructuralUpdateViolation.ACTUATION_PARTITION, joint)
 
 
 @wp.kernel
@@ -317,10 +318,42 @@ def validate_joint_axes_kernel(
             left_handed = wp.dot(wp.cross(axis_0, axis_1), axis_2) < 0.0
             expected_left_handed = dof_type == JointDoFType.GIMBAL_LEFT_HANDED
             if left_handed != expected_left_handed:
-                wp.atomic_min(violations, JointUpdateViolation.GIMBAL_HANDEDNESS, joint)
+                wp.atomic_min(violations, StructuralUpdateViolation.GIMBAL_HANDEDNESS, joint)
                 return
     if not valid:
-        wp.atomic_min(violations, JointUpdateViolation.NONORTHONORMAL_AXES, joint)
+        wp.atomic_min(violations, StructuralUpdateViolation.NONORTHONORMAL_AXES, joint)
+
+
+@wp.func
+def has_zero_inverse_inertia(inv_inertia: wp.mat33f) -> bool:
+    """Return whether every element of an inverse inertia matrix is zero."""
+    return (
+        inv_inertia[0, 0] == 0.0
+        and inv_inertia[0, 1] == 0.0
+        and inv_inertia[0, 2] == 0.0
+        and inv_inertia[1, 0] == 0.0
+        and inv_inertia[1, 1] == 0.0
+        and inv_inertia[1, 2] == 0.0
+        and inv_inertia[2, 0] == 0.0
+        and inv_inertia[2, 1] == 0.0
+        and inv_inertia[2, 2] == 0.0
+    )
+
+
+@wp.kernel
+def validate_body_inertial_updates_kernel(
+    # Inputs:
+    body_inv_mass: wp.array[wp.float32],
+    body_inv_inertia: wp.array[wp.mat33f],
+    built_massless: wp.array[wp.int32],
+    # Outputs:
+    violations: wp.array[wp.int32],
+):
+    """Find the first body made massless after constructing SolverKamino."""
+    body = wp.tid()
+    is_massless = body_inv_mass[body] == 0.0 or has_zero_inverse_inertia(body_inv_inertia[body])
+    if is_massless and built_massless[body] == 0:
+        wp.atomic_min(violations, StructuralUpdateViolation.MASSLESS, body)
 
 
 @wp.kernel
@@ -868,44 +901,49 @@ def compute_required_contact_capacity(
     return int(np.sum(world_max_contacts)), world_max_contacts.astype(int).tolist()
 
 
-def validate_model_joint_updates(
+def validate_model_structural_updates(
     model: Model,
     joints: JointsModel,
     built_limit_finite: wp.array[wp.int32],
+    built_massless: wp.array[wp.int32],
     violations: wp.array[wp.int32],
     *,
     check_dof: bool,
     check_actuation: bool,
     check_axes: bool,
+    check_inertial: bool,
 ) -> int:
-    """Validate that runtime joint edits preserve Kamino's structural layout.
+    """Validate that runtime edits preserve Kamino's structural layout.
 
-    ``violations`` is a ``len(JointUpdateViolation)``-entry array
+    ``violations`` is a ``len(StructuralUpdateViolation)``-entry array
     containing the first index for each violation type:
 
-    - :attr:`JointUpdateViolation.DYNAMIC_CTS`: dynamic-constraint topology changed
-    - :attr:`JointUpdateViolation.LIMIT_FINITE`: finite-limit state changed
-    - :attr:`JointUpdateViolation.ACTUATION_PARTITION`: passive/actuated partition changed
-    - :attr:`JointUpdateViolation.INVALID_TARGET_MODE`: unsupported target-mode combination
-    - :attr:`JointUpdateViolation.NONORTHONORMAL_AXES`: nonorthonormal universal/gimbal axes
-    - :attr:`JointUpdateViolation.GIMBAL_HANDEDNESS`: gimbal axis handedness changed
+    - :attr:`StructuralUpdateViolation.DYNAMIC_CTS`: dynamic-constraint topology changed
+    - :attr:`StructuralUpdateViolation.LIMIT_FINITE`: finite-limit state changed
+    - :attr:`StructuralUpdateViolation.ACTUATION_PARTITION`: passive/actuated partition changed
+    - :attr:`StructuralUpdateViolation.INVALID_TARGET_MODE`: unsupported target-mode combination
+    - :attr:`StructuralUpdateViolation.NONORTHONORMAL_AXES`: nonorthonormal universal/gimbal axes
+    - :attr:`StructuralUpdateViolation.GIMBAL_HANDEDNESS`: gimbal axis handedness changed
+    - :attr:`StructuralUpdateViolation.MASSLESS`: a built massive body became massless
 
-    An entry equal to the maximum of the joint and DoF counts indicates that no
+    An entry equal to the maximum of the body, joint, and DoF counts indicates that no
     violation of that type was found.
 
     Args:
-        model: The Newton model containing the updated joints to validate.
+        model: The Newton model containing the updated properties to validate.
         joints: The current Kamino joint model, before applying the updates.
         built_limit_finite: The built finite limit state for each DoF.
+        built_massless: Whether each body was massless at solver construction.
         violations: The array to store the violations.
         check_dof: Whether to check the DoF updates.
         check_actuation: Whether to check the actuation updates.
         check_axes: Whether to check universal and gimbal axes.
+        check_inertial: Whether to check body inertial updates.
 
     Returns:
         The sentinel value indicating no violations.
     """
-    dim = max(model.joint_count, model.joint_dof_count)
+    dim = max(model.body_count, model.joint_count, model.joint_dof_count)
     violations.fill_(dim)
     if check_dof and dim > 0:
         wp.launch(
@@ -957,6 +995,20 @@ def validate_model_joint_updates(
             ],
             device=model.device,
         )
+    if check_inertial and model.body_count > 0:
+        wp.launch(
+            kernel=validate_body_inertial_updates_kernel,
+            dim=model.body_count,
+            inputs=[
+                # Inputs:
+                model.body_inv_mass,
+                model.body_inv_inertia,
+                built_massless,
+                # Outputs:
+                violations,
+            ],
+            device=model.device,
+        )
 
     return dim
 
@@ -1001,14 +1053,14 @@ def _validate_joint_axes(
             device=model.device,
         )
     violations_np = violations.numpy()
-    invalid_joint = int(violations_np[JointUpdateViolation.NONORTHONORMAL_AXES])
+    invalid_joint = int(violations_np[StructuralUpdateViolation.NONORTHONORMAL_AXES])
     if invalid_joint < model.joint_count:
         raise ValueError(
             f"Invalid joint configuration for SolverKamino:\n"
             f"  - joint {invalid_joint} ({model.joint_label[invalid_joint]!r}): "
             "universal and gimbal axes must be unit length and orthogonal"
         )
-    invalid_joint = int(violations_np[JointUpdateViolation.GIMBAL_HANDEDNESS])
+    invalid_joint = int(violations_np[StructuralUpdateViolation.GIMBAL_HANDEDNESS])
     if invalid_joint < model.joint_count:
         raise ValueError(
             f"Invalid joint configuration for SolverKamino:\n"
@@ -1320,7 +1372,7 @@ def convert_joints(
         device=model.device,
     )
 
-    axis_validation_violations = wp.empty(len(JointUpdateViolation), dtype=wp.int32, device=model.device)
+    axis_validation_violations = wp.empty(len(StructuralUpdateViolation), dtype=wp.int32, device=model.device)
     _validate_joint_axes(model, joint_dof_type, axis_validation_violations)
 
     wp.launch(

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -743,9 +743,18 @@ class SolverKamino(SolverBase, CouplingInterface):
             device=model.device,
         )
 
+        built_massless_np = (model.body_inv_mass.numpy() == 0.0) | np.all(
+            model.body_inv_inertia.numpy() == 0.0, axis=(1, 2)
+        )
+        self._built_massless = wp.array(
+            built_massless_np.astype(np.int32),
+            dtype=wp.int32,
+            device=model.device,
+        )
+
         # Scratch array for notify validation
         self._notify_violations = wp.empty(
-            len(self._kamino.JointUpdateViolation),
+            len(self._kamino.StructuralUpdateViolation),
             dtype=wp.int32,
             device=model.device,
         )
@@ -1361,25 +1370,29 @@ class SolverKamino(SolverBase, CouplingInterface):
         check_dof = bool(flags & ModelFlags.JOINT_DOF_PROPERTIES)
         check_actuation = bool(flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES))
         check_axes = check_dof
-        if not check_dof and not check_actuation and not check_axes:
+        check_inertial = bool(flags & ModelFlags.BODY_INERTIAL_PROPERTIES)
+        if not check_dof and not check_actuation and not check_axes and not check_inertial:
             return
 
-        sentinel = self._kamino.validate_model_joint_updates(
+        sentinel = self._kamino.validate_model_structural_updates(
             self.model,
             self._model_kamino.joints,
             self._built_limit_finite,
+            self._built_massless,
             self._notify_violations,
             check_dof=check_dof,
             check_actuation=check_actuation,
             check_axes=check_axes,
+            check_inertial=check_inertial,
         )
         violations = self._notify_violations.numpy()
-        dynamic_joint = violations[self._kamino.JointUpdateViolation.DYNAMIC_CTS]
-        limit_dof = violations[self._kamino.JointUpdateViolation.LIMIT_FINITE]
-        actuation_joint = violations[self._kamino.JointUpdateViolation.ACTUATION_PARTITION]
-        invalid_joint = violations[self._kamino.JointUpdateViolation.INVALID_TARGET_MODE]
-        axis_joint = violations[self._kamino.JointUpdateViolation.NONORTHONORMAL_AXES]
-        gimbal_handedness_joint = violations[self._kamino.JointUpdateViolation.GIMBAL_HANDEDNESS]
+        dynamic_joint = violations[self._kamino.StructuralUpdateViolation.DYNAMIC_CTS]
+        limit_dof = violations[self._kamino.StructuralUpdateViolation.LIMIT_FINITE]
+        actuation_joint = violations[self._kamino.StructuralUpdateViolation.ACTUATION_PARTITION]
+        invalid_joint = violations[self._kamino.StructuralUpdateViolation.INVALID_TARGET_MODE]
+        axis_joint = violations[self._kamino.StructuralUpdateViolation.NONORTHONORMAL_AXES]
+        gimbal_handedness_joint = violations[self._kamino.StructuralUpdateViolation.GIMBAL_HANDEDNESS]
+        massless_body = violations[self._kamino.StructuralUpdateViolation.MASSLESS]
 
         if dynamic_joint != sentinel:
             joint = int(dynamic_joint)
@@ -1422,6 +1435,13 @@ class SolverKamino(SolverBase, CouplingInterface):
                 f"Invalid joint configuration for SolverKamino:\n"
                 f"  - joint {joint} ({self.model.joint_label[joint]!r}): "
                 "gimbal axes must preserve the solver's original handedness"
+            )
+
+        if massless_body != sentinel:
+            body = int(massless_body)
+            label = self.model.body_label[body] if self.model.body_label else f"body {body}"
+            raise RuntimeError(
+                f"Making body {body} ({label!r}) massless is not supported; recreate SolverKamino to apply the change."
             )
 
     def _update_actuation_types(self) -> None:

--- a/newton/tests/kamino/test_kamino_gimbal.py
+++ b/newton/tests/kamino/test_kamino_gimbal.py
@@ -64,8 +64,8 @@ def _build_rotational_d6(
 ):
     """Build a minimal articulated three-axis D6 fixture."""
     builder = newton.ModelBuilder()
-    parent = builder.add_link(mass=2.0, inertia=wp.mat33(0.8, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 1.0))
-    child = builder.add_link(mass=1.0, inertia=wp.mat33(0.2, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.4))
+    parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
     root = builder.add_joint_fixed(-1, parent)
     d6 = builder.add_joint_d6(
         parent,
@@ -269,8 +269,8 @@ class TestGimbal(unittest.TestCase):
     def test_universal_rejects_nonorthogonal_axes(self):
         """Reject a universal joint whose axes are not perpendicular."""
         builder = newton.ModelBuilder()
-        parent = builder.add_link(mass=2.0, inertia=wp.mat33(0.8, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 1.0))
-        child = builder.add_link(mass=1.0, inertia=wp.mat33(0.2, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.4))
+        parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+        child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
         root = builder.add_joint_fixed(-1, parent)
         universal = builder.add_joint_d6(
             parent,

--- a/newton/tests/kamino/test_kamino_gimbal.py
+++ b/newton/tests/kamino/test_kamino_gimbal.py
@@ -64,8 +64,8 @@ def _build_rotational_d6(
 ):
     """Build a minimal articulated three-axis D6 fixture."""
     builder = newton.ModelBuilder()
-    parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
-    child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    parent = builder.add_link(mass=2.0, inertia=wp.mat33(0.8, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 1.0))
+    child = builder.add_link(mass=1.0, inertia=wp.mat33(0.2, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.4))
     root = builder.add_joint_fixed(-1, parent)
     d6 = builder.add_joint_d6(
         parent,
@@ -269,8 +269,8 @@ class TestGimbal(unittest.TestCase):
     def test_universal_rejects_nonorthogonal_axes(self):
         """Reject a universal joint whose axes are not perpendicular."""
         builder = newton.ModelBuilder()
-        parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
-        child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+        parent = builder.add_link(mass=2.0, inertia=wp.mat33(0.8, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 1.0))
+        child = builder.add_link(mass=1.0, inertia=wp.mat33(0.2, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.4))
         root = builder.add_joint_fixed(-1, parent)
         universal = builder.add_joint_d6(
             parent,

--- a/newton/tests/kamino/test_kamino_solver_kamino_notify.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino_notify.py
@@ -92,8 +92,16 @@ def _build_revolute(
 def _build_gimbal() -> tuple[newton.Model, int]:
     """Build a minimal articulated three-axis D6 model for notify tests."""
     builder = newton.ModelBuilder()
-    parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
-    child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    parent = builder.add_link(
+        mass=1.0,
+        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        lock_inertia=True,
+    )
+    child = builder.add_link(
+        mass=1.0,
+        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        lock_inertia=True,
+    )
     root = builder.add_joint_fixed(-1, parent)
     gimbal = builder.add_joint_d6(
         parent,
@@ -366,6 +374,24 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         # Reset goes through a body pose -> com pose -> body pose conversion. Check that the conversion is correct.
         solver.reset(state)
         np.testing.assert_allclose(state.body_q.numpy(), model.body_q.numpy(), atol=1e-6)
+
+    def test_making_body_massless_raises(self):
+        """Reject changing an initially massive body's inverse mass to zero."""
+        model = _build_revolute()
+        solver = SolverKamino(model)
+        model.body_inv_mass.assign([0.0])
+
+        with self.assertRaisesRegex(RuntimeError, "massless.*recreate SolverKamino"):
+            solver.notify_model_changed(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+    def test_making_inverse_inertia_fully_zero_raises(self):
+        """Reject changing an initially nonzero inverse inertia matrix to zero."""
+        model = _build_revolute()
+        solver = SolverKamino(model)
+        model.body_inv_inertia.assign([wp.mat33f(0.0)])
+
+        with self.assertRaisesRegex(RuntimeError, "massless.*recreate SolverKamino"):
+            solver.notify_model_changed(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
 
     def test_material_value_update_propagates(self):
         """Two shapes sharing one material can update it together and keep sharing it."""

--- a/newton/tests/kamino/test_kamino_solver_kamino_notify.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino_notify.py
@@ -92,16 +92,8 @@ def _build_revolute(
 def _build_gimbal() -> tuple[newton.Model, int]:
     """Build a minimal articulated three-axis D6 model for notify tests."""
     builder = newton.ModelBuilder()
-    parent = builder.add_link(
-        mass=1.0,
-        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        lock_inertia=True,
-    )
-    child = builder.add_link(
-        mass=1.0,
-        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        lock_inertia=True,
-    )
+    parent = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    child = builder.add_link(mass=1.0, inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
     root = builder.add_joint_fixed(-1, parent)
     gimbal = builder.add_joint_d6(
         parent,


### PR DESCRIPTION
## Description

Follow-up on https://github.com/newton-physics/newton/pull/3840. Adds runtime model change validation for massless bodies: 
- converting a normal body into a massless body is rejected. 
- converting a massless body to something with mass (and afterwards converting it back) is allowed.

With this restriction we do not have to do the full topology check again at runtime. I also excluded checking eigenvalues and only check for full zero Inertia matrix. It feels like setting singular inertias is a user error and not common enough to warrent an eigenvalue check.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded model-change validation to cover structural and inertial updates, including bodies becoming massless.
  - Added clear detection and reporting for unsupported structural changes.

- **Bug Fixes**
  - The solver now requires recreation when a body becomes massless or its inverse inertia is fully zeroed.

- **Tests**
  - Added regression coverage for massless-body and zero-inertia updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->