### PR TITLE
Compare USD sphere scale with a tolerance

### DIFF
--- a/changelog/+usd-sphere-scale-89498d51.fixed.md
+++ b/changelog/+usd-sphere-scale-89498d51.fixed.md
@@ -1,0 +1,6 @@
+Import USD spheres whose scale is uniform to within floating-point round-off
+without warning that non-uniform sphere scaling is unsupported. Scales reach the
+importer through a single-precision transform decomposition, so an exactly
+uniform scale composed through a nested transform chain could arrive with its
+components a few ULP apart and trip an exact equality check. The warning now
+also names the prim it applies to.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -154,6 +154,17 @@ def _cache_path_for_absolute_usd_reference(url: str) -> str:
     return posixpath.join("_external_usd", digest, basename)
 
 
+def _is_uniform_scale(scale, rel_tol: float = 1.0e-6) -> bool:
+    """Whether the three components of a scale vector agree to within ``rel_tol``.
+
+    Scales reach the importer through single-precision transform decomposition, so an
+    exactly uniform scale routinely comes back with components a few ULP apart. An exact
+    ``==`` comparison reports those as non-uniform.
+    """
+    lo, hi = min(scale), max(scale)
+    return hi - lo <= rel_tol * max(abs(lo), abs(hi))
+
+
 def _warn_mirrored_body_transform(usd_prim, key: str, xform_cache) -> None:
     """Warn when a rigid body prim has an improper (mirrored) world transform.
 
@@ -1367,8 +1378,8 @@ def parse_usd(
                     label=path_name,
                 )
             elif type_name == "sphere":
-                if not (scale[0] == scale[1] == scale[2]):
-                    print("Warning: Non-uniform scaling of spheres is not supported.")
+                if not _is_uniform_scale(scale):
+                    print(f"Warning: Non-uniform scaling of spheres is not supported, at {path_name}.")
                 radius = usd.get_float(prim, "radius", 1.0) * max(scale)
                 shape_id = builder.add_shape_sphere(
                     parent_body_id,
@@ -3781,8 +3792,8 @@ def parse_usd(
                         hz=hz,
                     )
                 elif key == UsdPhysics.ObjectType.SphereShape:
-                    if not (scale[0] == scale[1] == scale[2]):
-                        print("Warning: Non-uniform scaling of spheres is not supported.")
+                    if not _is_uniform_scale(scale):
+                        print(f"Warning: Non-uniform scaling of spheres is not supported, at {path}.")
                     radius = shape_spec.radius
                     shape_id = builder.add_shape_sphere(
                         **shape_params,

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import builtins
+import contextlib
 import functools
 import hashlib
+import io
 import logging
 import math
 import os
@@ -30,6 +32,7 @@ from newton._src.solvers.mujoco.constants import (
     SOLREF_MODE_RAW,
 )
 from newton._src.solvers.mujoco.utils import MjcEqualityTargetKind
+from newton._src.utils.import_usd import _is_uniform_scale
 from newton.math import quat_between_axes
 from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import USD_AVAILABLE, assert_np_equal, get_test_devices, patch_sys_module
@@ -935,6 +938,111 @@ def Xform "World"
 
         shape_id = results["path_shape_map"]["/World/Body/Parent/Child/Collision"]
         assert_np_equal(np.array(builder.shape_scale[shape_id]), np.array([1.0, 6.0, 6.0]), tol=1e-5)
+
+    def test_import_sphere_scale_uniformity_tolerance(self):
+        """Treat scales within a relative tolerance as uniform, and larger spreads as non-uniform."""
+        # The single-precision transform decomposition emits these for an exactly uniform
+        # scale composed through a nested transform chain; they differ by one float32 ULP.
+        self.assertTrue(_is_uniform_scale((0.9999999403953552, 0.9999999403953552, 1.0)))
+        self.assertTrue(_is_uniform_scale((0.9999999403953552, 1.0, 0.9999999403953552)))
+        self.assertTrue(_is_uniform_scale((1.0, 1.0, 1.0)))
+        self.assertTrue(_is_uniform_scale((0.0, 0.0, 0.0)))
+        # Genuinely non-uniform scales must still be reported.
+        self.assertFalse(_is_uniform_scale((1.0, 1.0, 2.0)))
+        self.assertFalse(_is_uniform_scale((1.0, 1.0, 1.001)))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_sphere_near_uniform_scale_does_not_warn(self):
+        """Import spheres whose scale is uniform to within float32 round-off without warning.
+
+        Both the collision and the visual code path guard against non-uniform sphere scaling.
+        A scale that is exactly uniform in the source asset can still reach those guards with
+        its components a ULP apart, which an exact equality comparison reports as non-uniform.
+        """
+        from pxr import Usd
+
+        usd_text = """#usda 1.0
+(
+    upAxis = "Z"
+)
+def PhysicsScene "physicsScene"
+{
+}
+def Xform "World"
+{
+    def Xform "Body" (
+        prepend apiSchemas = ["PhysicsRigidBodyAPI"]
+    )
+    {
+        def Sphere "NearUniformCollision" (
+            prepend apiSchemas = ["PhysicsCollisionAPI"]
+        )
+        {
+            double radius = 0.5
+            float3 xformOp:scale = (0.99999994, 0.99999994, 1)
+            uniform token[] xformOpOrder = ["xformOp:scale"]
+        }
+
+        def Sphere "NearUniformVisual"
+        {
+            double radius = 0.5
+            double3 xformOp:translate = (2, 0, 0)
+            float3 xformOp:scale = (0.99999994, 0.99999994, 1)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+    }
+}
+"""
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(usd_text)
+
+        builder = newton.ModelBuilder()
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            builder.add_usd(stage)
+
+        self.assertNotIn("Non-uniform scaling of spheres", stdout.getvalue())
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_sphere_non_uniform_scale_warns(self):
+        """Warn, and name the prim, when a sphere really is scaled non-uniformly."""
+        from pxr import Usd
+
+        usd_text = """#usda 1.0
+(
+    upAxis = "Z"
+)
+def PhysicsScene "physicsScene"
+{
+}
+def Xform "World"
+{
+    def Xform "Body" (
+        prepend apiSchemas = ["PhysicsRigidBodyAPI"]
+    )
+    {
+        def Sphere "SquashedCollision" (
+            prepend apiSchemas = ["PhysicsCollisionAPI"]
+        )
+        {
+            double radius = 0.5
+            float3 xformOp:scale = (1, 1, 2)
+            uniform token[] xformOpOrder = ["xformOp:scale"]
+        }
+    }
+}
+"""
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(usd_text)
+
+        builder = newton.ModelBuilder()
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            builder.add_usd(stage)
+
+        output = stdout.getvalue()
+        self.assertIn("Non-uniform scaling of spheres", output)
+        self.assertIn("/World/Body/SquashedCollision", output)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_import_articulation_no_visuals(self):


### PR DESCRIPTION
## Description

`import_usd` guards against non-uniform sphere scaling in two places — the visual path and the `UsdPhysics` collision path — and both compared the three scale components with `==`.

Scale reaches those guards through `wp.transform_decompose`, which works in single precision. An exactly uniform scale composed through a nested transform chain therefore arrives with its components a few ULP apart, and the exact comparison reports it as non-uniform. The deeper the transform chain, the more likely it is to fire.

This replaces the equality test with a shared `_is_uniform_scale` helper that compares against a relative tolerance, and adds the prim path to the warning so one that does fire can be acted on.

Found while reviewing [newton-assets#38](https://github.com/newton-physics/newton-assets/pull/38): importing the SO-101 Menagerie asset printed the warning seven times, for spheres that compose to exactly `(1, 1, 1)`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k test_import_usd
```

311 tests, OK. Three tests are new:

| test | covers |
| --- | --- |
| `test_import_sphere_scale_uniformity_tolerance` | the helper, against the ULP-apart values observed in the wild and against genuinely non-uniform scales |
| `test_import_sphere_near_uniform_scale_does_not_warn` | a stage exercising both the collision and visual code paths |
| `test_import_sphere_non_uniform_scale_warns` | a real `(1, 1, 2)` scale still warns, and names the prim |

All three fail without the source change (2 failures, plus 1 error for the missing helper); the near-uniform test emits two warnings there, one per code path.

Also confirmed against the real assets: SO-101 imports with 0 warnings where it previously printed 7, and the model is unchanged (8 bodies, 50 shapes, 6 DOF).

## Bug fix

**Steps to reproduce:**

1. Author a `UsdGeom.Sphere` whose composed scale is uniform but not exactly representable after a single-precision decomposition — in practice, any sphere a few levels deep in a transform chain.
2. Import the stage with `ModelBuilder.add_usd`.
3. Observe `Warning: Non-uniform scaling of spheres is not supported.` even though the sphere is uniformly scaled.

**Minimal reproduction:**

```python
import newton
from pxr import Usd

usd_text = """#usda 1.0
(
    upAxis = "Z"
)
def PhysicsScene "physicsScene"
{
}
def Xform "World"
{
    def Xform "Body" (
        prepend apiSchemas = ["PhysicsRigidBodyAPI"]
    )
    {
        def Sphere "Collision" (
            prepend apiSchemas = ["PhysicsCollisionAPI"]
        )
        {
            double radius = 0.5
            float3 xformOp:scale = (0.99999994, 0.99999994, 1)
            uniform token[] xformOpOrder = ["xformOp:scale"]
        }
    }
}
"""

stage = Usd.Stage.CreateInMemory()
stage.GetRootLayer().ImportFromString(usd_text)

builder = newton.ModelBuilder()
builder.add_usd(stage)  # prints the non-uniform scaling warning without this PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved USD sphere-scale handling to ignore negligible floating-point differences when determining uniform scale.
  - Reduced false warnings for nearly uniform visual and collision sphere scales.
  - Enhanced non-uniform scale warnings to identify the affected prim path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->