### PR TITLE
Require GitPython 3.1.58 or newer

### DIFF
--- a/changelog/+gitpython-config-injection-6a8d2c1f.fixed.md
+++ b/changelog/+gitpython-config-injection-6a8d2c1f.fixed.md
@@ -1,0 +1,1 @@
+Require GitPython 3.1.58 or newer to prevent config option-name injection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ examples = [
     "newton[importers]",    # include import dependencies
     "newton[onnx]",         # for RL policy examples
     "pyglet>=2.1.6,<3",     # for OpenGL viewer
-    "GitPython>=3.1.47",    # for downloading assets via newton.utils.download_asset()
+    "GitPython>=3.1.58",    # for downloading assets via newton.utils.download_asset()
     "imgui_bundle>=1.92.0", # for viewer GUI
     "pyyaml>=6.0.2",
     "cbor2>=5.7.0",         # for binary recording format (.bin files) - more efficient than JSON
@@ -127,7 +127,7 @@ docs = [
     "ipykernel>=6.0.0,<7.0.0",      # required by nbsphinx to execute notebooks (pinned <7 for rerun-sdk compatibility)
     "pypandoc>=1.11",               # required by nbsphinx for notebook conversion
     "pypandoc_binary>=1.11",        # bundled pandoc binary
-    "GitPython>=3.1.47",            # for downloading tutorial assets via newton.utils.download_asset() (>=3.1.47 for GHSA-x2qx-6953-8485)
+    "GitPython>=3.1.58",            # for downloading tutorial assets via newton.utils.download_asset()
     # Pin the backend and web client to one Viser build; 1.0.24-1.0.26 changed playback-sensitive paths.
     "viser==1.0.26",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1833,14 +1833,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.54"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -3928,8 +3928,8 @@ requires-dist = [
     { name = "coacd", marker = "python_full_version < '3.14' and extra == 'importers'", specifier = ">=1.0.7" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.8.0" },
     { name = "fast-simplification", marker = "extra == 'importers'", specifier = ">=0.1.11" },
-    { name = "gitpython", marker = "extra == 'docs'", specifier = ">=3.1.47" },
-    { name = "gitpython", marker = "extra == 'examples'", specifier = ">=3.1.47" },
+    { name = "gitpython", marker = "extra == 'docs'", specifier = ">=3.1.58" },
+    { name = "gitpython", marker = "extra == 'examples'", specifier = ">=3.1.58" },
     { name = "imgui-bundle", marker = "extra == 'examples'", specifier = ">=1.92.0" },
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.0.0,<7.0.0" },
     { name = "jupyter-server-proxy", marker = "extra == 'notebook'", specifier = ">=4.5.0" },


### PR DESCRIPTION
## Description

Raise the GitPython minimum for the `examples` and `docs` extras from 3.1.47 to 3.1.58, the first release patched for [GHSA-jm78-9fvv-mhgr](https://github.com/advisories/GHSA-jm78-9fvv-mhgr). Refresh `uv.lock` from GitPython 3.1.54 to 3.1.59.

This prevents Newton development, example, and documentation environments from retaining a GitPython version vulnerable to config option-name injection.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv lock --check
uv run --extra dev -m newton.tests -k test_download_assets
uvx --python 3.12 pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version 0.0.0 --date 1970-01-01
```

Also verified in isolated environments that GitPython 3.1.54 accepts the crafted option name while GitPython 3.1.59 raises `ValueError`.

## Bug fix

**Steps to reproduce:**

1. Install the existing `examples` or `docs` extra.
2. Pass a crafted option name to GitPython's config writer.
3. Observe that the locked GitPython 3.1.54 writes the injected config directive.

**Minimal reproduction:**

```python
import tempfile

from git import Repo

repo = Repo.init(tempfile.mkdtemp())
with repo.config_writer() as writer:
    writer.set_value("core", "sshCommand = harmless #", "x")
```

GitPython 3.1.58 and newer reject this option name with `ValueError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum GitPython version to 3.1.58 to address a security issue involving configuration option-name injection.

* **Documentation**
  * Added a changelog entry documenting the GitPython version requirement and security fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->