### PR TITLE
Prepare Newton 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.5.0] - 2026-08-11
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Newton was initiated by [Disney Research](https://www.disneyresearch.com/), [Goo
 - **OS:** Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
 - **GPU:** NVIDIA GPU (Maxwell or newer), driver 545 or newer (CUDA 12). No local CUDA Toolkit installation required. macOS runs on CPU.
 
-For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/latest/guide/compatibility.html).
+For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/1.5.0/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/1.5.0/guide/compatibility.html).
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ pip install "newton[examples]"
 python -m newton.examples
 ```
 
-To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html).
+To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/1.5.0/guide/installation.html).
 
 ## Examples
 
@@ -918,11 +918,11 @@ python -m newton.examples basic_viewer --viewer gl --num-frames 500 --device cpu
 
 ## Contributing and Development
 
-See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/latest/guide/development.html) for instructions on how to contribute to Newton.
+See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/1.5.0/guide/development.html) for instructions on how to contribute to Newton.
 
 ## Support and Community Discussion
 
-For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/latest/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
+For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/1.5.0/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
 
 ## Code of Conduct
 

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.0rc3``
+     - ``1.5.0``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.0rc3"
+version = "1.5.0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0rc3"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare the `release-1.5` branch for the final Newton 1.5.0 release.

- Finalize and date the 1.5.0 changelog section.
- Replace RC metadata with the final `1.5.0` version.
- Regenerate the API version table and minimally update the lockfile.
- Point README documentation links at the versioned `/1.5.0/` deployment.

This combines the final changelog and version preparation so the full PR CI
matrix runs once. After merge, the minimum-dependency and four-GPU release
workflows will be rerun against the exact final commit before tagging.

The existing release-audit report remains under parallel review and covers the
RC2 head. Maintainer go/no-go approval was given to proceed with GA; this PR
does not represent a newly generated exact-head audit.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv lock --check
uv run docs/generate_api.py
uvx --python 3.12 pre-commit run -a
uv run --extra docs --extra sim sphinx-build -W -D nbsphinx_execute=never -b html docs <output>
uv build --out-dir <output>
uv run --no-project --isolated --python 3.12 --with <wheel> python -c \
  "import importlib.metadata as m, newton; print(m.version('newton')); print(newton.__version__); print(newton.__file__)"
```

All checks passed. The isolated wheel reports `1.5.0` from both package
metadata and `newton.__version__`. PyPI has no `1.5.0` release and `v1.5.0`
is unused locally and on the canonical remote as of 2026-08-11.
