### PR TITLE
Expanded MPM solver names for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add `fullscreen` to `ViewerGL.log_image()` to display a logged image, such as a sensor output texture, as the main viewer surface for a frame while keeping the UI available.
 - Add CUDA-graph-capturable rebuildable sparse grids to `SolverImplicitMPM` when `max_active_cell_count` is positive, with optional `max_leaf_node_count`, `max_lower_node_count`, and `max_upper_node_count` hierarchy capacities.
 - Add opt-in isolated multi-world implicit MPM with capacity-bounded rebuildable sparse grids, selective world resets, outer graph capture, and asynchronous overflow reporting through `SolverImplicitMPM.check_sparse_grid_rebuild_status()`; legacy shared topology remains the default.
+- Accept the expanded implicit-MPM solver names `conjugate-gradient`, `conjugate-residual`, and `generalized-minimal-residual` while retaining the `cg`, `cr`, and `gmres` aliases.
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - Add `fullscreen` to `ViewerGL.log_image()` to display a logged image, such as a sensor output texture, as the main viewer surface for a frame while keeping the UI available.
 - Add CUDA-graph-capturable rebuildable sparse grids to `SolverImplicitMPM` when `max_active_cell_count` is positive, with optional `max_leaf_node_count`, `max_lower_node_count`, and `max_upper_node_count` hierarchy capacities.
 - Add opt-in isolated multi-world implicit MPM with capacity-bounded rebuildable sparse grids, selective world resets, outer graph capture, and asynchronous overflow reporting through `SolverImplicitMPM.check_sparse_grid_rebuild_status()`; legacy shared topology remains the default.
-- Accept the expanded implicit-MPM solver names `conjugate-gradient`, `conjugate-residual`, and `generalized-minimal-residual` while retaining the `cg`, `cr`, and `gmres` aliases.
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)

--- a/changelog/+implicit-mpm-solver-aliases-6e4b91c2.added.md
+++ b/changelog/+implicit-mpm-solver-aliases-6e4b91c2.added.md
@@ -1,0 +1,1 @@
+Accept the expanded implicit-MPM solver names `conjugate-gradient`, `conjugate-residual`, and `generalized-minimal-residual` while retaining the `cg`, `cr`, and `gmres` aliases.

--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -1380,8 +1380,11 @@ class _JacobiSolver(_RheologySolver):
 
 _ITERATIVE_LINEAR_SOLVERS = {
     "cg": cg,
+    "conjugate-gradient": cg,
     "cr": cr,
+    "conjugate-residual": cr,
     "gmres": gmres,
+    "generalized-minimal-residual": gmres,
 }
 
 _RHEOLOGY_SOLVERS = {
@@ -1918,7 +1921,9 @@ def solve_rheology(
             Base solvers: ``"gauss-seidel"`` (or ``"gs"``),
             ``"gauss-seidel-soa"`` (or ``"gs-soa"``),
             ``"gauss-seidel-batched"`` (or ``"gs-batched"``),
-            ``"jacobi"``, ``"cg"``, ``"cr"``, ``"gmres"``.
+            ``"jacobi"``, ``"conjugate-gradient"`` (or ``"cg"``),
+            ``"conjugate-residual"`` (or ``"cr"``), and
+            ``"generalized-minimal-residual"`` (or ``"gmres"``).
             Chained solvers run left-to-right as warmstarts for the
             final solver, e.g. ``("cr", "gs")`` runs CR then Gauss-Seidel,
             ``("cg", "jacobi", "gs-batched")`` runs CG, then a Jacobi smoother,
@@ -1928,7 +1933,9 @@ def solve_rheology(
             ``"gauss-seidel-batched"`` additionally merges colors into
             batches with Jacobi-style mass splitting within each
             batch. Good for wide velocity stencils (B2/B3).
-            The iterative linear solvers (``"cg"``, ``"cr"``, ``"gmres"``)
+            The iterative linear solvers (``"conjugate-gradient"``,
+            ``"conjugate-residual"``, ``"generalized-minimal-residual"``, or
+            their abbreviated aliases ``"cg"``, ``"cr"``, and ``"gmres"``)
             only support solid materials without contacts.
         max_iterations: Maximum number of nonlinear iterations.
         tolerance: Solver tolerance for the stress residual (L2 norm).

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -209,8 +209,11 @@ _RheologySolverName = Literal[
     "gauss-seidel-batched",
     "jacobi",
     "cg",
+    "conjugate-gradient",
     "cr",
+    "conjugate-residual",
     "gmres",
+    "generalized-minimal-residual",
 ]
 _MPMVelocityBasisName = Literal["Q1", "B2", "B3"]
 # Python typing cannot express the accepted ``"pic"`` / ``"picN"`` basis family.
@@ -815,9 +818,11 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
         (B2, B3).  Accepted values: ``"auto"``, ``"gs"`` (or
         ``"gauss-seidel"``), ``"gs-soa"`` (or ``"gauss-seidel-soa"``),
         ``"gs-batched"`` (or ``"gauss-seidel-batched"``), ``"jacobi"``,
-        ``"cg"``, ``"cr"``, ``"gmres"``.  Pass an ordered sequence to
-        warmstart solvers left-to-right, e.g. ``("cr", "gs")`` or
-        ``("cg", "jacobi", "gs")``."""
+        ``"conjugate-gradient"`` (or ``"cg"``), ``"conjugate-residual"``
+        (or ``"cr"``), ``"generalized-minimal-residual"`` (or ``"gmres"``).
+        Pass an ordered sequence to warmstart solvers left-to-right, e.g.
+        ``("conjugate-residual", "gauss-seidel")`` or
+        ``("conjugate-gradient", "jacobi", "gauss-seidel")``."""
         warmstart_mode: Literal["none", "auto", "particles", "grid", "smoothed"] = "auto"
         """Warmstart mode to use for the rheology solver.
 

--- a/newton/tests/test_implicit_mpm.py
+++ b/newton/tests/test_implicit_mpm.py
@@ -15,6 +15,7 @@ from newton._src.solvers.implicit_mpm.rasterized_collisions import (
     rasterize_collider_kernel,
 )
 from newton._src.solvers.implicit_mpm.solve_rheology import (
+    _ITERATIVE_LINEAR_SOLVERS,
     ArraySquaredNorm,
     _compute_environment_l2_tolerance_scales,
     _linear_solver_result_norms,
@@ -63,6 +64,14 @@ def _make_mpm_config(grid_type="dense", integration_scheme="pic", solver="jacobi
     config.tolerance = 0.0
     config.warmstart_mode = "grid"
     return config
+
+
+def test_expanded_iterative_solver_names(test, device):
+    """Verify expanded iterative solver names resolve to the existing implementations."""
+    del device
+    test.assertIs(_ITERATIVE_LINEAR_SOLVERS["conjugate-gradient"], _ITERATIVE_LINEAR_SOLVERS["cg"])
+    test.assertIs(_ITERATIVE_LINEAR_SOLVERS["conjugate-residual"], _ITERATIVE_LINEAR_SOLVERS["cr"])
+    test.assertIs(_ITERATIVE_LINEAR_SOLVERS["generalized-minimal-residual"], _ITERATIVE_LINEAR_SOLVERS["gmres"])
 
 
 def _make_two_world_particle_model(device, builder=None, local_builder=None):
@@ -1447,6 +1456,14 @@ basic_cuda_devices = get_cuda_test_devices(mode="basic")
 
 class TestImplicitMPM(unittest.TestCase):
     pass
+
+
+add_function_test(
+    TestImplicitMPM,
+    "test_expanded_iterative_solver_names",
+    test_expanded_iterative_solver_names,
+    devices=basic_devices,
+)
 
 
 add_function_test(


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-name options for conjugate-gradient, conjugate-residual, and generalized-minimal-residual solvers.
  - Existing abbreviated solver names remain supported.

- **Documentation**
  - Updated solver configuration and usage documentation to include the new names and aliases.
  - Added a changelog entry describing the expanded solver naming options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->