### PR TITLE
Retry transient asset download errors

### DIFF
--- a/changelog/3774.fixed.md
+++ b/changelog/3774.fixed.md
@@ -1,0 +1,1 @@
+Retry transient Git errors when downloading assets.

--- a/newton/_src/utils/download_assets.py
+++ b/newton/_src/utils/download_assets.py
@@ -26,6 +26,38 @@ MENAGERIE_URL = "https://github.com/google-deepmind/mujoco_menagerie.git"
 MENAGERIE_REF = "affef0836947b64cc06c4ab1cbf0152835693374"
 
 _SHA_RE = re.compile(r"[0-9a-f]{40}")
+_HTTP_SERVER_ERROR_RE = re.compile(r"\bhttp 5\d\d\b", re.IGNORECASE)
+_GIT_DOWNLOAD_ATTEMPTS = 3
+_GIT_DOWNLOAD_RETRY_DELAY = 1.0
+_TRANSIENT_GIT_ERROR_PATTERNS = (
+    "rpc failed",
+    "early eof",
+    "the remote end hung up",
+    "error reading section header",
+    "expected 'packfile'",
+)
+_PERMANENT_GIT_ERROR_PATTERNS = (
+    "authentication failed",
+    "permission denied",
+    "repository not found",
+    "couldn't find remote ref",
+    "http 401",
+    "http 403",
+    "http 404",
+)
+
+
+def _is_transient_git_error(error: Exception) -> bool:
+    """Return whether a Git error indicates a transient network failure."""
+    stderr = getattr(error, "stderr", "") or ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    details = stderr.lower()
+    if any(pattern in details for pattern in _PERMANENT_GIT_ERROR_PATTERNS):
+        return False
+    return bool(_HTTP_SERVER_ERROR_RE.search(details)) or any(
+        pattern in details for pattern in _TRANSIENT_GIT_ERROR_PATTERNS
+    )
 
 
 def _get_newton_cache_dir() -> str:
@@ -356,9 +388,6 @@ def download_git_folder(
     _cleanup_stale_temp_dirs(cache_path, base_prefix)
 
     try:
-        if temp_dir.exists():
-            _safe_rmtree(temp_dir)
-
         if cached is not None:
             print(
                 f"New version of {folder_path} found "
@@ -368,32 +397,44 @@ def download_git_folder(
         print(f"Cloning {git_url} (ref: {ref})...")
 
         is_sha = bool(_SHA_RE.fullmatch(ref))
-        if is_sha:
-            # Single fetch — skip the clone, which would download the
-            # default-branch tip only to throw it away.
-            repo = gitpython.Repo.init(temp_dir)
+        for attempt in range(_GIT_DOWNLOAD_ATTEMPTS):
             try:
-                repo.create_remote("origin", git_url)
-                repo.git.sparse_checkout("init")
-                repo.git.sparse_checkout("set", folder_path)
-                repo.git.fetch("origin", ref, "--depth=1", "--filter=blob:none")
-                repo.git.checkout("FETCH_HEAD")
-            finally:
-                repo.close()
-        else:
-            repo = gitpython.Repo.clone_from(
-                git_url,
-                temp_dir,
-                branch=ref,
-                depth=1,
-                no_checkout=True,
-                multi_options=["--filter=blob:none", "--sparse"],
-            )
-            try:
-                repo.git.sparse_checkout("set", folder_path)
-                repo.git.checkout(ref)
-            finally:
-                repo.close()
+                if temp_dir.exists():
+                    _safe_rmtree(temp_dir)
+
+                if is_sha:
+                    # Single fetch — skip the clone, which would download the
+                    # default-branch tip only to throw it away.
+                    repo = gitpython.Repo.init(temp_dir)
+                    try:
+                        repo.create_remote("origin", git_url)
+                        repo.git.sparse_checkout("init")
+                        repo.git.sparse_checkout("set", folder_path)
+                        repo.git.fetch("origin", ref, "--depth=1", "--filter=blob:none")
+                        repo.git.checkout("FETCH_HEAD")
+                    finally:
+                        repo.close()
+                else:
+                    repo = gitpython.Repo.clone_from(
+                        git_url,
+                        temp_dir,
+                        branch=ref,
+                        depth=1,
+                        no_checkout=True,
+                        multi_options=["--filter=blob:none", "--sparse"],
+                    )
+                    try:
+                        repo.git.sparse_checkout("set", folder_path)
+                        repo.git.checkout(ref)
+                    finally:
+                        repo.close()
+                break
+            except GitCommandError as e:
+                if attempt == _GIT_DOWNLOAD_ATTEMPTS - 1 or not _is_transient_git_error(e):
+                    raise
+                delay = _GIT_DOWNLOAD_RETRY_DELAY * 2**attempt
+                print(f"Transient Git error. Retrying in {delay:g} seconds...")
+                time.sleep(delay)
 
         temp_target = temp_dir / folder_path
         if not temp_target.exists():

--- a/newton/tests/test_download_assets.py
+++ b/newton/tests/test_download_assets.py
@@ -181,6 +181,117 @@ class TestDownloadAssets(unittest.TestCase):
         self.assertTrue(p.exists())
         self.assertEqual((p / "foo.txt").read_text(encoding="utf-8"), "v1\n")
 
+    def test_transient_fetch_error_retries_from_clean_temp_dir(self):
+        """Retry a transient fetch from a clean temporary directory."""
+        ref = self.work.head.commit.hexsha
+        real_init = git.Repo.init
+        attempts = 0
+        incomplete_repo = mock.Mock()
+        incomplete_repo.git.fetch.side_effect = git.exc.GitCommandError(
+            "git fetch",
+            128,
+            stderr=b"error: RPC failed; HTTP 503\nfatal: expected 'packfile'",
+        )
+
+        def flaky_init(path, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            path = Path(path)
+            if attempts == 1:
+                path.mkdir(parents=True)
+                (path / "partial").write_text("incomplete", encoding="utf-8")
+                return incomplete_repo
+            self.assertFalse(path.exists())
+            return real_init(path, *args, **kwargs)
+
+        with (
+            mock.patch("git.Repo.init", side_effect=flaky_init),
+            mock.patch("newton._src.utils.download_assets.time.sleep") as mock_sleep,
+        ):
+            path = download_git_folder(self.remote_dir, self.asset_rel, cache_dir=self.cache_dir, ref=ref)
+
+        self.assertEqual((path / "foo.txt").read_text(encoding="utf-8"), "v1\n")
+        self.assertEqual(attempts, 2)
+        incomplete_repo.git.fetch.assert_called_once_with("origin", ref, "--depth=1", "--filter=blob:none")
+        incomplete_repo.close.assert_called_once()
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_transient_clone_error_retries_from_clean_temp_dir(self):
+        """Retry a transient clone from a clean temporary directory."""
+        real_clone = git.Repo.clone_from
+        attempts = 0
+
+        def flaky_clone(url, path, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            path = Path(path)
+            if attempts == 1:
+                path.mkdir(parents=True)
+                (path / "partial").write_text("incomplete", encoding="utf-8")
+                raise git.exc.GitCommandError(
+                    "git clone",
+                    128,
+                    stderr="error: RPC failed; HTTP 502\nfatal: early EOF",
+                )
+            self.assertFalse(path.exists())
+            return real_clone(url, path, *args, **kwargs)
+
+        with (
+            mock.patch("git.Repo.clone_from", side_effect=flaky_clone),
+            mock.patch("newton._src.utils.download_assets.time.sleep") as mock_sleep,
+        ):
+            path = download_git_folder(self.remote_dir, self.asset_rel, cache_dir=self.cache_dir, ref="main")
+
+        self.assertEqual((path / "foo.txt").read_text(encoding="utf-8"), "v1\n")
+        self.assertEqual(attempts, 2)
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_transient_fetch_error_stops_after_three_attempts(self):
+        """Stop retrying a transient fetch after three attempts."""
+        error = git.exc.GitCommandError(
+            "git fetch",
+            128,
+            stderr="error: RPC failed; HTTP 503\nfatal: expected 'packfile'",
+        )
+
+        with (
+            mock.patch("git.Repo.init", side_effect=error) as mock_init,
+            mock.patch("newton._src.utils.download_assets.time.sleep") as mock_sleep,
+            self.assertRaises(RuntimeError),
+        ):
+            download_git_folder(
+                self.remote_dir,
+                self.asset_rel,
+                cache_dir=self.cache_dir,
+                ref=self.work.head.commit.hexsha,
+            )
+
+        self.assertEqual(mock_init.call_count, 3)
+        self.assertEqual(mock_sleep.call_args_list, [mock.call(1.0), mock.call(2.0)])
+
+    def test_permanent_fetch_error_does_not_retry(self):
+        """Do not retry a permanent fetch error."""
+        error = git.exc.GitCommandError(
+            "git fetch",
+            128,
+            stderr="error: RPC failed; HTTP 403\nfatal: Authentication failed",
+        )
+
+        with (
+            mock.patch("git.Repo.init", side_effect=error) as mock_init,
+            mock.patch("newton._src.utils.download_assets.time.sleep") as mock_sleep,
+            self.assertRaises(RuntimeError),
+        ):
+            download_git_folder(
+                self.remote_dir,
+                self.asset_rel,
+                cache_dir=self.cache_dir,
+                ref=self.work.head.commit.hexsha,
+            )
+
+        mock_init.assert_called_once()
+        mock_sleep.assert_not_called()
+
 
 class TestSafeRename(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

Retry transient Git fetch and clone failures up to three times with 1 and 2 second backoff. Each retry starts with a clean temporary directory. Permanent and unknown errors still fail immediately.

Closes #3774

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m unittest newton.tests.test_download_assets -v
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-13
```

37 tests passed. All pre-commit hooks passed. The changelog draft rendered successfully.

## Bug fix

**Steps to reproduce:**

1. Start with an empty asset cache.
2. Return a transient HTTP 5xx from Git during a sparse fetch or clone.
3. Observe that the first `GitCommandError` aborts the download.

**Minimal reproduction:**

The issue contains a mock-based reproduction for the failing fetch path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset downloads now automatically retry transient Git failures up to three times with increasing delays.
  * Temporary download data is reset between attempts to improve recovery from incomplete downloads.
  * Permanent errors, such as authentication failures, are reported immediately without retries.
* **Documentation**
  * Added changelog information describing the improved retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->