### PR TITLE
Synchronize Newton 1.5 changelog to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 - Add a `damping` parameter to `ModelBuilder.add_joint_ball()` that applies passive angular damping to all three ball-joint DOFs; when omitted, `ModelBuilder.default_joint_cfg.damping` applies.
 - Add per-world `xforms` argument to `ModelBuilder.replicate()` for batching explicitly positioned worlds.
 - Add cubic and triplanar `SensorTiledCamera` texture projection modes for shapes without authored UVs.
+- Add `fullscreen` to `ViewerGL.log_image()` to display a logged image, such as a sensor output texture, as the main viewer surface for a frame while keeping the UI available.
 - Add CUDA-graph-capturable rebuildable sparse grids to `SolverImplicitMPM` when `max_active_cell_count` is positive, with optional `max_leaf_node_count`, `max_lower_node_count`, and `max_upper_node_count` hierarchy capacities.
-- Add opt-in isolated multi-world implicit MPM with capacity-bounded rebuildable sparse grids, selective world resets, outer graph capture, and asynchronous overflow reporting; legacy shared topology remains the default.
+- Add opt-in isolated multi-world implicit MPM with capacity-bounded rebuildable sparse grids, selective world resets, outer graph capture, and asynchronous overflow reporting through `SolverImplicitMPM.check_sparse_grid_rebuild_status()`; legacy shared topology remains the default.
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)
@@ -30,6 +31,7 @@
 - Add opt-in DVI forward dynamics to `SolverKamino` through `SolverKamino.Config(dynamics_solver="dvi")`, with sparse and dense execution, DVI-specific convergence diagnostics, warm-starting, bounded contact-recovery controls, and RCM-reordered bilateral factorization with reusable ordering and panel-parallel numeric factorization for large systems. PADMM remains the default. (#3570, #3613)
 - Add `fk_actuation_flags` to `SolverKamino.register_custom_attributes()` for selecting joint actuation types in forward-kinematics workflows. (#3338)
 - Add D6 gimbal/Euler joint support to `SolverKamino`, including conversion, limits, Jacobians, reset, and forward-kinematics handling. (#3717)
+- Return the selected `physics_scene_path` from `ModelBuilder.add_usd()` and add `newton.usd.get_physics_scenes()` to retrieve every physics scene in parser order.
 - Warn in `ModelBuilder.add_usd()` when a rigid body prim has a mirrored (negative-determinant) world transform. Improper transforms have no unique rotation decomposition, so imported body and joint frames can acquire a spurious constant rotation (common with mirror-scaled CAD exports); the warning recommends baking the reflection into the mesh geometry before import.
 - Add dedicated gravity for global world `-1` while preserving the single-entry `Model.gravity` array for implicit single-world models and local-only array updates through `Model.set_gravity()`. (#3724; fixes #3723)
 - Add a `sign_method` argument to `Mesh.build_sdf()` and `SDF.create_from_mesh()` with `"auto"`, `"parity"`, `"winding"`, and `"normal"` (angle-weighted pseudo-normal) strategies. Automatic runtime mesh queries use parity for watertight meshes and pseudo-normals for non-watertight meshes, while SDFs baked during model finalization use winding numbers. (#3403; fixes #3242)
@@ -64,6 +66,7 @@
 - Map `shape_material_kf` to per-contact MuJoCo `solreffriction` in `SolverMuJoCo` (elliptic friction cones with Newton contacts); resolve `kf` with priority/`solmix`, treat a resolved `kf = 0` as frictionless, and use native MuJoCo contacts or a pyramidal cone to preserve the previous solref-inherited friction.
 - Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default; pass `load_static_visual_shapes=False` to retain the previous body-associated-visuals-only behavior.
 - Speed up `Mesh.create_heightfield()` and `Mesh.create_terrain()` by building the vertex and index buffers in place, substantially reducing construction time and peak memory for large terrain grids such as those used by Isaac Lab.
+- Optimize VBD cable bend-twist Jacobian assembly while preserving residual-consistent behavior near folds.
 - Load solver backends lazily on first access to speed up `import newton`; access solver classes through `newton.solvers` as before, and import solver modules explicitly if module-level side effects are required.
 - Reduce `SolverKamino` kernel compilation time. (#3564)
 - Speed up USD mesh import for faceVarying normals by resolving the common single-cluster case for all vertices at once instead of clustering every face corner in Python; the split vertices, indices, normals, and UVs are unchanged, except that a corner sitting exactly at `vertex_splitting_angle_threshold_deg` from its cluster may now cluster differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,7 @@
 
 ### Changed
 
-- Decide collider visibility from USD `purpose` and visibility rather than from a bound render material. A collider whose `purpose` resolves to `default` is viewport geometry and is drawn; mark it `guide` to state that it is collision-only. Previously an unrelated visual elsewhere in the scene could make a collider vanish. `force_show_colliders` and `hide_collision_shapes` are unchanged.
 - Filter shared full-surface soft contacts per `SolverCoupled` entry, preserving them for capable solvers and dropping them for particle-only solvers or records spanning entries.
-- Require `warp-lang>=1.16.0`; upgrade Warp to version 1.16.0 or later.
 - Follow USD viewport `purpose` and visibility for imported visual geometry and colliders rather than inferring visibility from a bound render material. Visual shapes and Gaussian splats are drawn only for `default` and `proxy`; a collider whose `purpose` resolves to `default` is drawn, while `guide` identifies collision-only geometry. `force_show_colliders` and `hide_collision_shapes` are unchanged. (#3404, #3712)
 - Require `warp-lang>=1.16.0`; upgrade Warp to version 1.16.0 or later. (#3780)
 - Disable the implicit positive Dahl-friction defaults in `SolverVBD.register_custom_attributes()` (deprecated in 1.3.0): `vbd:dahl_eps_max` and `vbd:dahl_tau` now default to zero, and Dahl cable friction is enabled only where both are authored positive. Pass `dahl_defaults_enabled=True` to temporarily restore the old defaults; the compatibility mode will be removed in a future release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <!-- towncrier release notes start -->
 
+## [1.5.0] - 2026-08-11
+
 ### Added
 
 - Import MJCF mesh assets authored with inline vertex, face, normal, and texture-coordinate data.
@@ -77,7 +79,6 @@
 - Reject invalid `ModelBuilder.ShapeConfig` SDF and density values during shape validation. Use finite nonnegative density and SDF padding, a finite positive target voxel size, a narrow-band range satisfying `inner < 0 < outer`, and a positive maximum resolution below 65536 that is divisible by 8; set either maximum resolution or target voxel size, not both. (#3311)
 - Reject runtime changes that alter `SolverKamino`'s as-built joint constraint counts, passive/actuated partition, or finite-limit structure; recreate the solver after making one of these structural changes. (#3532)
 - Cull positive-distance speculative contacts by default when converting Newton contacts for `SolverKamino` as a temporary workaround for restitution issues. No public compatibility option restores the old behavior; if a scene needs contact forces before geometry surfaces touch, increase `ModelBuilder.ShapeConfig.margin` so margin-shifted surfaces overlap at the desired force onset, and re-test contact behavior. (#3779)
-- Refine contact visualizations (showing contact force and color-coded contact mode) in Newton viewer.
 
 ### Deprecated
 
@@ -106,7 +107,6 @@
 - Convert `newton:mimicCoef0` from degrees to radians when the mimic follower joint is angular. Assets authored against the old behavior need the value rescaled to degrees.
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.
 - Bound Kamino DVI contact allocation with a per-world geometry heuristic instead of sizing every contact pair simultaneously; set `collision_detector.max_contacts_per_world` to override the inferred capacity.
-- Improve `SolverKamino` DVI contact convergence, warm-starting, and performance for dense contact manifolds.
 - Fix panel-parallel RCM-blocked LLT factorization hanging when a matrix ends in a partial tile.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix MJCF contact pairs ignoring properties inherited from pair default classes.

--- a/changelog/+contact-visualizations-238c2f64.changed.md
+++ b/changelog/+contact-visualizations-238c2f64.changed.md
@@ -1,0 +1,1 @@
+Refine contact visualizations in Newton viewers to show contact forces and color-coded contact modes.

--- a/changelog/+implicit-mpm-status-8f2c4a1d.skip
+++ b/changelog/+implicit-mpm-status-8f2c4a1d.skip
@@ -1,1 +1,0 @@
-Release 1.5 API cleanup; changelog coverage is handled by the release-branch cherry-pick.

--- a/changelog/+kamino-dvi-contact-a77b78b3.fixed.md
+++ b/changelog/+kamino-dvi-contact-a77b78b3.fixed.md
@@ -1,0 +1,1 @@
+Improve `SolverKamino` DVI contact convergence, warm-starting, and performance for dense contact manifolds.

--- a/changelog/+usd-physics-scene-7c41d2a9.added.md
+++ b/changelog/+usd-physics-scene-7c41d2a9.added.md
@@ -1,1 +1,0 @@
-Return the selected `physics_scene_path` from `ModelBuilder.add_usd()` and add `newton.usd.get_physics_scenes()` to retrieve all physics scenes.

--- a/changelog/+viewer-main-image-18cc9933.added.md
+++ b/changelog/+viewer-main-image-18cc9933.added.md
@@ -1,3 +1,0 @@
-Add `fullscreen` to `ViewerGL.log_image()` to display a logged image (e.g. a
-sensor output texture) as the main viewer surface for a frame, skipping the 3D
-scene render while keeping the UI available.


### PR DESCRIPTION
## Description

Synchronize the final Newton 1.5.0 changelog back to `main` after tagging.

- Cherry-pick the two release-side changelog-management commits in order.
- Add the dated `1.5.0` section below a fresh empty `[Unreleased]` heading.
- Delete the three Towncrier fragments consumed by the final release
  cherry-picks: implicit-MPM status rename, USD physics-scene helper, and
  ViewerGL fullscreen image rendering.
- Preserve all genuine main-only fragments for the next release.
- Move two main-only entries that had directly entered `CHANGELOG.md` into
  Towncrier fragments: contact visualization changes from #3615 and later
  Kamino DVI contact improvements from #3778.

The resulting `1.5.0` section matches tag `v1.5.0` exactly. Changelog history
from `1.4.0` downward is unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uvx --from towncrier==25.8.0 towncrier build --draft \
  --version 1.6.0 --date 2026-08-11
uvx --python 3.12 pre-commit run -a
git diff v1.5.0 -- CHANGELOG.md changelog
```

- Towncrier draft rendering passes and contains only next-release entries.
- The `1.5.0` section is byte-for-byte identical to the release tag.
- Older dated history is unchanged.
- Every surviving pre-existing fragment originates from a main-only commit
  absent from `v1.5.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 1.5.0 changelog with notes on fullscreen image logging, multi-world sparse-grid rebuild status, USD physics-scene APIs, soft-contact filtering, and improved cable bend-twist calculations.
  * Added notes covering Newton contact visualizations and improved DVI contact convergence, warm-starting, and performance.
  * Removed outdated or superseded release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->