### PR TITLE
[Kamino] Fix midstep contacts in Moreau integrator

### DIFF
--- a/newton/_src/solvers/kamino/_src/geometry/detector.py
+++ b/newton/_src/solvers/kamino/_src/geometry/detector.py
@@ -34,7 +34,6 @@ from .....core.types import override
 from ...config import CollisionDetectorConfig
 from ..core.data import DataKamino
 from ..core.model import ModelKamino
-from ..core.state import StateKamino
 from ..geometry.contacts import ContactsKamino
 from ..geometry.primitive import CollisionPipelinePrimitive
 from ..geometry.unified import CollisionPipelineUnifiedKamino
@@ -423,7 +422,7 @@ class CollisionDetector:
                 case _:
                     raise ValueError(f"Unsupported CollisionPipelineType: {self._pipeline_type}")
 
-    def collide(self, data: DataKamino, state: StateKamino, contacts: ContactsKamino | None = None):
+    def collide(self, data: DataKamino, contacts: ContactsKamino | None = None):
         """
         Executes collision detection given a model and its associated data.
 
@@ -432,7 +431,10 @@ class CollisionDetector:
 
         Args:
             data: The solver data container holding solver-specific internal geome/shape data.
-            state: The state container holding the time-varying state of simulation.
+                Body poses are sourced from ``data.bodies.q_i`` so that detection follows the
+                configuration the integrator is currently working at. Under a mid-point scheme
+                such as :class:`IntegratorMoreauJean` this is the mid-step pose, whereas under
+                :class:`IntegratorEuler` it still equals the pose at the start of the time-step.
             contacts: An optional ContactsKamino container to store the generated contacts.
                 If `None`, uses the internal ContactsKamino container managed by the CollisionDetector.
         """
@@ -456,17 +458,11 @@ class CollisionDetector:
         if not isinstance(data, DataKamino):
             raise TypeError(f"Cannot perform collision detection: expected DataKamino, got {type(data)}")
 
-        # Ensure that the state is valid
-        if state is None:
-            raise ValueError("Cannot perform collision detection: state is None")
-        if not isinstance(state, StateKamino):
-            raise TypeError(f"Cannot perform collision detection: expected StateKamino, got {type(state)}")
-
         # Execute the configured collision detection pipeline
         match self._pipeline_type:
             case CollisionPipelineType.PRIMITIVE:
-                self._primitive_pipeline.collide(data, state, _contacts)
+                self._primitive_pipeline.collide(data, _contacts)
             case CollisionPipelineType.UNIFIED:
-                self._unified_pipeline.collide(data, state, _contacts)
+                self._unified_pipeline.collide(data, _contacts)
             case _:
                 raise ValueError(f"Unsupported CollisionPipelineType: {self._pipeline_type}")

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
@@ -18,7 +18,6 @@ import warp as wp
 from ......geometry.types import GeoType
 from ...core.data import DataKamino
 from ...core.model import ModelKamino
-from ...core.state import StateKamino
 from ...core.types import to_warp_int32_array, vec6f
 from ..contacts import DEFAULT_GEOM_PAIR_CONTACT_GAP, ContactsKamino
 from .broadphase import (
@@ -162,13 +161,12 @@ class CollisionPipelinePrimitive:
             )
             self._contact_overflow_warning_emitted = wp.zeros(shape=(1,), dtype=wp.int32)
 
-    def collide(self, data: DataKamino, state: StateKamino, contacts: ContactsKamino):
+    def collide(self, data: DataKamino, contacts: ContactsKamino):
         """
-        Runs the unified collision detection pipeline to generate discrete contacts.
+        Runs the primitive collision detection pipeline to generate discrete contacts.
 
         Args:
             data: The data container holding internal time-varying state of the solver.
-            state: The state container holding the time-varying state of the simulation.
             contacts: Output contacts container (will be cleared and populated)
         """
         # Ensure that the pipeline has been finalized
@@ -182,7 +180,7 @@ class CollisionPipelinePrimitive:
 
         # Perform the broad-phase collision detection to generate candidate pairs
         primitive_broadphase_explicit(
-            body_poses=state.q_i,
+            body_poses=data.bodies.q_i,
             geoms_model=self._model.geoms,
             geoms_data=data.geoms,
             bv_type=self._bvtype,

--- a/newton/_src/solvers/kamino/_src/geometry/unified.py
+++ b/newton/_src/solvers/kamino/_src/geometry/unified.py
@@ -29,7 +29,6 @@ from .....geometry.types import GeoType
 from ..core.data import DataKamino
 from ..core.materials import DEFAULT_FRICTION, DEFAULT_RESTITUTION, make_get_material_pair_properties
 from ..core.model import ModelKamino
-from ..core.state import StateKamino
 from ..core.types import (
     to_warp_int32_array,
 )
@@ -580,13 +579,12 @@ class CollisionPipelineUnifiedKamino:
     # Operations
     ###
 
-    def collide(self, data: DataKamino, state: StateKamino, contacts: ContactsKamino):
+    def collide(self, data: DataKamino, contacts: ContactsKamino):
         """
         Runs the unified collision detection pipeline to generate discrete contacts.
 
         Args:
             data: The data container holding the time-varying state of the simulation.
-            state: The state container holding the current simulation state.
             contacts: Output contacts container (will be cleared and populated).
         """
         # Check if contacts is allocated on the same device
@@ -605,7 +603,7 @@ class CollisionPipelineUnifiedKamino:
         self._contact_overflow_warning_emitted.zero_()
 
         # Update geometry poses from body states and compute respective AABBs
-        self._update_geom_data(data, state)
+        self._update_geom_data(data)
 
         # Run broad-phase collision detection to get candidate shape pairs
         self._run_broadphase()
@@ -645,13 +643,12 @@ class CollisionPipelineUnifiedKamino:
         if self._model.geoms.collision_radius is not None:
             self.collision_radius.assign(self._model.geoms.collision_radius)
 
-    def _update_geom_data(self, data: DataKamino, state: StateKamino):
+    def _update_geom_data(self, data: DataKamino):
         """
         Updates geometry poses from corresponding body states and computes respective AABBs.
 
         Args:
             data: The data container holding the time-varying state of the simulation.
-            state: The state container holding the current simulation state.
         """
         wp.launch(
             kernel=_update_geom_poses_and_compute_aabbs,
@@ -665,7 +662,7 @@ class CollisionPipelineUnifiedKamino:
                 self._model.geoms.gap,
                 self.geom_data,
                 self.collision_radius,
-                state.q_i,
+                data.bodies.q_i,
             ],
             outputs=[
                 data.geoms.pose,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -284,11 +284,19 @@ class SolverKaminoImpl(SolverBase):
         if self._config.use_fk_solver:
             self._solver_fk = ForwardKinematicsSolver(model=self._model, config=self._config.fk)
 
-        # Create the time-integrator instance based on the config
+        # Contacts generated externally are evaluated at the start of a step, so they require
+        # Euler integration. Moreau-Jean is valid only with the internal mid-step detector.
         if self._config.integrator == "euler":
             self._integrator = IntegratorEuler(model=self._model)
         elif self._config.integrator == "moreau":
-            self._integrator = IntegratorMoreauJean(model=self._model)
+            if self._config.use_collision_detector:
+                self._integrator = IntegratorMoreauJean(model=self._model)
+            else:
+                msg.warning(
+                    "Falling back to the 'euler' integrator: 'moreau' requires "
+                    "`use_collision_detector=True` to generate contacts at the mid-point."
+                )
+                self._integrator = IntegratorEuler(model=self._model)
         else:
             raise ValueError(
                 f"Unsupported integrator type: Expected 'euler' or 'moreau', but got {self._config.integrator}."
@@ -1127,7 +1135,7 @@ class SolverKaminoImpl(SolverBase):
         # If a collision detector is provided, use it to generate
         # update the set of active contacts at the current state
         if detector is not None:
-            detector.collide(data=self._data, state=state_in, contacts=contacts)
+            detector.collide(data=self._data, contacts=contacts)
 
         # If a limits container/detector is provided, run joint-limit
         # detection to generate active joint limits at the current state

--- a/newton/_src/solvers/kamino/examples/rl/test_multi_env_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/rl/test_multi_env_dr_legs.py
@@ -30,6 +30,7 @@ wp.set_module_options({"enable_backward": False})
 def make_settings(sim_dt: float = 0.004) -> Simulator.Config:
     settings = Simulator.Config()
     settings.dt = sim_dt
+    settings.solver.use_collision_detector = True
     settings.solver.integrator = "moreau"
     settings.solver.constraints.alpha = 0.1
     settings.solver.padmm.primal_tolerance = 1e-6

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -240,6 +240,7 @@ class Example:
         sparse = sparse or dynamics_solver == "dvi"
         config.solver.sparse_jacobian = sparse
         config.solver.sparse_dynamics = sparse
+        config.solver.use_collision_detector = True
         config.solver.integrator = "moreau"  # Select from {"euler", "moreau"}
         config.solver.constraints.alpha = 0.1
         config.solver.constraints.beta = 0.011

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -249,7 +249,9 @@ class SolverKamino(SolverBase, CouplingInterface):
 
         integrator: Literal["euler", "moreau"] = "euler"
         """
-        The time-integrator to use for state integration.\n
+        The time-integrator to use for state integration. The ``"moreau"`` option requires
+        ``use_collision_detector=True``.\n
+
         See available options in the `integrators` module.\n
         Defaults to `"euler"`.
         """
@@ -966,10 +968,11 @@ class SolverKamino(SolverBase, CouplingInterface):
         """
         Simulate the model for a given time step using the given control input.
 
-        When ``contacts`` is not ``None`` (i.e. populated by :meth:`~newton.CollisionPipeline.collide`),
-        those contacts are converted to Kamino's internal format and used directly,
-        bypassing Kamino's own collision detector.  When ``contacts`` is ``None``,
-        Kamino's internal collision pipeline runs as a fallback.
+        Contact source is selected when the solver is constructed. When
+        :attr:`Config.use_collision_detector` is enabled, Kamino's internal collision pipeline
+        generates contacts on every step and ``contacts`` is ignored. Otherwise, non-``None``
+        contacts (for example, populated by :meth:`~newton.CollisionPipeline.collide`) are
+        converted to Kamino's internal format and used directly.
 
         Args:
             state_in: The input state.
@@ -977,8 +980,8 @@ class SolverKamino(SolverBase, CouplingInterface):
             control: The control input.
                 Defaults to `None` which means the control values from the
                 :class:`Model` are used.
-            contacts: The contact information from Newton's collision
-                pipeline, or ``None`` to use Kamino's internal collision detector.
+            contacts: The contact information from Newton's collision pipeline. Ignored when
+                :attr:`Config.use_collision_detector` is enabled.
             dt: The time step (typically in seconds).
         """
         # Interface the input state containers to Kamino's equivalents
@@ -993,8 +996,10 @@ class SolverKamino(SolverBase, CouplingInterface):
             control = self.model.control(clone_variables=False)
         self._control_kamino.from_newton(control, self._model_kamino)
 
-        # If contacts are provided, use them directly, bypassing Kamino's collision detector
-        if contacts is not None:
+        # Internal detection is authoritative when enabled for this solver.
+        if self._config.use_collision_detector:
+            self._detector = self._collision_detector_kamino
+        elif contacts is not None:
             self._detector = None
             self._kamino.convert_contacts_newton_to_kamino(
                 model=self.model,
@@ -1005,9 +1010,10 @@ class SolverKamino(SolverBase, CouplingInterface):
                 friction_mix_mode=self._config.materials.friction_mix_mode,
                 restitution_mix_mode=self._config.materials.restitution_mix_mode,
             )
-        # Otherwise, use Kamino's internal collision detector to generate contacts
         else:
-            self._detector = self._collision_detector_kamino
+            self._detector = None
+            # Clear the internal contacts container to avoid using stale contacts from previous steps.
+            self._contacts_kamino.clear()
 
         # Convert Newton body-frame poses to Kamino CoM-frame poses
         self._kamino.convert_body_origin_to_com(

--- a/newton/examples/kamino/example_kamino_robot_dr_legs.py
+++ b/newton/examples/kamino/example_kamino_robot_dr_legs.py
@@ -92,7 +92,8 @@ class Example:
         self.config.padmm.use_graph_conditionals = getattr(args, "use_graph_conditionals", True) if args else True
         if self.dynamics_solver == "dvi":
             self.config.use_fk_solver = False
-            self.config.integrator = "moreau"
+            if self.use_kamino_contacts:
+                self.config.integrator = "moreau"
             self.config.constraints.alpha = 0.1
             self.config.constraints.beta = 0.011
             self.config.constraints.gamma = 0.015

--- a/newton/tests/kamino/test_kamino_geometry_aggregation.py
+++ b/newton/tests/kamino/test_kamino_geometry_aggregation.py
@@ -51,7 +51,6 @@ class TestContactAggregation(unittest.TestCase):
         builder = make_homogeneous_builder(num_worlds=3, build_fn=self.build_func)
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
 
         # Create a collision detector with primitive pipeline
         config = CollisionDetector.Config(
@@ -66,7 +65,7 @@ class TestContactAggregation(unittest.TestCase):
         aggregator = ContactAggregation(model=model, contacts=detector.contacts)
 
         # Run collision detection and aggregate per-body and per-geom contacts
-        detector.collide(data, state)
+        detector.collide(data)
 
         # Set contact reactions to known values for testing aggregation results
         model_active_nc = int(detector.contacts.model_active_contacts.numpy()[0])

--- a/newton/tests/kamino/test_kamino_geometry_detector.py
+++ b/newton/tests/kamino/test_kamino_geometry_detector.py
@@ -94,7 +94,6 @@ class TestGeometryCollisionDetector(unittest.TestCase):
         builder = make_homogeneous_builder(num_worlds=3, build_fn=self.build_func)
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
 
         # Create a collision detector with primitive pipeline
         config = CollisionDetector.Config(
@@ -106,7 +105,7 @@ class TestGeometryCollisionDetector(unittest.TestCase):
         self.assertIs(detector.device, self.default_device)
 
         # Run collision detection
-        detector.collide(data, state)
+        detector.collide(data)
 
         # Create a list of expected number of contacts per shape pair
         expected_world_contacts: list[int] = [self.expected_contacts] * builder.num_worlds
@@ -135,7 +134,6 @@ class TestGeometryCollisionDetector(unittest.TestCase):
         builder = make_homogeneous_builder(num_worlds=3, build_fn=self.build_func)
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
 
         # Create a collision detector with unified pipeline
         config = CollisionDetector.Config(
@@ -147,7 +145,7 @@ class TestGeometryCollisionDetector(unittest.TestCase):
         self.assertIs(detector.device, self.default_device)
 
         # Run collision detection
-        detector.collide(data, state)
+        detector.collide(data)
 
         # Create a list of expected number of contacts per shape pair
         expected_world_contacts: list[int] = [self.expected_contacts] * builder.num_worlds

--- a/newton/tests/kamino/test_kamino_geometry_margin_gap.py
+++ b/newton/tests/kamino/test_kamino_geometry_margin_gap.py
@@ -62,12 +62,11 @@ def _run_primitive_pipeline(builder: ModelBuilderKamino, device, max_contacts_pe
     """Run broadphase + narrowphase and return the contacts container."""
     model = builder.finalize(device)
     data = model.data()
-    state = model.state()
     _, world_req = builder.compute_required_contact_capacity(max_contacts_per_pair=max_contacts_per_pair)
     contacts = ContactsKamino(capacity=world_req, device=device)
     contacts.clear()
     pipeline = CollisionPipelinePrimitive(model=model, bvtype="aabb", default_gap=0.0)
-    pipeline.collide(data, state, contacts)
+    pipeline.collide(data, contacts)
     return contacts, model
 
 

--- a/newton/tests/kamino/test_kamino_geometry_mesh_heightfield.py
+++ b/newton/tests/kamino/test_kamino_geometry_mesh_heightfield.py
@@ -392,9 +392,7 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
     def test_04_multi_world_heightfield(self):
         """Multi-world sphere-on-heightfield: each world gets exactly 2 contacts (1 per triangle)."""
         num_worlds = 3
-        _, model, data = _finalize_and_get_kamino(
-            _build_multi_world_heightfield(num_worlds), self.default_device
-        )
+        _, model, data = _finalize_and_get_kamino(_build_multi_world_heightfield(num_worlds), self.default_device)
         contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])

--- a/newton/tests/kamino/test_kamino_geometry_mesh_heightfield.py
+++ b/newton/tests/kamino/test_kamino_geometry_mesh_heightfield.py
@@ -181,15 +181,14 @@ def _build_multi_world_heightfield(num_worlds: int = 3) -> newton.ModelBuilder:
 
 
 def _finalize_and_get_kamino(builder, device):
-    """Finalize Newton model, create Kamino model, data, and state."""
+    """Finalize Newton model and create Kamino model data."""
     newton_model = builder.finalize(device=device)
     model = ModelKamino.from_newton(newton_model)
     data = model.data(device=device)
-    state = model.state(device=device)
-    return newton_model, model, data, state
+    return newton_model, model, data
 
 
-def _run_unified_pipeline(model, data, state, device):
+def _run_unified_pipeline(model, data, device):
     """Create unified pipeline, allocate contacts, run collision detection."""
     num_worlds = model.size.num_worlds
     pipeline = CollisionPipelineUnifiedKamino(
@@ -198,7 +197,7 @@ def _run_unified_pipeline(model, data, state, device):
     )
     contacts = ContactsKamino(capacity=[4096] * num_worlds, device=device)
     contacts.clear()
-    pipeline.collide(data, state, contacts)
+    pipeline.collide(data, contacts)
     return contacts
 
 
@@ -311,8 +310,8 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
 
     def test_01_sphere_on_flat_heightfield(self):
         """Sphere touching flat heightfield: 2 contacts (one per cell triangle), normal=(0,0,1), position at z=0."""
-        _, model, data, state = _finalize_and_get_kamino(_build_sphere_on_heightfield(), self.default_device)
-        contacts = _run_unified_pipeline(model, data, state, self.default_device)
+        _, model, data = _finalize_and_get_kamino(_build_sphere_on_heightfield(), self.default_device)
+        contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])
         # A sphere centered over a heightfield cell touches both triangles in that cell,
@@ -347,8 +346,8 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
 
     def test_02_box_on_flat_heightfield(self):
         """Box resting on flat heightfield: >=4 contacts, all at z ≈ 0."""
-        _, model, data, state = _finalize_and_get_kamino(_build_box_on_heightfield(), self.default_device)
-        contacts = _run_unified_pipeline(model, data, state, self.default_device)
+        _, model, data = _finalize_and_get_kamino(_build_box_on_heightfield(), self.default_device)
+        contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])
         self.assertGreaterEqual(nc, 4, f"Box face on heightfield should produce >=4 contacts, got {nc}")
@@ -376,8 +375,8 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
 
     def test_03_heightfield_terrain(self):
         """Sphere on sine-wave terrain: contacts generated, normal has upward component."""
-        _, model, data, state = _finalize_and_get_kamino(_build_heightfield_terrain(), self.default_device)
-        contacts = _run_unified_pipeline(model, data, state, self.default_device)
+        _, model, data = _finalize_and_get_kamino(_build_heightfield_terrain(), self.default_device)
+        contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])
         self.assertGreaterEqual(nc, 1, "Sphere on terrain must produce contacts")
@@ -393,10 +392,10 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
     def test_04_multi_world_heightfield(self):
         """Multi-world sphere-on-heightfield: each world gets exactly 2 contacts (1 per triangle)."""
         num_worlds = 3
-        _, model, data, state = _finalize_and_get_kamino(
+        _, model, data = _finalize_and_get_kamino(
             _build_multi_world_heightfield(num_worlds), self.default_device
         )
-        contacts = _run_unified_pipeline(model, data, state, self.default_device)
+        contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])
         expected_total = 2 * num_worlds  # 2 contacts per sphere (one per cell triangle)
@@ -408,10 +407,10 @@ class TestUnifiedPipelineMeshHeightfield(unittest.TestCase):
 
     def test_05_no_contacts_when_separated(self):
         """Sphere far above heightfield must produce zero contacts."""
-        _, model, data, state = _finalize_and_get_kamino(
+        _, model, data = _finalize_and_get_kamino(
             _build_sphere_on_heightfield(sphere_z=SPHERE_RADIUS + 1.0), self.default_device
         )
-        contacts = _run_unified_pipeline(model, data, state, self.default_device)
+        contacts = _run_unified_pipeline(model, data, self.default_device)
 
         nc = int(contacts.model_active_contacts.numpy()[0])
         self.assertEqual(nc, 0, f"Separated sphere should produce 0 contacts, got {nc}")

--- a/newton/tests/kamino/test_kamino_geometry_primitive.py
+++ b/newton/tests/kamino/test_kamino_geometry_primitive.py
@@ -1037,7 +1037,7 @@ class TestPipelinePrimitive(unittest.TestCase):
         self.assertIsNone(pipeline._device)
         self.assertEqual(pipeline._bvtype, BoundingVolumeType.AABB)
         self.assertEqual(pipeline._default_gap, DEFAULT_GEOM_PAIR_CONTACT_GAP)
-        self.assertRaises(RuntimeError, pipeline.collide, ModelKamino(), DataKamino(), ContactsKamino())
+        self.assertRaises(RuntimeError, pipeline.collide, DataKamino(), ContactsKamino())
 
     def test_02_make_and_collide(self):
         """
@@ -1064,7 +1064,6 @@ class TestPipelinePrimitive(unittest.TestCase):
         )
         model = builder.finalize(device=self.default_device)
         data = model.data()
-        state = model.state()
 
         # Create a contacts container
         max_contacts_per_pair = 12  # Conservative estimate based on max contacts for any supported shape pair
@@ -1076,7 +1075,7 @@ class TestPipelinePrimitive(unittest.TestCase):
         pipeline = CollisionPipelinePrimitive(model=model)
 
         # Run collision detection
-        pipeline.collide(data, state, contacts)
+        pipeline.collide(data, contacts)
 
         # Create a list of expected number of contacts per shape pair
         expected_contacts_per_pair: list[int] = list(nominal_expected_contacts_per_shape_pair.values())
@@ -1101,22 +1100,21 @@ class TestPipelinePrimitive(unittest.TestCase):
         builder = testing.make_shape_pairs_builder(shape_pairs=[("box", "box")])
         model = builder.finalize(device=self.default_device)
         data = model.data()
-        state = model.state()
         contacts_small = ContactsKamino(capacity=1, device=self.default_device)
         contacts_large = ContactsKamino(capacity=8, device=self.default_device)
         pipeline = CollisionPipelinePrimitive(model=model)
 
-        pipeline.collide(data, state, contacts_small)
+        pipeline.collide(data, contacts_small)
 
         self.assertEqual(int(contacts_small.model_active_contacts.numpy()[0]), 1)
         self.assertEqual(int(contacts_small.world_active_contacts.numpy()[0]), 1)
         self.assertEqual(int(pipeline._contact_overflow_warning_emitted.numpy()[0]), 1)
 
-        pipeline.collide(data, state, contacts_large)
+        pipeline.collide(data, contacts_large)
 
         self.assertEqual(int(pipeline._contact_overflow_warning_emitted.numpy()[0]), 0)
 
-        pipeline.collide(data, state, contacts_small)
+        pipeline.collide(data, contacts_small)
 
         self.assertEqual(int(pipeline._contact_overflow_warning_emitted.numpy()[0]), 1)
 

--- a/newton/tests/kamino/test_kamino_geometry_unified.py
+++ b/newton/tests/kamino/test_kamino_geometry_unified.py
@@ -17,7 +17,6 @@ from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.math import I_3
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.shapes import SphereShape
-from newton._src.solvers.kamino._src.core.state import StateKamino
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
 from newton._src.solvers.kamino._src.geometry.unified import CollisionPipelineUnifiedKamino
 from newton._src.solvers.kamino._src.models.builders import basics, testing
@@ -110,7 +109,6 @@ def test_unified_pipeline(
     # Create a test model and data
     model: ModelKamino = builder.finalize(device)
     data: DataKamino = model.data()
-    state: StateKamino = model.state()
     contacts = ContactsKamino(model=model, device=device)
 
     # Run the narrow-phase test over each broad-phase backend
@@ -127,7 +125,7 @@ def test_unified_pipeline(
         )
 
         # Execute the unified collision detection pipeline
-        pipeline.collide(data, state, contacts)
+        pipeline.collide(data, contacts)
 
         # Optional verbose output
         msg.debug("[%s][%s]: bodies.q_i:\n%s", case, bp_mode, data.bodies.q_i)
@@ -565,7 +563,6 @@ class TestUnifiedWriterContactDataRegression(unittest.TestCase):
     def _run_pipeline(self, builder: ModelBuilderKamino, default_gap=0.0):
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
         pipeline = CollisionPipelineUnifiedKamino(
             model=model,
             broadphase="explicit",
@@ -575,7 +572,7 @@ class TestUnifiedWriterContactDataRegression(unittest.TestCase):
         capacity = 8 * ((n_geoms * (n_geoms - 1)) // 2)
         contacts = ContactsKamino(capacity=max(capacity, 8), device=self.default_device)
         contacts.clear()
-        pipeline.collide(data, state, contacts)
+        pipeline.collide(data, contacts)
         return contacts
 
     def test_00_touching_spheres_produces_contact(self):
@@ -723,7 +720,6 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
 
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
 
         pipeline = CollisionPipelineUnifiedKamino(
             model=model,
@@ -736,7 +732,7 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
         contacts = ContactsKamino(capacity=max(capacity, 12), device=self.default_device)
         contacts.clear()
 
-        pipeline.collide(data, state, contacts)
+        pipeline.collide(data, contacts)
 
         active = contacts.model_active_contacts.numpy()[0]
         self.assertEqual(active, 0, "Non-collidable groups must produce zero contacts via NXN")
@@ -751,7 +747,6 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
 
         model = builder.finalize(self.default_device)
         data = model.data()
-        state = model.state()
 
         pipeline = CollisionPipelineUnifiedKamino(
             model=model,
@@ -764,7 +759,7 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
         contacts = ContactsKamino(capacity=max(capacity, 12), device=self.default_device)
         contacts.clear()
 
-        pipeline.collide(data, state, contacts)
+        pipeline.collide(data, contacts)
 
         active = contacts.model_active_contacts.numpy()[0]
         self.assertEqual(active, 0, "Same-body shapes must not collide via NXN broadphase")

--- a/newton/tests/kamino/test_kamino_solver_kamino.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino.py
@@ -20,6 +20,7 @@ from newton._src.solvers.kamino._src.core.state import StateKamino
 from newton._src.solvers.kamino._src.dynamics import DualProblem
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
 from newton._src.solvers.kamino._src.geometry.detector import CollisionDetector
+from newton._src.solvers.kamino._src.integrators import IntegratorEuler, IntegratorMoreauJean
 from newton._src.solvers.kamino._src.kinematics.jacobians import DenseSystemJacobians, SparseSystemJacobians
 from newton._src.solvers.kamino._src.kinematics.joints import JointCorrectionMode, compute_joints_data
 from newton._src.solvers.kamino._src.kinematics.limits import LimitsKamino
@@ -446,6 +447,28 @@ class TestCollisionCapacityInitialization(unittest.TestCase):
 
         self.assertEqual(model.rigid_contact_max, solver._contacts_kamino.model_max_contacts_host)
         self.assertEqual(pipeline.rigid_contact_max, solver._contacts_kamino.model_max_contacts_host)
+
+    def test_moreau_uses_internal_detection(self):
+        """Verify Moreau-Jean is selected with internal collision detection."""
+        model = self._make_three_world_model()
+        solver = SolverKamino(
+            model,
+            config=SolverKamino.Config(integrator="moreau", use_collision_detector=True),
+        )
+
+        self.assertIsInstance(solver._solver_kamino._integrator, IntegratorMoreauJean)
+
+    def test_external_contacts_use_euler(self):
+        """Verify external-contact configurations warn and pick Euler."""
+        model = self._make_three_world_model()
+        with self.assertLogs(level="WARNING") as logs:
+            solver = SolverKamino(
+                model,
+                config=SolverKamino.Config(integrator="moreau", use_collision_detector=False),
+            )
+
+        self.assertIsInstance(solver._solver_kamino._integrator, IntegratorEuler)
+        self.assertTrue(any("Falling back to the 'euler' integrator" in message for message in logs.output))
 
     def test_external_collisions_preserve_explicit_rigid_contact_max(self):
         """Verify external collisions preserve an explicit contact capacity."""

--- a/newton/tests/kamino/test_kamino_solver_kamino.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino.py
@@ -458,6 +458,38 @@ class TestCollisionCapacityInitialization(unittest.TestCase):
 
         self.assertIsInstance(solver._solver_kamino._integrator, IntegratorMoreauJean)
 
+    def test_moreau_detects_midpoint_contact(self):
+        """Verify Moreau-Jean detects contacts created at the midpoint."""
+        # Start the sphere surface 0.3 m above the zero-gap ground plane.
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        SolverKamino.register_custom_attributes(builder)
+        basics.build_sphere_on_plane(builder=builder, z_offset=0.3)
+        model = builder.finalize(device=self.default_device, skip_validation_joints=True)
+
+        config = SolverKamino.Config(integrator="moreau", use_collision_detector=True)
+        solver = SolverKamino(model, config=config)
+
+        detector = solver._collision_detector_kamino
+        contacts = solver._contacts_kamino
+        assert detector is not None
+        assert contacts is not None
+        assert contacts.model_active_contacts is not None
+
+        # Establish that the step-start configuration has no contacts.
+        detector.collide(data=solver._solver_kamino._data, contacts=contacts)
+        self.assertEqual(int(contacts.model_active_contacts.numpy()[0]), 0)
+
+        state_in = model.state()
+        state_out = model.state()
+        assert state_in.body_qd is not None
+        # Over the first half-step, the sphere moves 0.35 m down and penetrates the plane.
+        state_in.body_qd.assign(np.array([[0.0, 0.0, -7.0, 0.0, 0.0, 0.0]], dtype=np.float32))
+
+        solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+
+        # This contact exists only if detection uses the midpoint rather than state_in.
+        self.assertGreater(int(contacts.model_active_contacts.numpy()[0]), 0)
+
     def test_external_contacts_use_euler(self):
         """Verify external-contact configurations warn and pick Euler."""
         model = self._make_three_world_model()

--- a/newton/tests/kamino/utils/make.py
+++ b/newton/tests/kamino/utils/make.py
@@ -180,7 +180,7 @@ def update_containers(
 
     # Run collision detection to generate active contacts
     if detector is not None:
-        detector.collide(data=data, state=state)
+        detector.collide(data)
         wp.synchronize()
 
     # Update the constraint state info
@@ -271,7 +271,7 @@ def make_test_problem(
 
     # Run collision detection to generate active contacts
     if with_contacts:
-        detector.collide(data, state)
+        detector.collide(data)
         wp.synchronize()
         if verbose:
             print(f"contacts.world_active_contacts: {detector.contacts.world_active_contacts}")


### PR DESCRIPTION
## Description

Previously, the Moreau time-stepping scheme was using contact detection at the start of the step. This created wrong kinematics for the contact Jacobians, where the body state was taken at t+1/2, but the contact point stayed at is original position. 2 changes are made:
- Moreau + internal detector now detect contact at the mid-point.
- Moreau + external detector is rejected. I implemented a fallback to Euler with a warning.

Note that in order to pick the integrator at config time, I changed the implementation to always use the internal contact detector if one was created. Before, the code would still using the external contacts if you created Kamino with a detector, but gave it external contacts. I think the new behavior is more inline with what you expect from the config. This is also what MJWarp does when their internal detector is selected via the config.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Benchmarks
| Worktree | Path | Commit | Role |
|---|---|---|---|
| `kamino-start` | `/home/rgrandia/code/newton-tmp/kamino-start` | `83f09811` | Historical Moreau, **start-of-step** detection |
| `kamino-midpoint` | `/home/rgrandia/code/newton-tmp/kamino-midpoint` | `2c7fa6ab` | Fixed Moreau, **midpoint** detection; Euler runs here |

Shared run configuration for all 190 runs:
- GPU: `cuda:0` (RTX 5090), seed `0`, no CUDA graphs, no controls
- `use_collision_detector=True`, `max_contacts_per_world=1024`, unified pipeline
- Default PADMM “accurate” solver config from `make_solver_config_default()`
- All material / material-pair restitution forced to `0.0`

Three solver configs per scenario:
1. `kamino-start` / Moreau / start-of-step  
2. `kamino-midpoint` / Moreau / midpoint  
3. `kamino-midpoint` / Euler / start-of-step (on the fixed branch)

---

## Box-on-plane impact

Setup: 20 mm clearance (`z_offset=0.02`), velocities `(0,0,-8)` and `(5,0,-8)`, 0.1 s sim, dt ∈ {1/120 … 1/960}.  
Reference: midpoint Moreau at **1/7680 s**.  
Height offsets: ±2 mm (median/max/std reported across 5 offsets).

### Normal impact (median over height offsets)

| Config | dt=1/120 | dt=1/240 | dt=1/480 | dt=1/960 |
|---|---:|---:|---:|---:|
| **start / Moreau** peak penetr. [mm] | 5.51 | 2.43 | 1.48 | 0.79 |
| **midpoint / Moreau** peak penetr. [mm] | 2.53 | 1.44 | 0.52 | 0.21 |
| **midpoint / Euler** peak penetr. [mm] | 2.53 | 1.44 | 0.52 | 0.21 |

Touchdown time is essentially unchanged (~65–75 ms).

Final position error vs the 1/7680 s midpoint-Moreau reference (median over height offsets):

| Config | dt=1/120 | dt=1/240 | dt=1/480 | dt=1/960 |
|---|---:|---:|---:|---:|
| **start / Moreau** pos. err. [mm] | 5.37 | 2.26 | 1.28 | 0.57 |
| **midpoint / Moreau** pos. err. [mm] | 2.45 | 1.33 | 0.44 | 0.15 |
| **midpoint / Euler** pos. err. [mm] | 2.43 | 1.32 | 0.44 | 0.15 |

At **dt=1/960**, midpoint Moreau vs start (difference of medians over height offsets): peak penetration **0.79 → 0.21 mm** (−0.57 mm); final position error **0.57 → 0.15 mm** (−0.42 mm).

### Oblique impact (median over height offsets)

| Config | dt=1/120 | dt=1/240 | dt=1/480 | dt=1/960 |
|---|---:|---:|---:|---:|
| **start / Moreau** peak penetr. [mm] | 6.75 | 4.03 | 2.05 | 0.85 |
| **midpoint / Moreau** peak penetr. [mm] | 4.59 | 2.44 | 1.05 | 0.48 |
| **midpoint / Euler** peak penetr. [mm] | 5.03 | 2.35 | 1.10 | 0.69 |

Final position error vs the 1/7680 s midpoint-Moreau reference (median over height offsets):

| Config | dt=1/120 | dt=1/240 | dt=1/480 | dt=1/960 |
|---|---:|---:|---:|---:|
| **start / Moreau** pos. err. [mm] | 2.23 | 1.21 | 0.64 | 0.32 |
| **midpoint / Moreau** pos. err. [mm] | 1.13 | 0.88 | 0.33 | 0.18 |
| **midpoint / Euler** pos. err. [mm] | 2.86 | 1.52 | 0.70 | 0.29 |

At **dt=1/960**, midpoint Moreau vs start (difference of medians over height offsets): peak penetration **0.85 → 0.48 mm** (−0.36 mm); final position error **0.32 → 0.18 mm** (−0.14 mm).

Post-impact force variation (window `[touchdown+dt, touchdown+dt+50 ms]`, touchdown step excluded) is near zero for normal impact; oblique shows larger transient spread at coarse dt for start-of-step Moreau (postF std up to ~4.6 N at 1/960). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved collision handling by consistently using current model data.
  - Moreau-Jean integration now works with internally detected contacts.
  - Added automatic fallback to Euler integration when collision detection is unavailable.
  - Clarified collision-source selection and prevented stale contact data.

- **Bug Fixes**
  - Fixed contact handling for internal and externally supplied collisions.
  - Enabled collision detection in relevant simulator and example configurations.

- **Tests**
  - Expanded coverage for midpoint contact detection, integrator selection, and collision pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->