### PR TITLE
Optimize cable bend-twist Jacobian assembly

### DIFF
--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -50,13 +50,16 @@ Cable joints
 
 :attr:`newton.JointType.CABLE` is represented in Newton's joint data model, but
 it is not a conventional generalized-coordinate joint. Its four per-joint
-entries are VBD constraint/material slots: two linear slots for stretch/shear
-and two angular slots for bend/twist. These slots store per-cable stiffness and
-damping through
-:attr:`newton.Model.joint_target_ke` and :attr:`newton.Model.joint_target_kd`;
-generic joint storage allocates matching ``joint_q`` / ``joint_qd`` entries, but
-they are not generalized coordinates or velocities that reconstruct the child
-body pose.
+entries are VBD constraint/material slots: stretch (slot 0, ``JointSlot.STRETCH``),
+shear (slot 1, ``JointSlot.SHEAR``), bend (slot 2, ``JointSlot.BEND``), and twist
+(slot 3, ``JointSlot.TWIST``). :attr:`newton.Model.joint_target_ke` and
+:attr:`newton.Model.joint_target_kd` independently control stiffness and damping
+for each slot. Generic joint storage allocates matching ``joint_q`` / ``joint_qd``
+entries, but they are not generalized coordinates or velocities that reconstruct
+the child body pose.
+
+Use the cable-specific ``JointSlot`` names: ``JointSlot.ANGULAR`` has value 1
+and selects shear, while bending uses ``JointSlot.BEND`` (slot 2).
 
 Cable body poses and velocities are maximal-coordinate state stored in
 :attr:`newton.State.body_q` and :attr:`newton.State.body_qd`, and are advanced by
@@ -337,9 +340,10 @@ by maximal-coordinate body state as described in `Cable joints`_.
 Definition of ``joint_q``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :attr:`newton.Model.joint_q` array stores the default generalized joint positions
-for all joints in the model and is used to initialize :attr:`newton.State.joint_q`.
-Both arrays share the same per-joint layout.
+Except for :attr:`newton.JointType.CABLE` (see `Cable joints`_), the
+:attr:`newton.Model.joint_q` array stores the default generalized joint
+positions and initializes :attr:`newton.State.joint_q`. Both arrays share the
+same per-joint layout.
 For scalar-coordinate joints (for example this D6 joint), the positional coordinates can be queried as follows:
 
 .. testsetup:: articulation-joint-layout
@@ -383,9 +387,10 @@ For scalar-coordinate joints (for example this D6 joint), the positional coordin
 Definition of ``joint_qd``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :attr:`newton.Model.joint_qd` array stores the default generalized joint velocities
-for all joints in the model and is used to initialize :attr:`newton.State.joint_qd`.
-The generalized joint forces at :attr:`newton.Control.joint_f` use the same DOF order.
+Except for :attr:`newton.JointType.CABLE` (see `Cable joints`_), the
+:attr:`newton.Model.joint_qd` array stores the default generalized joint
+velocities and initializes :attr:`newton.State.joint_qd`. The generalized joint
+forces at :attr:`newton.Control.joint_f` use the same DOF order.
 
 Several other arrays also use this same DOF-ordered layout, indexed from
 :attr:`newton.Model.joint_qd_start` rather than :attr:`newton.Model.joint_q_start`.
@@ -401,9 +406,9 @@ The position targets at :attr:`newton.Control.joint_target_q` instead match
 indexed via :attr:`newton.Model.joint_qd_start` — see the
 :ref:`migration guide <joint-target-layout>` for details.
 
-For every joint, these per-DOF arrays are stored consecutively, with linear DOFs
-first and angular DOFs second. Use :attr:`newton.Model.joint_dof_dim` to query
-how many of each a joint has.
+For generalized-coordinate joints, these per-DOF arrays are stored consecutively,
+with linear DOFs first and angular DOFs second. Use
+:attr:`newton.Model.joint_dof_dim` to query how many of each a joint has.
 
 The velocity DOFs for each joint can be queried as follows:
 

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -49,17 +49,14 @@ Cable joints
 ^^^^^^^^^^^^
 
 :attr:`newton.JointType.CABLE` is represented in Newton's joint data model, but
-it is not a conventional generalized-coordinate joint. Its four per-joint
-entries are VBD constraint/material slots: stretch (slot 0, ``JointSlot.STRETCH``),
-shear (slot 1, ``JointSlot.SHEAR``), bend (slot 2, ``JointSlot.BEND``), and twist
-(slot 3, ``JointSlot.TWIST``). :attr:`newton.Model.joint_target_ke` and
-:attr:`newton.Model.joint_target_kd` independently control stiffness and damping
-for each slot. Generic joint storage allocates matching ``joint_q`` / ``joint_qd``
-entries, but they are not generalized coordinates or velocities that reconstruct
-the child body pose.
-
-Use the cable-specific ``JointSlot`` names: ``JointSlot.ANGULAR`` has value 1
-and selects shear, while bending uses ``JointSlot.BEND`` (slot 2).
+it is not a conventional generalized-coordinate joint. Its four entries are
+VBD constraint/material slots: stretch (slot 0, ``JointSlot.STRETCH``), shear
+(slot 1, ``JointSlot.SHEAR``), bend (slot 2, ``JointSlot.BEND``), and twist
+(slot 3, ``JointSlot.TWIST``). These slots store independent per-cable stiffness
+and damping through :attr:`newton.Model.joint_target_ke` and
+:attr:`newton.Model.joint_target_kd`. Generic joint storage allocates matching
+``joint_q`` / ``joint_qd`` entries, but they are not generalized coordinates or
+velocities that reconstruct the child body pose.
 
 Cable body poses and velocities are maximal-coordinate state stored in
 :attr:`newton.State.body_q` and :attr:`newton.State.body_qd`, and are advanced by
@@ -328,22 +325,20 @@ Joint types
    * - ``JointType.CABLE``
      - Cable joint with 2 linear material slots (stretch/shear) and 2 angular
        material slots (bend/twist)
-     - 4 structural entries
-     - 4 structural entries
+     - 4
+     - 4
 
 D6 joints are the most general joint type in Newton and can be used to represent any combination of translational and rotational degrees of freedom.
 Prismatic, revolute, planar, and universal joints can be seen as special cases of the D6 joint.
-For ``JointType.CABLE``, the table reports allocated material-slot entries rather
-than generalized motion coordinates or velocity DOFs; cable motion is represented
-by maximal-coordinate body state as described in `Cable joints`_.
+For ``JointType.CABLE``, both counts represent allocated material slots, not
+generalized coordinates or velocity DOFs; see `Cable joints`_.
 
 Definition of ``joint_q``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Except for :attr:`newton.JointType.CABLE` (see `Cable joints`_), the
-:attr:`newton.Model.joint_q` array stores the default generalized joint
-positions and initializes :attr:`newton.State.joint_q`. Both arrays share the
-same per-joint layout.
+The :attr:`newton.Model.joint_q` array stores the default generalized joint positions
+for generalized-coordinate joints and is used to initialize :attr:`newton.State.joint_q`.
+Both arrays share the same per-joint layout.
 For scalar-coordinate joints (for example this D6 joint), the positional coordinates can be queried as follows:
 
 .. testsetup:: articulation-joint-layout
@@ -387,10 +382,9 @@ For scalar-coordinate joints (for example this D6 joint), the positional coordin
 Definition of ``joint_qd``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Except for :attr:`newton.JointType.CABLE` (see `Cable joints`_), the
-:attr:`newton.Model.joint_qd` array stores the default generalized joint
-velocities and initializes :attr:`newton.State.joint_qd`. The generalized joint
-forces at :attr:`newton.Control.joint_f` use the same DOF order.
+The :attr:`newton.Model.joint_qd` array stores the default generalized joint velocities
+for generalized-coordinate joints and is used to initialize :attr:`newton.State.joint_qd`.
+The generalized joint forces at :attr:`newton.Control.joint_f` use the same DOF order.
 
 Several other arrays also use this same DOF-ordered layout, indexed from
 :attr:`newton.Model.joint_qd_start` rather than :attr:`newton.Model.joint_q_start`.
@@ -406,8 +400,8 @@ The position targets at :attr:`newton.Control.joint_target_q` instead match
 indexed via :attr:`newton.Model.joint_qd_start` — see the
 :ref:`migration guide <joint-target-layout>` for details.
 
-For generalized-coordinate joints, these per-DOF arrays are stored consecutively,
-with linear DOFs first and angular DOFs second. Use
+For every generalized-coordinate joint, these per-DOF arrays are stored
+consecutively, with linear DOFs first and angular DOFs second. Use
 :attr:`newton.Model.joint_dof_dim` to query how many of each a joint has.
 
 The velocity DOFs for each joint can be queried as follows:

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -49,12 +49,14 @@ Cable joints
 ^^^^^^^^^^^^
 
 :attr:`newton.JointType.CABLE` is represented in Newton's joint data model, but
-it is not a conventional generalized-coordinate joint. Its two entries are
-VBD constraint/material slots: one linear slot for stretch and one angular slot
-for bend/twist. These slots store per-cable stiffness and damping through
+it is not a conventional generalized-coordinate joint. Its four per-joint
+entries are VBD constraint/material slots: two linear slots for stretch/shear
+and two angular slots for bend/twist. These slots store per-cable stiffness and
+damping through
 :attr:`newton.Model.joint_target_ke` and :attr:`newton.Model.joint_target_kd`;
-they are not ``joint_q`` coordinates that uniquely reconstruct the child body
-pose.
+generic joint storage allocates matching ``joint_q`` / ``joint_qd`` entries, but
+they are not generalized coordinates or velocities that reconstruct the child
+body pose.
 
 Cable body poses and velocities are maximal-coordinate state stored in
 :attr:`newton.State.body_q` and :attr:`newton.State.body_qd`, and are advanced by
@@ -321,12 +323,16 @@ Joint types
      - up to 6
      - up to 6
    * - ``JointType.CABLE``
-     - Cable joint with 1 linear (stretch/shear) and 1 angular (bend/twist) degree of freedom
-     - 2
-     - 2
+     - Cable joint with 2 linear material slots (stretch/shear) and 2 angular
+       material slots (bend/twist)
+     - 4 structural entries
+     - 4 structural entries
 
 D6 joints are the most general joint type in Newton and can be used to represent any combination of translational and rotational degrees of freedom.
 Prismatic, revolute, planar, and universal joints can be seen as special cases of the D6 joint.
+For ``JointType.CABLE``, the table reports allocated material-slot entries rather
+than generalized motion coordinates or velocity DOFs; cable motion is represented
+by maximal-coordinate body state as described in `Cable joints`_.
 
 Definition of ``joint_q``
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5186,8 +5186,8 @@ class ModelBuilder:
     ) -> int:
         """Adds a cable joint to the model.
 
-        Cable joints have split linear stretch/shear DoFs plus separate angular
-        bend and twist DoFs. When both ``shear_stiffness`` and
+        Cable joints have split linear stretch/shear material slots plus separate
+        angular bend and twist material slots. When both ``shear_stiffness`` and
         ``shear_damping`` are omitted, shear uses the stretch stiffness /
         damping, reproducing the isotropic linear energy while using the
         split layout. When both ``twist_stiffness`` and ``twist_damping`` are

--- a/newton/_src/sim/enums.py
+++ b/newton/_src/sim/enums.py
@@ -174,7 +174,7 @@ class JointType(IntEnum):
     """6-DoF joint: Generic joint with up to 3 translational and 3 rotational degrees of freedom."""
 
     CABLE = 7
-    """Cable joint: two DOF slots for linear stretch and angular bend/twist."""
+    """Cable joint: four VBD material slots for stretch, shear, bend, and twist."""
 
     def dof_count(self, num_axes: int) -> tuple[int, int]:
         """

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -560,17 +560,63 @@ def _cable_bend_twist_directional_derivatives_from_measure(
 
 
 @wp.func
-def _geometric_cable_strain_directional_derivative_z_from_measure(
-    q_wp: wp.quat,
+def _finite_curvature_binormal_jacobian(t0: wp.vec3, t1: wp.vec3, is_parent: bool) -> wp.mat33:
+    """Jacobian of the finite curvature binormal for one endpoint rotation.
+
+    This is the matrix form of ``_finite_curvature_binormal_derivative`` and
+    evaluates geometry shared by the three world-axis columns only once.
+    """
+    zero = wp.mat33(0.0)
+    raw_tangent_dot = wp.dot(t0, t1)
+    tangent_dot = wp.clamp(raw_tangent_dot, -1.0, 1.0)
+    tangent_cross = wp.cross(t0, t1)
+    denom = 1.0 + tangent_dot
+    cross_sq = wp.dot(tangent_cross, tangent_cross)
+    if denom <= _CABLE_KB_FOLD_EPS and cross_sq <= _CABLE_KB_FOLD_EPS:
+        return zero
+
+    identity = wp.identity(3, float)
+    if is_parent:
+        ddenom_domega = tangent_cross
+        dcross_domega = wp.outer(t0, t1) - raw_tangent_dot * identity
+    else:
+        ddenom_domega = -tangent_cross
+        dcross_domega = raw_tangent_dot * identity - wp.outer(t1, t0)
+
+    denom_safe = wp.max(_CABLE_KB_FOLD_EPS, denom)
+    inv_denom = 1.0 / denom_safe
+    kb_raw = (2.0 * inv_denom) * tangent_cross
+    dkb_domega = (2.0 * inv_denom) * dcross_domega
+    if denom > _CABLE_KB_FOLD_EPS:
+        dkb_domega = dkb_domega - (2.0 * inv_denom * inv_denom * wp.outer(tangent_cross, ddenom_domega))
+
+    kb_len = wp.length(kb_raw)
+    if kb_len > _CABLE_KB_CURVATURE_CAP:
+        inv_len = 1.0 / kb_len
+        projection = wp.identity(3, float) - (inv_len * inv_len) * wp.outer(kb_raw, kb_raw)
+        dkb_domega = (_CABLE_KB_CURVATURE_CAP * inv_len) * projection * dkb_domega
+
+    return dkb_domega
+
+
+@wp.func
+def _transported_twist_angle_jacobian_from_measure(
     measure: CableBendTwistMeasure,
-    omega_world: wp.vec3,
     is_parent: bool,
 ) -> wp.vec3:
-    """Directional derivative of [bend_x, bend_y, twist_z] for local +Z cables."""
-    d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(
-        q_wp, measure, omega_world, is_parent
-    )
-    return wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
+    """Jacobian row of transported twist for one endpoint rotation.
+
+    The tangent bisector is the closed form of the directional derivative in
+    ``_transported_twist_angle_derivative_from_measure``.
+    """
+    t0 = measure.t0
+    t1 = measure.t1
+    denom = 1.0 + wp.clamp(wp.dot(t0, t1), -1.0, 1.0)
+    if denom <= _CABLE_TRANSPORT_DENOM_EPS:
+        return -t0 if is_parent else t1
+
+    jacobian = (t0 + t1) / denom
+    return -jacobian if is_parent else jacobian
 
 
 @wp.func
@@ -584,14 +630,16 @@ def _cable_bend_twist_jacobian_z_from_measure(
     The local residual is exactly ``[bend_x, bend_y, twist_z]``, so no bend
     projector or twist-axis vector is needed in this hot path.
     """
-    e0 = wp.vec3(1.0, 0.0, 0.0)
-    e1 = wp.vec3(0.0, 1.0, 0.0)
-    e2 = wp.vec3(0.0, 0.0, 1.0)
+    dkb_domega = _finite_curvature_binormal_jacobian(measure.t0, measure.t1, is_parent)
+    if is_parent:
+        dkb_domega = dkb_domega + wp.skew(measure.kb_world)
 
-    j0 = _geometric_cable_strain_directional_derivative_z_from_measure(q_wp, measure, e0, is_parent)
-    j1 = _geometric_cable_strain_directional_derivative_z_from_measure(q_wp, measure, e1, is_parent)
-    j2 = _geometric_cable_strain_directional_derivative_z_from_measure(q_wp, measure, e2, is_parent)
-    return wp.matrix_from_cols(j0, j1, j2)
+    parent_x_world = measure.m0
+    parent_y_world = wp.cross(measure.t0, measure.m0)
+    bend_jacobian_x = wp.transpose(dkb_domega) * parent_x_world
+    bend_jacobian_y = wp.transpose(dkb_domega) * parent_y_world
+    twist_jacobian = _transported_twist_angle_jacobian_from_measure(measure, is_parent)
+    return wp.matrix_from_rows(bend_jacobian_x, bend_jacobian_y, twist_jacobian)
 
 
 @wp.func

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -71,6 +71,13 @@ _CABLE_TRANSPORT_DENOM_EPS = wp.constant(1.0e-8)
 This is larger than _CABLE_KB_FOLD_EPS because transport has no curvature cap;
 the closed-form expression must be left before it becomes ill-conditioned."""
 
+_CABLE_TWIST_JACOBIAN_DIRECTIONAL_DENOM = wp.constant(2.0e-2)
+"""Near-fold threshold for evaluating the twist Jacobian through directional derivatives.
+
+The tangent-bisector row is algebraically exact, but loses float32 consistency
+with the normalized transport residual as 1 + dot(t0, t1) approaches zero. This
+cutoff is approximately where the curvature-binormal cap starts to engage."""
+
 _CABLE_TWIST_ATAN2_DENOM_EPS = wp.constant(1.0e-12)
 """Floor on sin^2 + cos^2 in the transported-twist atan2 derivative."""
 
@@ -606,14 +613,22 @@ def _transported_twist_angle_jacobian_from_measure(
 ) -> wp.vec3:
     """Jacobian row of transported twist for one endpoint rotation.
 
-    The tangent bisector is the closed form of the directional derivative in
-    ``_transported_twist_angle_derivative_from_measure``.
+    Use the tangent-bisector closed form for well-conditioned tangents. Near a
+    fold, evaluate the full directional derivative along each world axis so the
+    Jacobian remains consistent with the float32 transport residual.
     """
     t0 = measure.t0
     t1 = measure.t1
     denom = 1.0 + wp.clamp(wp.dot(t0, t1), -1.0, 1.0)
-    if denom <= _CABLE_TRANSPORT_DENOM_EPS:
-        return -t0 if is_parent else t1
+    if denom <= _CABLE_TWIST_JACOBIAN_DIRECTIONAL_DENOM:
+        e0 = wp.vec3(1.0, 0.0, 0.0)
+        e1 = wp.vec3(0.0, 1.0, 0.0)
+        e2 = wp.vec3(0.0, 0.0, 1.0)
+        return wp.vec3(
+            _transported_twist_angle_derivative_from_measure(measure, e0, is_parent),
+            _transported_twist_angle_derivative_from_measure(measure, e1, is_parent),
+            _transported_twist_angle_derivative_from_measure(measure, e2, is_parent),
+        )
 
     jacobian = (t0 + t1) / denom
     return -jacobian if is_parent else jacobian
@@ -621,7 +636,6 @@ def _transported_twist_angle_jacobian_from_measure(
 
 @wp.func
 def _cable_bend_twist_jacobian_z_from_measure(
-    q_wp: wp.quat,
     measure: CableBendTwistMeasure,
     is_parent: bool,
 ) -> wp.mat33:
@@ -1010,7 +1024,7 @@ def evaluate_cable_bend_twist_force_hessian_z(
         f_local = f_local + wp.cw_mul(K_damp_diag, dkappa_dt)
         H_local_diag = H_local_diag + inv_dt * K_damp_diag
 
-    J_body = _cable_bend_twist_jacobian_z_from_measure(q_wp, measure, is_parent)
+    J_body = _cable_bend_twist_jacobian_z_from_measure(measure, is_parent)
     # Gauss-Newton self Hessian: J^T diag(H_local_diag) J.
     H_aa = wp.transpose(J_body) * _diag_mul_mat33(H_local_diag, J_body)
     tau_world = -(wp.transpose(J_body) * f_local)

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -4859,7 +4859,7 @@ def _eval_bend_twist_deformation_derivative_kernel(errors: wp.array[wp.vec3]):
     measure = _measure_cable_bend_twist_z(q_wp, q_wc)
     d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(q_wp, measure, axis, is_parent)
     directional = wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
-    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(q_wp, measure, is_parent) * axis
+    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(measure, is_parent) * axis
 
     h = 1.0e-3
     q_wp_p = q_wp
@@ -4883,25 +4883,59 @@ def _eval_bend_twist_deformation_derivative_kernel(errors: wp.array[wp.vec3]):
 
 
 @wp.kernel
-def _eval_bend_twist_jacobian_guard_branches_kernel(errors: wp.array[float]):
+def _eval_bend_twist_jacobian_guard_branches_kernel(errors: wp.array[wp.vec3]):
     tid = wp.tid()
     is_parent = tid % 2 == 0
 
-    # The first pair exercises capped curvature; the second pair exercises the
-    # exact-fold curvature convention and near-antiparallel twist fallback.
+    # Exercise capped curvature, the numerically directional twist path just
+    # outside an exact fold, and the exact-fold curvature/transport convention.
     angle = 3.05
-    if tid >= 2:
+    bend_axis = wp.vec3(1.0, 0.0, 0.0)
+    omega = wp.vec3(0.31, -0.27, 0.19)
+    if tid >= 4:
         angle = wp.pi
+    elif tid >= 2:
+        # 1 + cos(pi - 1e-3) ~= 5e-7: above the residual's Bishop fallback
+        # threshold. Y-bend/X-perturbation reproduces the strongest observed
+        # float32 tangent-bisector error.
+        angle = wp.pi - 1.0e-3
+        bend_axis = wp.vec3(0.0, 1.0, 0.0)
+        omega = wp.vec3(1.0, 0.0, 0.0)
 
     q_wp = wp.quat_identity()
-    q_wc = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), angle)
+    q_wc = wp.quat_from_axis_angle(bend_axis, angle)
     measure = _measure_cable_bend_twist_z(q_wp, q_wc)
-    omega = wp.vec3(0.31, -0.27, 0.19)
 
     d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(q_wp, measure, omega, is_parent)
     directional = wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
-    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(q_wp, measure, is_parent) * omega
-    errors[tid] = wp.length(jacobian_action - directional) / (1.0 + wp.length(directional))
+    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(measure, is_parent) * omega
+    directional_error = wp.length(jacobian_action - directional) / (1.0 + wp.length(directional))
+
+    fd_error = 0.0
+    fd_signal = 0.0
+    if tid >= 2 and tid < 4:
+        h = 1.0e-5
+        q_wp_p = q_wp
+        q_wp_m = q_wp
+        q_wc_p = q_wc
+        q_wc_m = q_wc
+        if is_parent:
+            q_wp_p = _quat_perturb_world(q_wp, omega, h)
+            q_wp_m = _quat_perturb_world(q_wp, omega, -h)
+        else:
+            q_wc_p = _quat_perturb_world(q_wc, omega, h)
+            q_wc_m = _quat_perturb_world(q_wc, omega, -h)
+
+        kb_rest_local = wp.quat_rotate(wp.quat_inverse(q_wp), measure.kb_world)
+        fd = (
+            compute_geometric_cable_kappa_cached_z(q_wp_p, q_wc_p, kb_rest_local, measure.twist)
+            - compute_geometric_cable_kappa_cached_z(q_wp_m, q_wc_m, kb_rest_local, measure.twist)
+        ) / (2.0 * h)
+        fd_error = wp.abs(jacobian_action[2] - fd[2]) / (1.0 + wp.abs(fd[2]))
+        fd_signal = wp.abs(fd[2])
+
+    # Store [Jacobian-vs-directional, near-fold twist-vs-FD, near-fold FD signal].
+    errors[tid] = wp.vec3(directional_error, fd_error, fd_signal)
 
 
 # DER-primitive unit tests: exercise the singular fallback paths and the
@@ -5842,14 +5876,24 @@ def _split_cable_bend_twist_deformation_derivative_matches_finite_difference(tes
 
 
 def _split_cable_bend_twist_jacobian_guard_branches_match_directional(test, device):
-    """Optimized Jacobian matches the directional reference in capped and singular branches."""
-    errors = wp.zeros(4, dtype=float, device=device)
-    wp.launch(_eval_bend_twist_jacobian_guard_branches_kernel, dim=4, outputs=[errors], device=device)
+    """Optimized Jacobian matches directional and finite-difference guard-branch references."""
+    errors = wp.zeros(6, dtype=wp.vec3, device=device)
+    wp.launch(_eval_bend_twist_jacobian_guard_branches_kernel, dim=6, outputs=[errors], device=device)
     errors_np = errors.numpy()
     test.assertLess(
-        float(np.max(errors_np)),
+        float(np.max(errors_np[:, 0])),
         5.0e-6,
         f"bend/twist Jacobian changed a capped or singular directional derivative: {errors_np}",
+    )
+    test.assertLess(
+        float(np.max(errors_np[2:4, 1])),
+        5.0e-4,
+        f"near-antiparallel twist Jacobian finite-difference mismatch: {errors_np}",
+    )
+    test.assertGreater(
+        float(np.min(errors_np[2:4, 2])),
+        100.0,
+        f"near-antiparallel twist finite-difference check is vacuous: {errors_np}",
     )
 
 

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -11,6 +11,7 @@ import newton
 from newton._src.solvers.vbd.rigid_vbd_kernels import (
     _bishop_transport_quat,
     _cable_bend_twist_directional_derivatives_from_measure,
+    _cable_bend_twist_jacobian_z_from_measure,
     _finite_curvature_binormal,
     _finite_curvature_binormal_derivative,
     _measure_cable_bend_twist_z,
@@ -4835,7 +4836,8 @@ def _eval_geometric_sharp_turn_kernel(errors: wp.array[wp.vec3]):
 @wp.kernel
 def _eval_bend_twist_deformation_derivative_kernel(errors: wp.array[wp.vec3]):
     tid = wp.tid()
-    is_parent = tid == 0
+    is_parent = tid < 3
+    axis_id = tid % 3
 
     # Pre-curved rest exercises the rest-relative composition in the derivative,
     # not just the identity-rest special case.
@@ -4848,15 +4850,16 @@ def _eval_bend_twist_deformation_derivative_kernel(errors: wp.array[wp.vec3]):
     q_wp = wp.quat_from_axis_angle(wp.normalize(wp.vec3(0.3, 0.7, -0.2)), 0.55) * q_wp_rest
     q_wc = wp.quat_from_axis_angle(wp.normalize(wp.vec3(-0.6, 0.2, 0.4)), 0.62) * q_wc_rest
 
-    omega = wp.vec3(0.21, -0.34, 0.27)
-    if not is_parent:
-        omega = wp.vec3(-0.18, 0.29, 0.2)
-    omega_len = wp.length(omega)
-    axis = omega / omega_len
+    axis = wp.vec3(1.0, 0.0, 0.0)
+    if axis_id == 1:
+        axis = wp.vec3(0.0, 1.0, 0.0)
+    elif axis_id == 2:
+        axis = wp.vec3(0.0, 0.0, 1.0)
 
     measure = _measure_cable_bend_twist_z(q_wp, q_wc)
-    d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(q_wp, measure, omega, is_parent)
-    analytic = wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
+    d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(q_wp, measure, axis, is_parent)
+    directional = wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
+    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(q_wp, measure, is_parent) * axis
 
     h = 1.0e-3
     q_wp_p = q_wp
@@ -4864,17 +4867,41 @@ def _eval_bend_twist_deformation_derivative_kernel(errors: wp.array[wp.vec3]):
     q_wc_p = q_wc
     q_wc_m = q_wc
     if is_parent:
-        q_wp_p = _quat_perturb_world(q_wp, axis, h * omega_len)
-        q_wp_m = _quat_perturb_world(q_wp, axis, -h * omega_len)
+        q_wp_p = _quat_perturb_world(q_wp, axis, h)
+        q_wp_m = _quat_perturb_world(q_wp, axis, -h)
     else:
-        q_wc_p = _quat_perturb_world(q_wc, axis, h * omega_len)
-        q_wc_m = _quat_perturb_world(q_wc, axis, -h * omega_len)
+        q_wc_p = _quat_perturb_world(q_wc, axis, h)
+        q_wc_m = _quat_perturb_world(q_wc, axis, -h)
 
     fd = (
         compute_geometric_cable_kappa_cached_z(q_wp_p, q_wc_p, kb_rest_local, rest.twist)
         - compute_geometric_cable_kappa_cached_z(q_wp_m, q_wc_m, kb_rest_local, rest.twist)
     ) / (2.0 * h)
-    errors[tid] = wp.vec3(wp.length(analytic - fd), wp.length(analytic), wp.length(fd))
+    equivalence_error = wp.length(jacobian_action - directional) / (1.0 + wp.length(directional))
+    # Store [Jacobian-vs-directional, Jacobian-vs-finite-difference, finite-difference signal].
+    errors[tid] = wp.vec3(equivalence_error, wp.length(jacobian_action - fd), wp.length(fd))
+
+
+@wp.kernel
+def _eval_bend_twist_jacobian_guard_branches_kernel(errors: wp.array[float]):
+    tid = wp.tid()
+    is_parent = tid % 2 == 0
+
+    # The first pair exercises capped curvature; the second pair exercises the
+    # exact-fold curvature convention and near-antiparallel twist fallback.
+    angle = 3.05
+    if tid >= 2:
+        angle = wp.pi
+
+    q_wp = wp.quat_identity()
+    q_wc = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), angle)
+    measure = _measure_cable_bend_twist_z(q_wp, q_wc)
+    omega = wp.vec3(0.31, -0.27, 0.19)
+
+    d_bend_local, d_twist = _cable_bend_twist_directional_derivatives_from_measure(q_wp, measure, omega, is_parent)
+    directional = wp.vec3(d_bend_local[0], d_bend_local[1], d_twist)
+    jacobian_action = _cable_bend_twist_jacobian_z_from_measure(q_wp, measure, is_parent) * omega
+    errors[tid] = wp.length(jacobian_action - directional) / (1.0 + wp.length(directional))
 
 
 # DER-primitive unit tests: exercise the singular fallback paths and the
@@ -5795,20 +5822,35 @@ def _split_cable_geometric_sharp_turn_is_bounded(test, device):
 
 
 def _split_cable_bend_twist_deformation_derivative_matches_finite_difference(test, device):
-    """Rest-relative bend/twist derivative should match centered finite differences.
+    """Verify the bend/twist Jacobian against directional and finite-difference references.
 
-    Uses a pre-curved rest and checks both parent and child world rotations, so it
-    guards the rest composition in the analytic Jacobian, not just the identity-rest
-    special case.
+    Uses a pre-curved rest and checks every world-axis column for both bodies, so
+    it guards the matrix assembly and rest composition independently.
     """
-    errors = wp.zeros(2, dtype=wp.vec3, device=device)
-    wp.launch(_eval_bend_twist_deformation_derivative_kernel, dim=2, outputs=[errors], device=device)
+    errors = wp.zeros(6, dtype=wp.vec3, device=device)
+    wp.launch(_eval_bend_twist_deformation_derivative_kernel, dim=6, outputs=[errors], device=device)
 
     errors_np = errors.numpy()
-    max_error = float(np.max(errors_np[:, 0]))
-    max_signal = float(np.max(errors_np[:, 1:]))
-    test.assertLess(max_error, 5.0e-4, f"bend/twist derivative finite-difference mismatch: {errors_np}")
-    test.assertGreater(max_signal, 0.05, f"bend/twist derivative test is vacuous: {errors_np}")
+    max_equivalence_error = float(np.max(errors_np[:, 0]))
+    max_finite_difference_error = float(np.max(errors_np[:, 1]))
+    min_signal = float(np.min(errors_np[:, 2]))
+    test.assertLess(max_equivalence_error, 5.0e-6, f"bend/twist Jacobian changed directional derivative: {errors_np}")
+    test.assertLess(
+        max_finite_difference_error, 5.0e-4, f"bend/twist derivative finite-difference mismatch: {errors_np}"
+    )
+    test.assertGreater(min_signal, 0.05, f"bend/twist derivative test has a vacuous Jacobian column: {errors_np}")
+
+
+def _split_cable_bend_twist_jacobian_guard_branches_match_directional(test, device):
+    """Optimized Jacobian matches the directional reference in capped and singular branches."""
+    errors = wp.zeros(4, dtype=float, device=device)
+    wp.launch(_eval_bend_twist_jacobian_guard_branches_kernel, dim=4, outputs=[errors], device=device)
+    errors_np = errors.numpy()
+    test.assertLess(
+        float(np.max(errors_np)),
+        5.0e-6,
+        f"bend/twist Jacobian changed a capped or singular directional derivative: {errors_np}",
+    )
 
 
 def _split_cable_dahl_full_step_state_stays_in_active_subspace(test, device):
@@ -6143,6 +6185,12 @@ add_function_test(
     TestCable,
     "test_split_cable_bend_twist_deformation_derivative_matches_finite_difference",
     _split_cable_bend_twist_deformation_derivative_matches_finite_difference,
+    devices=devices,
+)
+add_function_test(
+    TestCable,
+    "test_split_cable_bend_twist_jacobian_guard_branches_match_directional",
+    _split_cable_bend_twist_jacobian_guard_branches_match_directional,
     devices=devices,
 )
 add_function_test(

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -5876,7 +5876,7 @@ def _split_cable_bend_twist_deformation_derivative_matches_finite_difference(tes
 
 
 def _split_cable_bend_twist_jacobian_guard_branches_match_directional(test, device):
-    """Optimized Jacobian matches directional and finite-difference guard-branch references."""
+    """Verify the guard-branch Jacobian against directional and finite-difference references."""
     errors = wp.zeros(6, dtype=wp.vec3, device=device)
     wp.launch(_eval_bend_twist_jacobian_guard_branches_kernel, dim=6, outputs=[errors], device=device)
     errors_np = errors.numpy()


### PR DESCRIPTION
## Description

- Assemble the cable bend Jacobian directly to avoid repeated directional evaluations.
- Use the fast closed-form twist Jacobian normally and a residual-consistent directional evaluation near folds.
- Add CPU/CUDA coverage for all Jacobian columns, capped curvature, near-antiparallel geometry, exact folds, and finite differences.
- Correct cable documentation to describe four VBD material slots: stretch, shear, bend, and twist.
- This is clean up/follow up #3122; no math or API change. 

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cable joint bend and twist calculations for more accurate behavior across orientations, including near-fold configurations.
  - Enhanced force and constraint evaluation consistency for cable motion.

- **Documentation**
  - Clarified that cable joints use four material slots covering stretch, shear, bend, and twist.
  - Updated joint references and API documentation to distinguish these slots from generalized degrees of freedom.

- **Tests**
  - Expanded coverage for cable Jacobians, finite-difference accuracy, curvature limits, and near-fold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->