### PR TITLE
Fix NotifyDRLegs ASV sampling

### DIFF
--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -158,10 +158,11 @@ class KpiDRLegs(_KpiBenchmark):
 class NotifyDRLegs:
     """Benchmark Kamino model notifications for 2048 DR Legs worlds."""
 
-    number = 10
-    repeat = 7
+    number = 1
+    repeat = 5
     rounds = 1
-    timeout = 3600
+    warmup_time = 0
+    timeout = 600
     world_count = 2048
 
     def setup(self):


### PR DESCRIPTION
## Description

Update the NotifyDRLegs ASV configuration for asv_runner 0.3.0 setup semantics. One timed call is now collected per sample, removing repeated model and solver construction from explicitly batched calls. The suite uses five repeats, no timed warmups, and a 600-second timeout.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md) (not user-facing)

## Test plan

- `uvx pre-commit run -a`
- `uv run --extra dev asv check`
- `uv run --extra dev asv run --launch-method spawn -b 'NotifyDRLegs'`

On an RTX 5090, the seven-sample validation run completed in 88 seconds. Per-method spreads were 1–5.5%; no repeat increase is proposed initially. The PR ASV gate does not select NotifyDRLegs, so this needs a new nightly baseline rather than a threshold change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated benchmark settings to complete faster by reducing repetitions, disabling warmup, and shortening the timeout.
  * Maintained a single benchmark round for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->