### PR TITLE
[Kamino] remove default model contact cap

### DIFF
--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -74,13 +74,6 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 # Constants
 ###
 
-DEFAULT_MODEL_MAX_CONTACTS: int = 1000
-"""
-The global default for maximum number of contacts per model.
-Used when allocating contact data without a specified capacity.
-Set to `1000`.
-"""
-
 DEFAULT_WORLD_MAX_CONTACTS: int = 128
 """
 The global default for maximum number of contacts per world.

--- a/newton/_src/solvers/kamino/_src/geometry/detector.py
+++ b/newton/_src/solvers/kamino/_src/geometry/detector.py
@@ -220,7 +220,7 @@ def _resolve_contact_capacity(
         world_max_contacts = _estimate_fallback_world_max_contacts(model, config)
 
     model_max_contacts = sum(world_max_contacts)
-    if model_max_contacts > config.max_contacts:
+    if config.max_contacts is not None and model_max_contacts > config.max_contacts:
         world_max_contacts = _cap_world_contacts_at_total(world_max_contacts, config.max_contacts)
         model_max_contacts = sum(world_max_contacts)
 

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -104,7 +104,7 @@ class CollisionDetectorConfig(ConfigBase):
     initialization.\n
     When ``max_contacts_per_world`` is None, the geometry-based estimate is
     capped at this value; otherwise this field is ignored.\n
-    Defaults to ``DEFAULT_MODEL_MAX_CONTACTS`` (``1000``) if unspecified.
+    Defaults to ``None``, leaving the geometry-based estimate uncapped.
     """
 
     max_contacts_per_world: int | None = None
@@ -181,7 +181,6 @@ class CollisionDetectorConfig(ConfigBase):
         from ._src.geometry.contacts import (  # noqa: PLC0415
             DEFAULT_GEOM_PAIR_CONTACT_GAP,
             DEFAULT_GEOM_PAIR_MAX_CONTACTS,
-            DEFAULT_MODEL_MAX_CONTACTS,
             DEFAULT_TRIANGLE_MAX_PAIRS,
         )
 
@@ -209,8 +208,6 @@ class CollisionDetectorConfig(ConfigBase):
             raise ValueError(f"Invalid max_triangle_pairs: {self.max_triangle_pairs}. Must be non-negative.")
 
         # Check if optional arguments are specified and override with defaults if not
-        if self.max_contacts is None:
-            self.max_contacts = DEFAULT_MODEL_MAX_CONTACTS
         if self.max_contacts_per_pair is None:
             self.max_contacts_per_pair = DEFAULT_GEOM_PAIR_MAX_CONTACTS
         if self.max_triangle_pairs is None:

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -777,6 +777,8 @@ class SolverKamino(SolverBase, CouplingInterface):
         self._contacts_kamino = None
         if self._collision_detector_kamino is not None:
             self._contacts_kamino = self._collision_detector_kamino.contacts
+            # Keep Newton's externally allocated contact buffer in sync with Kamino.
+            model.rigid_contact_max = self._contacts_kamino.model_max_contacts_host
         else:
             # If collision detector is disabled allocate contacts based on the capacity estimate from the Newton CollisionPipeline.
             world_count = self.model.world_count

--- a/newton/_src/solvers/kamino/tests/test_geometry_detector.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_detector.py
@@ -235,10 +235,10 @@ class TestCollisionDetectorContactCapacity(unittest.TestCase):
         self.assertEqual(world_max[0], world_max[1])
 
     def test_02_resolve_contact_capacity_uses_pair_metadata(self):
-        """Verify resolved budgets match pair-based metadata when available."""
+        """Verify the default resolved budget matches pair-based metadata."""
         builder = basics.build_boxes_nunchaku()
         model = builder.finalize(self.default_device)
-        config = CollisionDetector.Config(max_contacts=10_000)
+        config = CollisionDetector.Config()
 
         model_max, world_max = _resolve_contact_capacity(model, config)
         self.assertEqual(world_max, model.geoms.world_minimum_contacts)

--- a/newton/_src/solvers/kamino/tests/test_geometry_unified.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_unified.py
@@ -442,19 +442,19 @@ class TestCollisionPipelineUnified(unittest.TestCase):
             "bid_AB": np.tile(np.array([0, 1], dtype=np.int32), reps=(4, 1)),
             "position_A": np.array(
                 [
+                    [-0.5, 0.5, 0.5 * abs(distance)],
                     [-0.5, -0.5, 0.5 * abs(distance)],
                     [0.5, -0.5, 0.5 * abs(distance)],
                     [0.5, 0.5, 0.5 * abs(distance)],
-                    [-0.5, 0.5, 0.5 * abs(distance)],
                 ],
                 dtype=np.float32,
             ),
             "position_B": np.array(
                 [
+                    [-0.5, 0.5, -0.5 * abs(distance)],
                     [-0.5, -0.5, -0.5 * abs(distance)],
                     [0.5, -0.5, -0.5 * abs(distance)],
                     [0.5, 0.5, -0.5 * abs(distance)],
-                    [-0.5, 0.5, -0.5 * abs(distance)],
                 ],
                 dtype=np.float32,
             ),

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -421,6 +421,16 @@ class TestCollisionCapacityInitialization(unittest.TestCase):
         # Kamino's capacity should be at least as large as the pipeline's capacity. Due to rounding up to the nearest multiple of the world count.
         self.assertGreaterEqual(solver._contacts_kamino.model_max_contacts_host, pipeline.rigid_contact_max)
 
+    def test_internal_collision_capacity_updates_model(self):
+        """Verify internal collision capacity updates the Newton model."""
+        model = self._make_three_world_model()
+
+        solver = SolverKamino(model, config=SolverKamino.Config(use_collision_detector=True))
+        pipeline = newton.CollisionPipeline(model)
+
+        self.assertEqual(model.rigid_contact_max, solver._contacts_kamino.model_max_contacts_host)
+        self.assertEqual(pipeline.rigid_contact_max, solver._contacts_kamino.model_max_contacts_host)
+
     def test_external_collisions_preserve_explicit_rigid_contact_max(self):
         """Verify external collisions preserve an explicit contact capacity."""
         model = self._make_three_world_model()


### PR DESCRIPTION
## Description

Removes the default model contact capacity limit. The default max of 1000 contacts prevented out-of-the box scaling to multi world scenarios. Instead we should just rely on the geometry based capacity estimate. 

Also writes back the estimated capacity to the model. This will be used downstream to determine the Newton contact buffer that is used to write results to.

Fixes https://github.com/newton-physics/newton/issues/3834.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collision contact-capacity handling when no maximum is configured.
  - Synchronized contact capacity across collision detection and solver components.
  - Preserved geometry-based capacity estimates without imposing an unintended default limit.
  - Corrected contact-point ordering expectations for box collisions.

- **Tests**
  - Added coverage for dynamically synchronized collision capacity.
  - Updated tests for uncapped default capacity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->