### PR TITLE
[Kamino] Fix natural map residual computation. Was missing joint constraints.

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -962,7 +962,7 @@ def _compute_dual_problem_metrics(
 
     # Compute the natural-map residuals as: r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf
     r_ncp_natmap, r_ncp_natmap_argmax = compute_ncp_natural_map_residual(
-        nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
+        njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
 
     # Store the computed metrics in the output arrays
@@ -1059,7 +1059,7 @@ def _compute_dual_problem_metrics_sparse(
 
     # Compute the natural-map residuals as: r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf
     r_ncp_natmap, r_ncp_natmap_argmax = compute_ncp_natural_map_residual(
-        nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
+        njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
 
     # Store the computed metrics in the output arrays

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -1414,7 +1414,7 @@ def make_collect_solver_info_kernel(use_acceleration: bool):
 
         # Compute the natural-map residuals as: r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf
         r_ncp_natmap, _ = compute_ncp_natural_map_residual(
-            nl, nc, vio, lcgo, ccgo, cio, problem_mu, solver_info_v_aug, solver_info_lambdas
+            njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, solver_info_v_aug, solver_info_lambdas
         )
 
         # Compute the iterate residuals, or reuse the accelerated solver status
@@ -1595,7 +1595,7 @@ def make_collect_solver_info_kernel_sparse(use_acceleration: bool):
 
         # Compute the natural-map residuals as: r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf
         r_ncp_natmap, _ = compute_ncp_natural_map_residual(
-            nl, nc, vio, lcgo, ccgo, cio, problem_mu, solver_info_v_aug, solver_info_lambdas
+            njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, solver_info_v_aug, solver_info_lambdas
         )
 
         # Compute the iterate residuals, or reuse the accelerated solver status

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -586,6 +586,7 @@ def compute_ncp_complementarity_residual(
 
 @wp.func
 def compute_ncp_natural_map_residual(
+    njc: wp.int32,
     nl: wp.int32,
     nc: wp.int32,
     vio: wp.int32,
@@ -599,7 +600,13 @@ def compute_ncp_natural_map_residual(
     """
     Computes the natural-map residuals as: `r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf`
 
+    Notes:
+    - For joint constraints, the cone is all of `R^njc`, so the natural-map residual is `abs(v_aug)`.
+    - For limit constraints, the cone is defined as `K_l := { lambda | lambda >= 0 }`.
+    - For contact constraints, the cone is defined as `K_c := { lambda | || lambda ||_2 <= mu * || vn ||_2 }`.
+
     Args:
+        njc: The number of joint constraints.
         nl: The number of active limit constraints.
         nc: The number of active contact constraints.
         vio: The vector index offset (i.e. start index) for the constraints.
@@ -618,6 +625,14 @@ def compute_ncp_natural_map_residual(
     # Initialize the natural-map residual
     r_ncp_natmap = float(0.0)
     r_ncp_natmap_argmax = wp.int32(-1)
+
+    for jid in range(njc):
+        jcio_j = vio + jid
+        v_j = v_aug[jcio_j]
+        r_j = wp.abs(v_j)
+        r_ncp_natmap = wp.max(r_ncp_natmap, r_j)
+        if r_ncp_natmap == r_j:
+            r_ncp_natmap_argmax = jid
 
     for lid in range(nl):
         # Compute the limit constraint index offset

--- a/newton/tests/kamino/test_kamino_solvers_metrics.py
+++ b/newton/tests/kamino/test_kamino_solvers_metrics.py
@@ -181,6 +181,9 @@ def compute_metrics_numpy(problem: DualProblem, solver_data: PADMMData) -> dict[
 
         # Compute the natural-map residuals as: r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf
         r_vi_natmap_i = 0.0
+        for jid in range(num_joint_cts[mat_id]):
+            r_vi_natmap_i = max(r_vi_natmap_i, np.abs(v_aug_i[jid]))
+
         for lid in range(num_limits[mat_id]):
             lcio = limit_group_offset[mat_id] + lid
             v_l = v_aug_i[lcio]


### PR DESCRIPTION
## Description

Fixes a bug in the natural map computation. This is metrics only, so will not affect the solver. The rows for joint constraints were not taken into account. Probably someone thought this was zero, but it is not. The natural map is given by:

$$v^+(\lambda) = D\lambda + v_f$$
$$F_{\text{NCP}}^{\text{nat}}(\lambda) = \lambda - \mathcal{P}^{\mathcal{K}} \left(\lambda - \left(v^+(\lambda) + \Gamma(v^+(\lambda))\right)\right)$$

For joint constraints, the projection is identity and the De Saxce correction is 0. So you get:

$$F_{\text{NCP}, j}^{\text{nat}}(\lambda) = \lambda_j - \left(\lambda_j - v_j^+(\lambda)\right) = v_j^+(\lambda)$$

So post-solve velocity residual is what should be measured for the joint constraints.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved natural-map residual calculations for joint constraints.
  * Corrected residual handling across dense and sparse solver paths, including contact indexing and non-joint constraints.
  * Updated reference calculations to include joint constraint contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->