### PR TITLE
Bump release version to 1.5.0rc3

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.0rc2``
+     - ``1.5.0rc3``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.0rc2"
+version = "1.5.0rc3"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0rc2"
+version = "1.5.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare Newton 1.5.0rc3 from exact `release-1.5` head
`c415ba3f58d56a2e9c9fbdaef877c7d9b22adc66` after the final approved
post-RC2 backports.

This updates the project version, generated API version, and editable package
entry in the lockfile. The rolling release changelog remains under
`[Unreleased]` until GA preparation.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv lock --check`
- `uv run docs/generate_api.py`
- `uvx --python 3.12 pre-commit run -a`
- `uv build --out-dir /tmp/newton-release-1.5-rc3-dist`
- Clean-install the built wheel and verify package metadata,
  `newton.__version__`, and the import path from isolated `site-packages`
- Full cross-platform, GPU, benchmark, and documentation coverage passed on
  the final backport PR #3880; the expected release-branch API-detection
  failure is explicitly accepted.
