### PR TITLE
Decouple ASV tests from installed package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           --junit-report-xml rspec.xml
           --coverage
           --coverage-xml coverage.xml
+      - name: Run ASV benchmark tests
+        run: uv run --no-sync -m unittest discover -s asv/tests
       - name: Test Summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           --junit-report-xml rspec.xml
           --coverage
           --coverage-xml coverage.xml
-      - name: Run ASV benchmark tests
+      - name: Run ASV harness unit tests
         run: >
           uv run --no-sync -m newton.tests
           --strict-warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,11 +150,18 @@ jobs:
           --coverage
           --coverage-xml coverage.xml
       - name: Run ASV benchmark tests
-        run: uv run --no-sync -m unittest discover -s asv/tests
+        run: >
+          uv run --no-sync -m newton.tests
+          --strict-warnings
+          --no-cache-clear
+          --start-directory asv/tests
+          --junit-report-xml asv-rspec.xml
       - name: Test Summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
-          paths: "rspec.xml"
+          paths: |
+            rspec.xml
+            asv-rspec.xml
           show: "fail"
         if: always()
       - name: Upload test results artifact
@@ -162,7 +169,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-${{ matrix.os }}
-          path: rspec.xml
+          path: |
+            rspec.xml
+            asv-rspec.xml
           retention-days: 1
           overwrite: true
       - name: Upload coverage artifact
@@ -219,6 +228,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github
+            asv/tests
             newton
       - name: Download test results artifact
         id: download-test-results
@@ -237,7 +247,7 @@ jobs:
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
         with:
           disable_search: true
-          files: ./rspec.xml
+          files: ./rspec.xml,./asv-rspec.xml
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov

--- a/asv/benchmarks/benchmark_metric_tracks.py
+++ b/asv/benchmarks/benchmark_metric_tracks.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import warp as wp
+from asv_runner.benchmarks.mark import skip_benchmark_if
+
+
+class _SimulationMetricTracks:
+    """ASV track methods backed by cached simulation metrics."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulate(self, metrics, world_count):
+        return metrics[world_count].mean_world_step_time_ms
+
+    track_simulate.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics, world_count):
+        return metrics[world_count].world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics, world_count):
+        return metrics[world_count].real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics, world_count):
+        return metrics[world_count].p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics, world_count):
+        return metrics[world_count].gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics, world_count):
+        return metrics[world_count].sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics, world_count):
+        return metrics[world_count].sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"
+
+
+class _SimulationMetricTracksUnparameterized:
+    """ASV track methods backed by one cached simulation configuration."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_mean_world_step_time(self, metrics):
+        return metrics.mean_world_step_time_ms
+
+    track_mean_world_step_time.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics):
+        return metrics.world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics):
+        return metrics.real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics):
+        return metrics.p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics):
+        return metrics.gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics):
+        return metrics.sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics):
+        return metrics.sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import numpy as np
 import warp as wp
-from asv_runner.benchmarks.mark import skip_benchmark_if
 
 
 @dataclass(frozen=True)
@@ -25,98 +24,6 @@ class SimulationMetrics:
     sim_substeps: int
     solver_niter_mean: float | None = None
     solver_niter_max: float | None = None
-
-
-class _SimulationMetricTracks:
-    """ASV track methods backed by cached simulation metrics."""
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulate(self, metrics, world_count):
-        return metrics[world_count].mean_world_step_time_ms
-
-    track_simulate.unit = "ms/world-step"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulation_steps_per_second(self, metrics, world_count):
-        return metrics[world_count].world_steps_per_second
-
-    track_simulation_steps_per_second.unit = "world-steps/s"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_real_time_factor(self, metrics, world_count):
-        return metrics[world_count].real_time_factor
-
-    track_real_time_factor.unit = "x"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_p95_step_time(self, metrics, world_count):
-        return metrics[world_count].p95_frame_time_ms
-
-    track_p95_step_time.unit = "ms/frame"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_steady_state_gpu_memory(self, metrics, world_count):
-        return metrics[world_count].gpu_memory_mib
-
-    track_steady_state_gpu_memory.unit = "MiB"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_sim_dt(self, metrics, world_count):
-        return metrics[world_count].sim_dt
-
-    track_sim_dt.unit = "s"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_sim_substeps(self, metrics, world_count):
-        return metrics[world_count].sim_substeps
-
-    track_sim_substeps.unit = "simulation-steps/frame"
-
-
-class _SimulationMetricTracksUnparameterized:
-    """ASV track methods backed by one cached simulation configuration."""
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_mean_world_step_time(self, metrics):
-        return metrics.mean_world_step_time_ms
-
-    track_mean_world_step_time.unit = "ms/world-step"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulation_steps_per_second(self, metrics):
-        return metrics.world_steps_per_second
-
-    track_simulation_steps_per_second.unit = "world-steps/s"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_real_time_factor(self, metrics):
-        return metrics.real_time_factor
-
-    track_real_time_factor.unit = "x"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_p95_step_time(self, metrics):
-        return metrics.p95_frame_time_ms
-
-    track_p95_step_time.unit = "ms/frame"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_steady_state_gpu_memory(self, metrics):
-        return metrics.gpu_memory_mib
-
-    track_steady_state_gpu_memory.unit = "MiB"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_sim_dt(self, metrics):
-        return metrics.sim_dt
-
-    track_sim_dt.unit = "s"
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_sim_substeps(self, metrics):
-        return metrics.sim_substeps
-
-    track_sim_substeps.unit = "simulation-steps/frame"
 
 
 def compute_simulation_metrics(

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -13,8 +13,8 @@ wp.config.log_level = wp.LOG_WARNING
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
+from benchmark_metric_tracks import _SimulationMetricTracksUnparameterized
 from benchmark_metrics import (
-    _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
     validate_simulation_state,
 )

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -14,9 +14,8 @@ wp.config.log_level = wp.LOG_WARNING
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
+from benchmark_metric_tracks import _SimulationMetricTracks, _SimulationMetricTracksUnparameterized
 from benchmark_metrics import (
-    _SimulationMetricTracks,
-    _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
 )
 

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -19,10 +19,8 @@ from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
-from benchmark_metrics import (
-    _SimulationMetricTracks,
-    collect_simulation_metrics,
-)
+from benchmark_metric_tracks import _SimulationMetricTracks
+from benchmark_metrics import collect_simulation_metrics
 
 
 class _SimulationMetricTracksMuJoCo(_SimulationMetricTracks):

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -13,8 +13,8 @@ wp.config.log_level = wp.LOG_WARNING
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
+from benchmark_metric_tracks import _SimulationMetricTracksUnparameterized
 from benchmark_metrics import (
-    _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
     validate_simulation_state,
 )

--- a/asv/tests/__init__.py
+++ b/asv/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0

--- a/asv/tests/test_benchmark_metrics.py
+++ b/asv/tests/test_benchmark_metrics.py
@@ -213,5 +213,6 @@ class TestBenchmarkMetrics(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "state.joint_qd"):
             validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/asv/tests/test_benchmark_metrics.py
+++ b/asv/tests/test_benchmark_metrics.py
@@ -4,14 +4,11 @@
 import sys
 import unittest
 from pathlib import Path
-from typing import ClassVar
 from unittest.mock import patch
 
 import numpy as np
 
-from newton.utils import run_benchmark
-
-BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+BENCHMARK_DIR = Path(__file__).parents[1] / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
 
 from benchmark_metrics import (  # noqa: E402
@@ -215,45 +212,6 @@ class TestBenchmarkMetrics(unittest.TestCase):
         FakeState.joint_qd = FakeArray([np.nan])
         with self.assertRaisesRegex(RuntimeError, "state.joint_qd"):
             validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
-
-    def test_run_benchmark_with_setup_cache(self):
-        """Pass one setup cache through the full benchmark lifecycle."""
-        cache_events = []
-
-        class CachedBenchmark:
-            params: ClassVar = [[2, 3]]
-            setup_cache_calls = 0
-            cache_value: ClassVar = {"base": 10}
-
-            def setup_cache(self):
-                type(self).setup_cache_calls += 1
-                return self.cache_value
-
-            def setup(self, cache, value):
-                cache_events.append(("setup", cache, value))
-
-            def time_value(self, cache, value):
-                cache_events.append(("time", cache, value))
-
-            def track_value(self, cache, value):
-                cache_events.append(("track", cache, value))
-                return cache["base"] + value
-
-            def teardown(self, cache, value):
-                cache_events.append(("teardown", cache, value))
-
-        results = run_benchmark(CachedBenchmark, print_results=False)
-
-        self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
-        self.assertTrue(all(cache is CachedBenchmark.cache_value for _, cache, _ in cache_events))
-        self.assertEqual([event for event, _, _ in cache_events].count("setup"), 2)
-        self.assertEqual([event for event, _, _ in cache_events].count("time"), 4)
-        self.assertEqual([event for event, _, _ in cache_events].count("track"), 2)
-        self.assertEqual([event for event, _, _ in cache_events].count("teardown"), 2)
-        self.assertEqual({value for _, _, value in cache_events}, {2, 3})
-        self.assertEqual(results[("track_value", (2,))], 12)
-        self.assertEqual(results[("track_value", (3,))], 13)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/asv/tests/test_benchmark_simulation.py
+++ b/asv/tests/test_benchmark_simulation.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import warp as wp
 
-BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+BENCHMARK_DIR = Path(__file__).parents[1] / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
 
 _WARP_CONFIG_FIELDS = ("enable_backward", "log_level")

--- a/changelog/+installed-test-discovery-a4c8f1d2.fixed.md
+++ b/changelog/+installed-test-discovery-a4c8f1d2.fixed.md
@@ -1,0 +1,1 @@
+Prevent installed test discovery from importing repository-only ASV modules.

--- a/newton/tests/test_run_benchmark.py
+++ b/newton/tests/test_run_benchmark.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from typing import ClassVar
+
+from newton.utils import run_benchmark
+
+
+class TestRunBenchmark(unittest.TestCase):
+    def test_run_benchmark_with_setup_cache(self):
+        """Pass one setup cache through the full benchmark lifecycle."""
+        cache_events = []
+
+        class CachedBenchmark:
+            params: ClassVar = [[2, 3]]
+            setup_cache_calls = 0
+            cache_value: ClassVar = {"base": 10}
+
+            def setup_cache(self):
+                type(self).setup_cache_calls += 1
+                return self.cache_value
+
+            def setup(self, cache, value):
+                cache_events.append(("setup", cache, value))
+
+            def time_value(self, cache, value):
+                cache_events.append(("time", cache, value))
+
+            def track_value(self, cache, value):
+                cache_events.append(("track", cache, value))
+                return cache["base"] + value
+
+            def teardown(self, cache, value):
+                cache_events.append(("teardown", cache, value))
+
+        results = run_benchmark(CachedBenchmark, print_results=False)
+
+        self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
+        self.assertTrue(all(cache is CachedBenchmark.cache_value for _, cache, _ in cache_events))
+        self.assertEqual([event for event, _, _ in cache_events].count("setup"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("time"), 4)
+        self.assertEqual([event for event, _, _ in cache_events].count("track"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("teardown"), 2)
+        self.assertEqual({value for _, _, value in cache_events}, {2, 3})
+        self.assertEqual(results[("track_value", (2,))], 12)
+        self.assertEqual(results[("track_value", (3,))], 13)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Move benchmark-specific tests out of the installed `newton.tests` package and
run them directly from `asv/tests` in source CI. This prevents wheel test
discovery from importing repository-only ASV modules that are intentionally
not packaged.

Separate the ASV `track_*` adapters from metric computation, collection, and
simulation-state validation. Keep the `newton.utils.run_benchmark` cache
lifecycle contract test in `newton.tests` because it covers shipped package
functionality.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md) (not user-facing)

## Test plan

```text
uv run --extra dev -m unittest discover -s asv/tests -v
python -m unittest newton.tests.test_run_benchmark -v
asv check
uv build
uvx --python 3.12 pre-commit run -a
```

The rebuilt wheel was installed into an isolated environment and exercised
through `python -m newton.tests`; full discovery completed without the former
benchmark-module import errors, and all 45 selected tests passed.

## Bug fix

**Steps to reproduce:**

1. Build the wheel with `uv build`.
2. Install it into an environment with Newton's test dependencies.
3. Run `python -m newton.tests`.
4. Observe `ModuleNotFoundError: No module named 'benchmark_metrics'` while
   discovering `test_benchmark_metrics` and `test_benchmark_simulation`.

**Minimal reproduction:**

```text
python -m newton.tests -k benchmark_metrics
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Added automated benchmark execution to continuous integration, including test reports, coverage, and downloadable artifacts.
  * Added coverage for benchmark setup-cache behavior and lifecycle handling.
  * Updated benchmark tests for the current repository layout.
* **Benchmarking**
  * Added simulation metrics for timing, throughput, frame times, GPU memory, timestep, and substeps.
  * Metrics are skipped automatically when CUDA is unavailable.
* **Maintenance**
  * Improved installed test discovery and benchmark component organization.
  * Added licensing headers to benchmark test support files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->