### PR TITLE
Pin asv_runner<0.3.0 in benchmark install_command

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,6 +17,7 @@
   "install_command": [
     "in-dir={env_dir} python -m pip install {wheel_file}[dev] --extra-index-url=https://pypi.nvidia.com/",
     "in-dir={env_dir} python -m pip install warp-lang==1.17.0.dev20260807 mujoco==3.11.0 mujoco-warp==3.11.0 --extra-index-url=https://pypi.nvidia.com/",
-    "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130"
+    "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
+    "python -m pip install 'asv_runner<0.3.0'"
   ]
 }


### PR DESCRIPTION
## Description

`asv_runner` 0.3.0 re-runs `setup()` before every timed call instead of amortizing it over the `number` loop. Benchmarks that pin `number = 1` (nearly all of ours) are unaffected, but `NotifyDRLegs` pairs an expensive `setup()` with `number = 10`, so on the nightly Jetson runs each of its eight methods jumped ~24s -> ~215s (~194s -> ~1719s for the family, ~9x). The PR benchmark gate is unaffected — its Fast\* benches use `number = 1` / `setup_cache()`.

The actual per-benchmark fix (`NotifyDRLegs` -> `number = 1`, `warmup_time = 0`) is being handled separately. This just adds a floor so we don't silently pull 0.3.0 again on the next env rebuild: asv installs `asv_runner` unpinned as a base requirement at env-setup time, so the pin has to live in `install_command` (which runs afterward, during `install_project`) — `uv.lock` / `pyproject` don't cover the benchmark envs.

Came out of the asv_runner `setup()` thread in #newton-dev.

## Checklist

- [ ] New or existing tests cover these changes (config-only)
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added (n/a — not user-facing)

## Test plan

Config-only. Checked the pin is well-formed and actually takes effect:
- `asv_runner<0.3.0` resolves to 0.2.1 (last pre-0.3 release).
- asv tokenizes `install_command` with `shlex.split` (`asv/util.py:interpolate_command`) and runs each step via `run_executable` (no shell), so `<` reaches pip literally, not as a redirect.
- `install_command` runs during `install_project`, after asv installs its unpinned `asv_runner` base requirement at env setup, so this final step downgrades it to <0.3.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the benchmarking environment setup to install a compatible version of the benchmarking runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->