### PR TITLE
Print Rerun web viewer URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,6 @@
 - Fix `SchemaResolverPhysx` reading every D6 translational limit gain from the `linear` instance instead of its `transX`, `transY`, or `transZ` instance.
 - Fix USD capsule, cylinder, and cone visuals and sites without authored `radius`/`height` to use the UsdGeom schema fallbacks, matching collision shapes.
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
-- Print the Rerun web viewer URL so examples remain accessible when the browser does not open automatically.
 - Fix loading of textures packaged inside `.usdz` archives; package-relative asset paths such as `scene.usdz[tex.png]` are resolved through USD's asset resolver instead of being treated as filesystem paths.
 - Preserve cross-import collision pairs when `SolverMuJoCo` combines independently imported MJCF mask domains.
 - Fix `ModelBuilder.add_usd()` raising `ValueError` when importing a mesh whose material subset binds a texture that decodes to an image array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 - Fix `SchemaResolverPhysx` reading every D6 translational limit gain from the `linear` instance instead of its `transX`, `transY`, or `transZ` instance.
 - Fix USD capsule, cylinder, and cone visuals and sites without authored `radius`/`height` to use the UsdGeom schema fallbacks, matching collision shapes.
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
+- Print the Rerun web viewer URL so examples remain accessible when the browser does not open automatically.
 - Fix loading of textures packaged inside `.usdz` archives; package-relative asset paths such as `scene.usdz[tex.png]` are resolved through USD's asset resolver instead of being treated as filesystem paths.
 - Preserve cross-import collision pairs when `SolverMuJoCo` combines independently imported MJCF mask domains.
 - Fix `ModelBuilder.add_usd()` raising `ValueError` when importing a mesh whose material subset binds a texture that decodes to an image array.

--- a/changelog/+rerun-viewer-url-8c4e2f1a.fixed.md
+++ b/changelog/+rerun-viewer-url-8c4e2f1a.fixed.md
@@ -1,0 +1,1 @@
+Print the Rerun web viewer URL so examples remain accessible when the browser does not open automatically.

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import inspect
 import subprocess
 from typing import Any
+from urllib.parse import urlencode
 
 import numpy as np
 import warp as wp
@@ -193,6 +194,8 @@ class ViewerRerun(ViewerBase):
             if serve_web_viewer:
                 self._grpc_server_uri = rr.serve_grpc(grpc_port=grpc_port, default_blueprint=blueprint)
                 rr.serve_web_viewer(connect_to=self._grpc_server_uri, web_port=web_port)
+                query = urlencode({"url": self._grpc_server_uri})
+                print(f"Rerun web viewer running at: http://127.0.0.1:{web_port}/?{query}", flush=True)
             else:
                 rr.spawn(port=grpc_port)
 

--- a/newton/tests/test_viewer_rerun_init_args.py
+++ b/newton/tests/test_viewer_rerun_init_args.py
@@ -52,27 +52,16 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     self.mock_rr.serve_grpc.assert_called_once()
                     # Verify rr.serve_web_viewer() was called
                     self.mock_rr.serve_web_viewer.assert_called_once()
+                    self.mock_print.assert_called_once_with(
+                        "Rerun web viewer running at: "
+                        "http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
+                        flush=True,
+                    )
 
                     # Verify rr.connect_grpc() was NOT called
                     self.mock_rr.connect_grpc.assert_not_called()
                     # Verify rr.spawn() was NOT called
                     self.mock_rr.spawn.assert_not_called()
-
-    def test_default_prints_web_viewer_url(self):
-        """Print the browser URL with the recording source encoded."""
-        with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
-            with patch("newton._src.viewer.viewer_rerun.rrb", self.mock_rrb):
-                with patch("newton._src.viewer.viewer_rerun.is_jupyter_notebook", return_value=False):
-                    from newton._src.viewer.viewer_rerun import ViewerRerun
-
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore")
-                        _ = ViewerRerun()
-
-        self.mock_print.assert_called_once_with(
-            "Rerun web viewer running at: http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
-            flush=True,
-        )
 
     def test_native_viewer(self):
         """Test that ViewerRerun() with no arguments spawns a viewer."""

--- a/newton/tests/test_viewer_rerun_init_args.py
+++ b/newton/tests/test_viewer_rerun_init_args.py
@@ -17,8 +17,10 @@ class TestViewerRerunInitArgs(unittest.TestCase):
         self.mock_rr.init = Mock()
         self.mock_rr.spawn = Mock()
         self.mock_rr.connect_grpc = Mock()
+        self.mock_rr.serve_grpc = Mock(return_value="rerun+http://127.0.0.1:9876/proxy")
         self.mock_rr.set_time = Mock()
         self.mock_rr.save = Mock()
+        self.mock_print = self.enterContext(patch("builtins.print"))
 
         # Mock blueprint module and components
         self.mock_rrb = Mock()
@@ -55,6 +57,22 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     self.mock_rr.connect_grpc.assert_not_called()
                     # Verify rr.spawn() was NOT called
                     self.mock_rr.spawn.assert_not_called()
+
+    def test_default_prints_web_viewer_url(self):
+        """Print the browser URL with the recording source encoded."""
+        with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
+            with patch("newton._src.viewer.viewer_rerun.rrb", self.mock_rrb):
+                with patch("newton._src.viewer.viewer_rerun.is_jupyter_notebook", return_value=False):
+                    from newton._src.viewer.viewer_rerun import ViewerRerun
+
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        _ = ViewerRerun()
+
+        self.mock_print.assert_called_once_with(
+            "Rerun web viewer running at: http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
+            flush=True,
+        )
 
     def test_native_viewer(self):
         """Test that ViewerRerun() with no arguments spawns a viewer."""


### PR DESCRIPTION
## Description

Print the directly openable Rerun web viewer URL after its server starts. The URL includes the encoded gRPC recording source, so users can open the running recording manually when automatic browser launch fails.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra notebook -m unittest newton.tests.test_viewer_rerun_init_args
uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-10
uvx --python 3.12 pre-commit run -a
```

Manually ran the following command and confirmed that the printed URL opens the viewer:

```console
uv run --extra notebook -m newton.examples basic_pendulum --viewer rerun
```

## Bug fix

**Steps to reproduce:**

1. Run an example with `--viewer rerun`.
2. Observe that Rerun sometimes does not open the browser automatically.
3. Without this change, the console provides no URL for opening the viewer manually.

**Minimal reproduction:**

```console
uv run --extra notebook -m newton.examples basic_pendulum --viewer rerun
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Rerun web viewer URL is now printed during startup, including the connection details needed to access the viewer.
  * The URL remains available when the browser cannot be opened automatically.
  * The printed link is ready to copy and open in another browser or environment.

* **Documentation**
  * Added a changelog entry describing the improved viewer URL output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->