### PR TITLE
[Kamino] Add config validation rejecting dense solver + balanced penalty

### DIFF
--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -735,7 +735,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         if config is None:
             config = self.Config.from_model(model)
         else:
-            # Validate the user-provided config. Protects against motifying the config after initialization.
+            # Validate the user-provided config. Protects against modifying the config after initialization.
             config.validate()
         self._config = config
 

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -429,6 +429,12 @@ class SolverKamino(SolverBase, CouplingInterface):
                     "The DVI solver currently requires `dynamics.preconditioning=False` so convergence checks and "
                     "contact cone updates stay in physical constraint units."
                 )
+            if (
+                self.dynamics_solver == "padmm"
+                and not self.sparse_dynamics
+                and self.padmm.penalty_update_method != "fixed"
+            ):
+                raise ValueError("Adaptive PADMM penalty updates require `sparse_dynamics=True`.")
 
             # Conversion to JointCorrectionMode will raise an error if the input string is invalid.
             JointCorrectionMode.from_string(self.rotation_correction)
@@ -728,6 +734,9 @@ class SolverKamino(SolverBase, CouplingInterface):
         # found on the model, so `self._config` will always be fully initialized after this step.
         if config is None:
             config = self.Config.from_model(model)
+        else:
+            # Validate the user-provided config. Protects against motifying the config after initialization.
+            config.validate()
         self._config = config
 
         # Create a Kamino model from the Newton model

--- a/newton/tests/kamino/test_kamino_solver_kamino.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino.py
@@ -391,6 +391,14 @@ class TestSolverKaminoConfig(unittest.TestCase):
             with self.assertRaises(ValueError):
                 kamino_config.PADMMSolverConfig(warmstart_scale=scale)
 
+    def test_02_reject_dense_adaptive_padmm_penalty(self):
+        """Reject adaptive PADMM penalties with dense dynamics."""
+        with self.assertRaisesRegex(ValueError, "Adaptive PADMM penalty updates require `sparse_dynamics=True`"):
+            SolverKamino.Config(
+                sparse_dynamics=False,
+                padmm=kamino_config.PADMMSolverConfig(penalty_update_method="balanced"),
+            )
+
 
 class TestCollisionCapacityInitialization(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

It was possible to select the balanced penalty update together with the dense solver. This creates a problem because then only the RHS sees the updated rho, but the LHS was factorized with the old rho. 

This PR also adds validation of the config to the solver init. This catches the common pattern of modifying the config after constructing it, which never validated again.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject adaptive PADMM penalty updates when sparse dynamics are not enabled.
  - Explicitly supplied solver configurations are now validated before use, helping prevent invalid setups and providing clearer configuration errors.
  - Invalid solver settings are now identified earlier, reducing the risk of failed or unexpected solver runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->