### PR TITLE
Fix distance-dependent drift in the free-joint analytic IK Jacobian

### DIFF
--- a/changelog/+free-joint-analytic-jacobian-3f214af5.fixed.md
+++ b/changelog/+free-joint-analytic-jacobian-3f214af5.fixed.md
@@ -1,0 +1,1 @@
+Fixed distance-dependent drift in the floating-base free-joint analytic IK Jacobian (regression from PR #2539); the analytic motion subspace now matches AUTODIFF regardless of world position.

--- a/newton/_src/sim/articulation.py
+++ b/newton/_src/sim/articulation.py
@@ -934,7 +934,6 @@ def eval_ik(
 @wp.func
 def write_free_distance_motion_subspace(
     X_pa_world: wp.transform,
-    x_child_com_world: wp.vec3,
     qd_start: int,
     # outputs
     joint_S_s: wp.array[wp.spatial_vector],
@@ -944,7 +943,7 @@ def write_free_distance_motion_subspace(
     Used by both the Featherstone inverse-dynamics path (``jcalc_motion``) and
     the IK/Jacobian path (``jcalc_motion_subspace``) so they agree on the exact
     column layout. Linear DOFs act at the child body's COM; angular DOFs are
-    world-aligned axes expressed through ``X_pa_world``.
+    world-aligned axes referenced to the fixed parent anchor.
 
     Args:
         X_pa_world: Parent-anchor world transform (``X_wp * joint_X_p``) used
@@ -952,7 +951,6 @@ def write_free_distance_motion_subspace(
             This is *not* the classical Featherstone ``X_sc`` (spatial-to-
             child); Newton's FREE/DISTANCE joint coordinates live in the
             parent-anchor basis.
-        x_child_com_world: World-space position of the child body's COM.
         qd_start: Starting velocity-DOF index for this joint.
         joint_S_s: Output spatial-vector subspace array; six slots starting at
             ``qd_start`` are overwritten.
@@ -960,13 +958,14 @@ def write_free_distance_motion_subspace(
     axis_world_x = wp.transform_vector(X_pa_world, wp.vec3(1.0, 0.0, 0.0))
     axis_world_y = wp.transform_vector(X_pa_world, wp.vec3(0.0, 1.0, 0.0))
     axis_world_z = wp.transform_vector(X_pa_world, wp.vec3(0.0, 0.0, 1.0))
+    x_anchor_world = wp.transform_get_translation(X_pa_world)
 
     joint_S_s[qd_start + 0] = wp.spatial_vector(axis_world_x, wp.vec3())
     joint_S_s[qd_start + 1] = wp.spatial_vector(axis_world_y, wp.vec3())
     joint_S_s[qd_start + 2] = wp.spatial_vector(axis_world_z, wp.vec3())
-    joint_S_s[qd_start + 3] = wp.spatial_vector(-wp.cross(axis_world_x, x_child_com_world), axis_world_x)
-    joint_S_s[qd_start + 4] = wp.spatial_vector(-wp.cross(axis_world_y, x_child_com_world), axis_world_y)
-    joint_S_s[qd_start + 5] = wp.spatial_vector(-wp.cross(axis_world_z, x_child_com_world), axis_world_z)
+    joint_S_s[qd_start + 3] = wp.spatial_vector(-wp.cross(axis_world_x, x_anchor_world), axis_world_x)
+    joint_S_s[qd_start + 4] = wp.spatial_vector(-wp.cross(axis_world_y, x_anchor_world), axis_world_y)
+    joint_S_s[qd_start + 5] = wp.spatial_vector(-wp.cross(axis_world_z, x_anchor_world), axis_world_z)
 
 
 @wp.func
@@ -1066,8 +1065,7 @@ def jcalc_motion_subspace(
         joint_S_s[qd_start + 2] = S_2
 
     elif joint_type_value == JointType.FREE or joint_type_value == JointType.DISTANCE:
-        x_child_com_world = wp.transform_point(X_wc, body_com_child)
-        write_free_distance_motion_subspace(X_pa_world, x_child_com_world, qd_start, joint_S_s)
+        write_free_distance_motion_subspace(X_pa_world, qd_start, joint_S_s)
 
 
 @wp.kernel

--- a/newton/tests/test_ik.py
+++ b/newton/tests/test_ik.py
@@ -163,6 +163,21 @@ def _build_descendant_free_distance(device, joint_type) -> tuple[newton.Model, i
     return builder.finalize(device=device, requires_grad=True), child
 
 
+def _build_root_free_distance(device, joint_type) -> tuple[newton.Model, int]:
+    builder = newton.ModelBuilder()
+    body = builder.add_link(mass=1.0)
+    joint = _add_free_distance_joint(
+        builder=builder,
+        joint_type=joint_type,
+        parent=-1,
+        child=body,
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([joint])
+    return builder.finalize(device=device, requires_grad=True), body
+
+
 # ----------------------------------------------------------------------------
 # helpers - D6
 # ----------------------------------------------------------------------------
@@ -711,6 +726,46 @@ def test_d6_jacobian_compare(test, device):
     _jacobian_compare(test, device, _d6_objective_builder)
 
 
+def test_free_distance_translated_jacobian_compare(test, device, joint_type):
+    """Match analytic and autodiff Jacobians for a translated floating body."""
+    with wp.ScopedDevice(device):
+        translations = (0.0, 1.0, 5.0, 20.0)
+        model, body = _build_root_free_distance(device, joint_type)
+        joint_q = np.zeros((len(translations), model.joint_coord_count), dtype=np.float32)
+        joint_q[:, 0] = translations
+        joint_q[:, 6] = 1.0
+        target_positions = wp.zeros(len(translations), dtype=wp.vec3, device=device)
+
+        solver_auto = ik.IKSolver(
+            model,
+            len(translations),
+            [ik.IKObjectivePosition(body, wp.vec3(), target_positions)],
+            jacobian_mode=ik.IKJacobianType.AUTODIFF,
+        )
+        solver_ana = ik.IKSolver(
+            model,
+            len(translations),
+            [ik.IKObjectivePosition(body, wp.vec3(), target_positions)],
+            jacobian_mode=ik.IKJacobianType.ANALYTIC,
+        )
+        q_auto = wp.array(joint_q, device=device, requires_grad=True)
+        q_ana = wp.array(joint_q, device=device)
+
+        solver_auto._impl._compute_residuals(q_auto)
+        solver_ana._impl._compute_residuals(q_ana)
+        jacobian_auto = solver_auto._impl._jacobian_at(solver_auto._impl._ctx_solver(q_auto)).numpy()
+        jacobian_ana = solver_ana._impl._jacobian_at(solver_ana._impl._ctx_solver(q_ana)).numpy()
+
+        for problem_idx, translation in enumerate(translations):
+            with test.subTest(translation=translation):
+                assert_np_equal(jacobian_auto[problem_idx], jacobian_ana[problem_idx], tol=1e-4)
+
+        motion_subspace = solver_ana._impl.joint_S_s.numpy()
+        for problem_idx, translation in enumerate(translations[1:], start=1):
+            with test.subTest(motion_subspace_translation=translation):
+                assert_np_equal(motion_subspace[0], motion_subspace[problem_idx], tol=1e-6)
+
+
 # ----------------------------------------------------------------------------
 # 3.  Test-class registration per device
 # ----------------------------------------------------------------------------
@@ -761,6 +816,14 @@ add_function_test(TestIKModes, "test_position_jacobian_compare", test_position_j
 add_function_test(TestIKModes, "test_rotation_jacobian_compare", test_rotation_jacobian_compare, cuda_devices)
 add_function_test(TestIKModes, "test_joint_limit_jacobian_compare", test_joint_limit_jacobian_compare, devices)
 add_function_test(TestIKModes, "test_d6_jacobian_compare", test_d6_jacobian_compare, cuda_devices)
+for joint_type in (newton.JointType.FREE, newton.JointType.DISTANCE):
+    add_function_test(
+        TestIKModes,
+        f"test_translated_{_joint_type_name(joint_type)}_jacobian_compare",
+        test_free_distance_translated_jacobian_compare,
+        devices,
+        joint_type=joint_type,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes distance-dependent drift in the floating-base free-joint analytic IK Jacobian, a regression from #2539.

#2539 (commit `250fae60`) rewrote the FREE/DISTANCE analytic motion subspace (`write_free_distance_motion_subspace` in `newton/_src/sim/articulation.py`) so the angular DOFs' rotation-to-translation coupling is taken about the **child body COM in world coordinates**. Because the child COM travels with the body, the `-cross(axis_world, x_child_com_world)` terms gain a spurious contribution proportional to the base's world position, so the analytic Jacobian's rotation-to-translation block is wrong by an amount that scales with distance from the origin. Floating-base `ANALYTIC`-mode IK therefore drifts the farther the body is from the origin (~150 mm observed on a traveling clip); in-place solves at the origin are fine, and `AUTODIFF` mode is correct throughout.

This PR references the **fixed parent-joint anchor** (`wp.transform_get_translation(X_pa_world)`) instead of the traveling child COM, restoring origin-invariant coupling. It preserves the public world-frame twist convention introduced by #2539, so the analytic motion subspace now matches AUTODIFF at any world position. The change is ~14 lines in `articulation.py` plus direct analytic-vs-AUTODIFF regression coverage in `test_ik.py`.

Closes #3866

> **Regression / 1.5 release candidate:** this bug is present in **1.4.0** and still in **1.5.0rc2**, so this is a candidate for the **1.5 release**. Could a maintainer consider cherry-picking it onto `release-1.5` as part of the backport?

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

New tests add direct analytic-vs-AUTODIFF IK Jacobian coverage for a translated floating body (both `FREE` and `DISTANCE`) at 0 / 1 / 5 / 20 m, and assert the root motion subspace is translation-invariant.

```
uv run --extra dev -m newton.tests -k ik
uv run --extra dev -m newton.tests -k featherstone
```

Verified on an NVIDIA RTX PRO 6000 (Blackwell) GPU:

- `-k ik`: **160 passed** (3 skipped), including the new `test_translated_free_jacobian_compare` and `test_translated_distance_jacobian_compare` on both CPU and CUDA.
- `-k featherstone`: **274 passed**.
- New analytic-vs-AUTODIFF tests: max abs Jacobian error is **exactly 0.0** at translations 0 / 1 / 5 / 20 m (was growing with distance before the fix).
- A warm-started traveling sweep that drifted ~**150 mm** in ANALYTIC mode now tracks AUTODIFF to **~2e-6 m**.

## Bug fix

**Steps to reproduce:**

1. Build a model with a single root `FREE` joint (identity parent/child anchors).
2. Set the joint translation to increasing world positions (0, 1, 5, 20 m) with an identity orientation.
3. Build two `IKSolver`s over an `IKObjectivePosition` on that body: one `AUTODIFF`, one `ANALYTIC`.
4. Compute and compare each solver's Jacobian. Without this PR, the max abs difference is ~0 at translation 0 and grows with translation.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp
import newton
import newton.ik as ik

device = "cuda:0"

with wp.ScopedDevice(device):
    builder = newton.ModelBuilder()
    body = builder.add_link(mass=1.0)
    joint = builder.add_joint_free(
        parent=-1,
        child=body,
        parent_xform=wp.transform_identity(),
        child_xform=wp.transform_identity(),
    )
    builder.add_articulation([joint])
    model = builder.finalize(device=device, requires_grad=True)

    translations = (0.0, 1.0, 5.0, 20.0)
    joint_q = np.zeros((len(translations), model.joint_coord_count), dtype=np.float32)
    joint_q[:, 0] = translations   # translate the base along +x
    joint_q[:, 6] = 1.0            # identity quaternion (w = 1)

    targets = wp.zeros(len(translations), dtype=wp.vec3, device=device)
    objectives = [ik.IKObjectivePosition(body, wp.vec3(), targets)]

    solver_auto = ik.IKSolver(model, len(translations), objectives,
                              jacobian_mode=ik.IKJacobianType.AUTODIFF)
    solver_ana = ik.IKSolver(model, len(translations), objectives,
                             jacobian_mode=ik.IKJacobianType.ANALYTIC)

    q_auto = wp.array(joint_q, device=device, requires_grad=True)
    q_ana = wp.array(joint_q, device=device)
    solver_auto._impl._compute_residuals(q_auto)
    solver_ana._impl._compute_residuals(q_ana)
    J_auto = solver_auto._impl._jacobian_at(solver_auto._impl._ctx_solver(q_auto)).numpy()
    J_ana = solver_ana._impl._jacobian_at(solver_ana._impl._ctx_solver(q_ana)).numpy()

    for i, t in enumerate(translations):
        print(f"translation {t:>5} m: max|J_ana - J_auto| = {np.abs(J_ana[i] - J_auto[i]).max():.6e}")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected analytic inverse-kinematics Jacobians for floating-base FREE and DISTANCE joints.
  * Ensured Jacobian results remain consistent regardless of world-space translation.
  * Aligned motion-subspace calculations with the parent-anchor coordinate convention.

* **Tests**
  * Added coverage comparing analytic and autodiff Jacobians across multiple translations and supported devices.

* **Documentation**
  * Added a changelog entry describing the Jacobian drift fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->