### PR TITLE
Fix API review analysis output

### DIFF
--- a/scripts/ci/detect_api_changes.py
+++ b/scripts/ci/detect_api_changes.py
@@ -47,6 +47,7 @@ class Definition:
         self.module = module
         self.node = node
         self.members = members or {}
+        self.surface_fingerprint: str | None = None
 
 
 class Module:
@@ -186,6 +187,55 @@ def _assignment(definitions: dict[str, Definition], node: ast.Assign | ast.AnnAs
         definitions[target.id] = Definition(symbol, module, node)
 
 
+def _self_attribute_names(target: ast.AST):
+    if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "self":
+        if not target.attr.startswith("_"):
+            yield target.attr
+        return
+    if isinstance(target, (ast.List, ast.Tuple)):
+        for item in target.elts:
+            yield from _self_attribute_names(item)
+
+
+def _instance_attributes(node: ast.FunctionDef | ast.AsyncFunctionDef, module: str) -> dict[str, Definition]:
+    """Collect public attributes initialized directly on ``self``."""
+    records: dict[str, tuple[ast.AST, set[str]]] = {}
+
+    def visit(child: ast.AST) -> None:
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        if isinstance(child, ast.Assign):
+            targets = child.targets
+            annotation = None
+        elif isinstance(child, ast.AnnAssign):
+            targets = [child.target]
+            annotation = _expr(child.annotation)
+        else:
+            targets = []
+            annotation = None
+        for target in targets:
+            for name in _self_attribute_names(target):
+                record_node, annotations = records.setdefault(name, (child, set()))
+                if annotation is not None:
+                    annotations.add(annotation)
+                records[name] = (record_node, annotations)
+        for grandchild in ast.iter_child_nodes(child):
+            visit(grandchild)
+
+    for child in node.body:
+        visit(child)
+
+    attributes = {}
+    for name, (record_node, attribute_annotations) in records.items():
+        symbol = {"kind": "attribute"}
+        if len(attribute_annotations) == 1:
+            symbol["annotation"] = next(iter(attribute_annotations))
+        elif attribute_annotations:
+            symbol["annotations"] = sorted(attribute_annotations)
+        attributes[name] = Definition(symbol, module, record_node)
+    return attributes
+
+
 def _class_definition(node: ast.ClassDef, module: str) -> Definition:
     bases = [_expr(base) or "?" for base in node.bases]
     decorators = [_expr(item) or "?" for item in node.decorator_list]
@@ -201,6 +251,9 @@ def _class_definition(node: ast.ClassDef, module: str) -> Definition:
     for child in node.body:
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             _callable_definition(members, child, module, method=True)
+            if child.name == "__init__":
+                for name, attribute in _instance_attributes(child, module).items():
+                    members.setdefault(name, attribute)
         elif isinstance(child, ast.ClassDef):
             members[child.name] = _class_definition(child, module)
         elif isinstance(child, (ast.Assign, ast.AnnAssign)):
@@ -349,10 +402,21 @@ def _collect_module(module: Module, notes: dict[str, dict[str, str]]) -> None:
             _callable_definition(module.definitions, node, module.name, method=False)
         elif isinstance(node, ast.ClassDef):
             module.definitions[node.name] = _class_definition(node, module.name)
-        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
-            _assignment(module.definitions, node, module.name)
+    for node in _iter_scope_assignments(module.tree):
+        _assignment(module.definitions, node, module.name)
     _parse_exports(module, notes)
     _parse_lazy_map(module, notes)
+
+
+def _iter_scope_assignments(node: ast.AST):
+    """Yield assignments in one scope, including module-level control flow."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+        return
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        yield node
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.stmt):
+            yield from _iter_scope_assignments(child)
 
 
 def _load_modules(root: Path, notes: dict[str, dict[str, str]]) -> dict[str, Module]:
@@ -461,6 +525,40 @@ def _export_names(module: Module, modules: dict[str, Module]) -> list[str]:
     return list(dict.fromkeys(names))
 
 
+def _definition_fingerprint(
+    definition: Definition,
+    modules: dict[str, Module],
+    stack: set[int] | None = None,
+) -> str:
+    """Hash the normalized public surface inherited from a definition."""
+    if definition.surface_fingerprint is not None:
+        return definition.surface_fingerprint
+    stack = set() if stack is None else stack
+    marker = id(definition)
+    if marker in stack:
+        return _digest(json.dumps({"cycle": definition.module, "symbol": definition.symbol}, sort_keys=True))
+    stack = {*stack, marker}
+    surface = {
+        "symbol": definition.symbol,
+        "members": {
+            name: _definition_fingerprint(member, modules, stack)
+            for name, member in sorted(definition.members.items())
+            if not name.startswith("_")
+        },
+    }
+    inherited = {}
+    for base in definition.symbol.get("bases", []):
+        if base in {"object", "Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "NamedTuple"}:
+            continue
+        found = _lookup(modules, definition.module, base) if base.isidentifier() else None
+        if found and found[0] == "definition":
+            inherited[base] = _definition_fingerprint(found[1], modules, stack)
+    if inherited:
+        surface["inherited"] = inherited
+    definition.surface_fingerprint = _digest(json.dumps(surface, sort_keys=True, separators=(",", ":")))
+    return definition.surface_fingerprint
+
+
 def _emit_definition(
     path: str,
     definition: Definition,
@@ -477,7 +575,7 @@ def _emit_definition(
             if base in {"object", "Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "NamedTuple"}:
                 continue
             found = _lookup(modules, definition.module, base) if base.isidentifier() else None
-            fingerprint = modules[found[1].module].digest if found and found[0] == "definition" else base
+            fingerprint = _definition_fingerprint(found[1], modules) if found and found[0] == "definition" else base
             _note(notes, f"inheritance:{path}:{base}", f"inherited members of {path} are not expanded", fingerprint)
     for name, member in definition.members.items():
         if not name.startswith("_"):
@@ -753,7 +851,10 @@ def format_comment(diff: dict, decision: str, uncertainty_changes: list[dict[str
     if decision == "unchanged":
         lines.append("No supported public API changes detected.")
     elif decision == "unknown":
-        lines.append("Static analysis is inconclusive; API review is requested conservatively.")
+        lines.append(
+            "Static analysis could not fully inspect one or more changed API-defining constructs. "
+            "Manual API review is requested."
+        )
     else:
         lines.append(
             f"Detected {summary['total']} interface change(s): "
@@ -769,12 +870,13 @@ def format_comment(diff: dict, decision: str, uncertainty_changes: list[dict[str
         remaining = summary["total"] - min(len(items), MAX_REPORT_ITEMS)
         if remaining:
             lines.append(f"- … and {remaining} more change(s).")
-    if uncertainty_changes:
-        lines.extend(["", "Analysis notes:"])
+    if decision == "unknown" and uncertainty_changes:
+        lines.extend(["", "<details>", "<summary>Technical analyzer details</summary>", ""])
         for item in uncertainty_changes[:MAX_REPORT_ITEMS]:
             lines.append(f"- {_safe(item['reason'])}")
         if len(uncertainty_changes) > MAX_REPORT_ITEMS:
             lines.append(f"- … and {len(uncertainty_changes) - MAX_REPORT_ITEMS} more note(s).")
+        lines.extend(["", "</details>"])
     lines.extend(
         ["", "This check is advisory: the label means API review needed, not that a breaking change is proven."]
     )

--- a/scripts/ci/tests/test_detect_api_changes.py
+++ b/scripts/ci/tests/test_detect_api_changes.py
@@ -113,6 +113,147 @@ class Example:
             changed = next(item for item in report["diff"]["changed"] if item["path"] == "newton.Example")
             self.assertIn("constructors", {item["field"] for item in changed["changes"]})
 
+    def test_tracks_instance_attribute_to_property_conversion(self):
+        """Track a public constructor attribute when it becomes a property."""
+        base_source = """
+class Example:
+    def __init__(self, enabled: bool):
+        if enabled:
+            self.value = 1
+        else:
+            self.value = None
+"""
+        head_source = """
+class Example:
+    def __init__(self, enabled: bool):
+        if enabled:
+            self._value = 1
+        else:
+            self._value = None
+
+    @property
+    def value(self) -> int | None:
+        return self._value
+
+    @value.setter
+    def value(self, value: int | None) -> None:
+        self._value = value
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base, head = root / "base", root / "head"
+            common_init = "from ._src.api import Example\n__all__ = ['Example']\n"
+            for tree, source in ((base, base_source), (head, head_source)):
+                _write(
+                    tree,
+                    {
+                        "newton/__init__.py": common_init,
+                        "newton/_src/__init__.py": "",
+                        "newton/_src/api.py": source,
+                    },
+                )
+
+            report = _run(base, head)
+
+            self.assertEqual(report["decision"], "changed")
+            self.assertEqual(
+                report["diff"]["summary"], {"added_count": 0, "removed_count": 0, "changed_count": 1, "total": 1}
+            )
+            changed = report["diff"]["changed"][0]
+            self.assertEqual(changed["path"], "newton.Example.value")
+            kind = next(item for item in changed["changes"] if item["field"] == "kind")
+            self.assertEqual((kind["before"], kind["after"]), ("attribute", "property"))
+
+    def test_resolves_export_assigned_in_module_control_flow(self):
+        """Resolve an exported constant assigned inside module control flow."""
+        version_source = """
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("newton")
+except PackageNotFoundError:
+    __version__ = "unknown"
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base, head = root / "base", root / "head"
+            _write(
+                base,
+                {
+                    "newton/__init__.py": "from ._version import __version__\n__all__ = ['__version__']\n",
+                    "newton/_version.py": version_source,
+                },
+            )
+            _write(
+                head,
+                {
+                    "newton/__init__.py": (
+                        "from ._version import __version__\nVALUE = 1\n__all__ = ['__version__', 'VALUE']\n"
+                    ),
+                    "newton/_version.py": version_source,
+                },
+            )
+
+            symbols, notes = _snapshot(base)
+            report = _run(base, head)
+
+            self.assertIn("newton.__version__", symbols)
+            self.assertFalse(notes)
+            self.assertEqual(report["decision"], "changed")
+            self.assertFalse(report["has_analysis_warnings"])
+            self.assertEqual([item["path"] for item in report["diff"]["added"]], ["newton.VALUE"])
+
+    def test_ignores_inherited_base_implementation_changes(self):
+        """Ignore base implementation changes when inherited APIs stay stable."""
+        template = """
+class Base:
+    def run(self, value: int) -> int:
+        return {result}
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base, head = root / "base", root / "head"
+            common = {
+                "newton/__init__.py": "from .derived import Derived\n__all__ = ['Derived']\n",
+                "newton/derived.py": "from ._src.base import Base\n__all__ = ['Derived']\nclass Derived(Base): ...\n",
+                "newton/_src/__init__.py": "",
+            }
+            for tree, result in ((base, 1), (head, 2)):
+                _write(tree, {**common, "newton/_src/base.py": template.format(result=result)})
+
+            report = _run(base, head)
+
+            self.assertEqual(report["decision"], "unchanged")
+            self.assertFalse(report["needs_review"])
+            self.assertFalse(report["has_analysis_warnings"])
+
+    def test_marks_inherited_base_api_changes_as_unknown(self):
+        """Request review when an inherited base API actually changes."""
+        template = """
+class Base:
+    def run(self, value: {annotation}) -> int:
+        return 1
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base, head = root / "base", root / "head"
+            common = {
+                "newton/__init__.py": "from .derived import Derived\n__all__ = ['Derived']\n",
+                "newton/derived.py": "from ._src.base import Base\n__all__ = ['Derived']\nclass Derived(Base): ...\n",
+                "newton/_src/__init__.py": "",
+            }
+            for tree, annotation in ((base, "int"), (head, "str")):
+                _write(tree, {**common, "newton/_src/base.py": template.format(annotation=annotation)})
+
+            report = _run(base, head)
+
+            self.assertEqual(report["decision"], "unknown")
+            self.assertTrue(report["needs_review"])
+            self.assertTrue(report["has_analysis_warnings"])
+            self.assertIn("Manual API review is requested.", report["comment"])
+            self.assertIn("<summary>Technical analyzer details</summary>", report["comment"])
+            self.assertIn("inherited members of newton.Derived are not expanded", report["comment"])
+
     def test_marks_changed_dynamic_exports_as_unknown(self):
         """Request review when a dependency of an unsupported export changes."""
         template = """
@@ -396,6 +537,17 @@ class SolverExample:
         self.assertIn("&lt;img", comment)
         self.assertIn("and 5 more", comment)
         self.assertLessEqual(len(comment), detector.MAX_COMMENT_CHARS)
+
+    def test_hides_uncertainty_details_when_changes_are_known(self):
+        """Hide analyzer uncertainty when concrete API changes request review."""
+        diff = detector.compare_symbols({}, {"newton.value": {"kind": "constant"}})
+        uncertainty = [{"key": "demo", "reason": "unsupported implementation detail"}]
+
+        comment = detector.format_comment(diff, "changed", uncertainty)
+
+        self.assertIn("Added: <code>newton.value</code>", comment)
+        self.assertNotIn("unsupported implementation detail", comment)
+        self.assertNotIn("Technical analyzer details", comment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix the public API review detector so it reports stable APIs accurately and keeps analyzer limitations from obscuring concrete findings.

- Track public instance attributes initialized in `__init__`, so attribute-to-property transitions are reported as modifications rather than additions.
- Resolve assignments nested in module-level control flow, including `newton.__version__`.
- Fingerprint normalized inherited public surfaces instead of entire provider modules.
- Hide uncertainty diagnostics when concrete API changes already request review. For uncertainty-only cases, show a concise explanation with technical details collapsed.

This reduces false positives observed on #3803 while preserving conservative review requests when static analysis is genuinely inconclusive.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md) — not applicable; this is a CI-only change

## Test plan

- Verified the four focused regression tests fail against the unmodified detector and pass with this change.
- `uv run --no-project -m unittest scripts.ci.tests.test_detect_api_changes scripts.ci.tests.test_pr_api_changes_workflow -v`
- `uvx pre-commit run -a`
- Replayed the detector against PRs #3053, #3772, #3775, #3752, and #3623.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved API change detection for instance attributes, inherited APIs, and exports defined through control flow.
  * More accurately distinguishes implementation changes from public API changes.

* **Bug Fixes**
  * Correctly identifies changes when instance attributes become properties.
  * Flags uncertain inherited API changes for manual review while ignoring unrelated inherited implementation updates.

* **Documentation**
  * Clarified generated review comments and hides analyzer uncertainty details when concrete API changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->