### PR TITLE
Link cable slots to their public API

### DIFF
--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -50,13 +50,15 @@ Cable joints
 
 :attr:`newton.JointType.CABLE` is represented in Newton's joint data model, but
 it is not a conventional generalized-coordinate joint. Its four entries are
-VBD constraint/material slots: stretch (slot 0, ``JointSlot.STRETCH``), shear
-(slot 1, ``JointSlot.SHEAR``), bend (slot 2, ``JointSlot.BEND``), and twist
-(slot 3, ``JointSlot.TWIST``). These slots store independent per-cable stiffness
-and damping through :attr:`newton.Model.joint_target_ke` and
-:attr:`newton.Model.joint_target_kd`. Generic joint storage allocates matching
-``joint_q`` / ``joint_qd`` entries, but they are not generalized coordinates or
-velocities that reconstruct the child body pose.
+VBD constraint/material slots defined by
+:class:`~newton.solvers.SolverVBD.JointSlot`: stretch (``STRETCH``, slot 0),
+shear (``SHEAR``, slot 1), bend (``BEND``, slot 2), and
+twist (``TWIST``, slot 3). These slots store independent per-cable stiffness
+and damping through
+:attr:`newton.Model.joint_target_ke` and :attr:`newton.Model.joint_target_kd`.
+Generic joint storage allocates matching ``joint_q`` / ``joint_qd`` entries, but
+they are not generalized coordinates or velocities that reconstruct the child
+body pose.
 
 Cable body poses and velocities are maximal-coordinate state stored in
 :attr:`newton.State.body_q` and :attr:`newton.State.body_qd`, and are advanced by


### PR DESCRIPTION
## Description

Follow up on the [documentation review comment from #3860](https://github.com/newton-physics/newton/pull/3860).
The cable slot documentation used `JointSlot.*` shorthand without identifying an importable public path. Link the slot names to `newton.solvers.SolverVBD.JointSlot` using a Sphinx cross-reference.
This is documentation-only and changes no API or behavior. No changelog fragment is needed.


<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how cable joint entries map to constraint and material slots.
  * Documented the slot assignments for stretch, shear, bend, and twist.
  * Explained that stiffness and damping are stored independently.
  * Distinguished storage slots from generalized coordinates and velocities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->