### PR TITLE
Fix frictionless Coulomb dual cone projection in PADMM

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -45,14 +45,13 @@ wp.set_module_options({"enable_backward": False})
 
 
 @wp.func
-def project_to_coulomb_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0.0) -> wp.vec3f:
+def project_to_coulomb_cone(x: wp.vec3f, mu: wp.float32) -> wp.vec3f:
     """
     Projects a 3D vector `x` onto an isotropic Coulomb friction cone defined by the friction coefficient `mu`.
 
     Args:
         x: The input vector to be projected.
         mu: The friction coefficient defining the aperture of the cone.
-        epsilon: A numerical tolerance applied to the cone boundary. Defaults to 0.0.
 
     Returns:
         The vector projected onto the Coulomb cone.
@@ -60,8 +59,11 @@ def project_to_coulomb_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0
     xn = x[2]
     xt_norm = wp.sqrt(x[0] * x[0] + x[1] * x[1])
     y = wp.vec3f(0.0)
-    if mu * xt_norm > -xn + epsilon:
-        if xt_norm <= mu * xn + epsilon:
+    # The polar-cone test must precede the membership test: at mu = 0 the primal
+    # cone degenerates to the ray { xt = 0, xn >= 0 }, testing xt_norm <= mu * xn
+    # first would leave the infeasible point (0, 0, -xn) unchanged.
+    if mu * xt_norm > -xn:
+        if xt_norm <= mu * xn:
             y = x
         else:
             ys = (mu * xt_norm + xn) / (mu * mu + 1.0)
@@ -73,7 +75,7 @@ def project_to_coulomb_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0
 
 
 @wp.func
-def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0.0) -> wp.vec3f:
+def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32) -> wp.vec3f:
     """
     Projects a 3D vector `x` onto the dual of an isotropic Coulomb
     friction cone defined by the friction coefficient `mu`.
@@ -81,7 +83,6 @@ def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float3
     Args:
         x: The input vector to be projected.
         mu: The friction coefficient defining the aperture of the cone.
-        epsilon: A numerical tolerance applied to the cone boundary. Defaults to 0.0.
 
     Returns:
         The vector projected onto the dual Coulomb cone.
@@ -92,9 +93,9 @@ def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float3
     # The membership test must precede the polar-cone test: at mu = 0 the dual
     # cone degenerates to the half-space xn >= 0, testing xt_norm > -mu * xn first
     # would map the feasible point (0, 0, +xn) to zero.
-    if mu * xt_norm <= xn + epsilon:
+    if mu * xt_norm <= xn:
         y = x
-    elif xt_norm > -mu * xn + epsilon:
+    elif xt_norm > -mu * xn:
         ys = (xt_norm + mu * xn) / (mu * mu + 1.0)
         yts = ys / xt_norm
         y[0] = yts * x[0]

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -90,7 +90,7 @@ def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float3
     xt_norm = wp.sqrt(x[0] * x[0] + x[1] * x[1])
     y = wp.vec3f(0.0)
     # The membership test must precede the polar-cone test: at mu = 0 the dual
-    # cone degenerates to the half-space xn >= 0, testing xt_norm > -mu * xn first 
+    # cone degenerates to the half-space xn >= 0, testing xt_norm > -mu * xn first
     # would map the feasible point (0, 0, +xn) to zero.
     if mu * xt_norm <= xn + epsilon:
         y = x

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -89,15 +89,17 @@ def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float3
     xn = x[2]
     xt_norm = wp.sqrt(x[0] * x[0] + x[1] * x[1])
     y = wp.vec3f(0.0)
-    if xt_norm > -mu * xn + epsilon:
-        if mu * xt_norm <= xn + epsilon:
-            y = x
-        else:
-            ys = (xt_norm + mu * xn) / (mu * mu + 1.0)
-            yts = ys / xt_norm
-            y[0] = yts * x[0]
-            y[1] = yts * x[1]
-            y[2] = mu * ys
+    # The membership test must precede the polar-cone test: at mu = 0 the dual
+    # cone degenerates to the half-space xn >= 0, testing xt_norm > -mu * xn first 
+    # would map the feasible point (0, 0, +xn) to zero.
+    if mu * xt_norm <= xn + epsilon:
+        y = x
+    elif xt_norm > -mu * xn + epsilon:
+        ys = (xt_norm + mu * xn) / (mu * mu + 1.0)
+        yts = ys / xt_norm
+        y[0] = yts * x[0]
+        y[1] = yts * x[1]
+        y[2] = mu * ys
     return y
 
 

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -1114,6 +1114,7 @@ class TestPADMMSolver(unittest.TestCase):
         self.assertLess(primal_error.max(), 1.0e-6)
         self.assertLess(dual_error.max(), 1.0e-6)
 
+
 ###
 # Test execution
 ###

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -435,95 +435,6 @@ def save_solver_info(solver: PADMMSolver, path: str | None = None, verbose: bool
     plt.close()
 
 
-def project_to_second_order_cone(x: np.ndarray, aperture: float) -> np.ndarray:
-    """
-    Computes a float64 reference projection onto the second-order cone `{ ||x_t|| <= aperture * x_n }`.
-
-    The two degenerate apertures are handled separately, both because the general formula
-    cannot represent them and because a zero aperture would compare against `-0.0`:
-    a zero aperture denotes the ray `{ x_t = 0, x_n >= 0 }` and an infinite one the
-    half-space `{ x_n >= 0 }`.
-
-    Args:
-        x: The 3D vector to project, with the cone axis along the last component.
-        aperture: The half-angle tangent defining the cone.
-
-    Returns:
-        The projection of `x` onto the cone.
-    """
-    x = np.asarray(x, dtype=np.float64)
-    tangent_norm = float(np.linalg.norm(x[:2]))
-
-    # Handle degenerate apertures
-    if aperture == 0.0:
-        return np.array([0.0, 0.0, max(x[2], 0.0)])
-    if np.isinf(aperture):
-        return np.array([x[0], x[1], max(x[2], 0.0)])
-
-    # Inside the cone the projection is the identity.
-    if tangent_norm <= aperture * x[2]:
-        return x.copy()
-    # Inside the polar cone the projection is zero.
-    if aperture * tangent_norm <= -x[2]:
-        return np.zeros(3)
-
-    # General case
-    scale = (aperture * tangent_norm + x[2]) / (aperture * aperture + 1.0)
-    tangent_scale = aperture * scale / tangent_norm
-    return np.array([tangent_scale * x[0], tangent_scale * x[1], scale])
-
-
-def make_cone_projection_samples() -> tuple[np.ndarray, np.ndarray]:
-    """
-    Builds float32 samples covering the interior, boundary, and polar cone of the Coulomb friction cone.
-
-    Returns:
-        The sampled vectors of shape `(num_samples, 3)` and their friction coefficients.
-    """
-    rng = np.random.default_rng(20260813)
-    count = 512
-
-    # Degenerate points on the cone axis and in the tangent plane.
-    vectors = [
-        np.array(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-            dtype=np.float64,
-        )
-    ]
-    frictions = [np.zeros(5)]
-
-    # Sample points inside the cone, on the boundary, and in the polar cone.
-    for mu in (0.0, 1.0e-6, 0.3, 1.0, 5.0):
-        scale = 10.0 ** rng.uniform(-6.0, 6.0, size=count)
-        angle = rng.uniform(0.0, 2.0 * np.pi, size=count)
-        # Straddle both boundaries so that either side of each branch is exercised.
-        straddle = 1.0 + rng.normal(scale=1.0e-6, size=count)
-        axial = np.abs(rng.normal(size=count)) * scale
-        radial = np.abs(rng.normal(size=count)) * scale
-        vectors.extend(
-            [
-                rng.normal(size=(count, 3)) * scale[:, None],
-                np.c_[mu * axial * straddle * np.cos(angle), mu * axial * straddle * np.sin(angle), axial],
-                np.c_[radial * np.cos(angle), radial * np.sin(angle), -mu * radial * straddle],
-            ]
-        )
-        frictions.extend([np.full(count, mu)] * 3)
-
-    return np.concatenate(vectors).astype(np.float32), np.concatenate(frictions).astype(np.float32)
-
-
-@wp.kernel
-def project_onto_coulomb_cones_kernel(
-    x: wp.array[wp.vec3f],
-    mu: wp.array[wp.float32],
-    primal: wp.array[wp.vec3f],
-    dual: wp.array[wp.vec3f],
-):
-    i = wp.tid()
-    primal[i] = project_to_coulomb_cone(x[i], mu[i])
-    dual[i] = project_to_coulomb_dual_cone(x[i], mu[i])
-
-
 ###
 # Tests
 ###
@@ -1078,41 +989,54 @@ class TestPADMMSolver(unittest.TestCase):
                 status = solver.data.status.numpy()
                 self.assertEqual([int(status[w][1]) for w in range(len(budgets))], budgets)
 
-    def project_onto_coulomb_cones(self, x: np.ndarray, mu: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """Evaluate the Coulomb cone and dual cone projections on the device."""
-        x_arg = wp.array(np.ascontiguousarray(x, dtype=np.float32), dtype=wp.vec3f, device=self.default_device)
-        mu_arg = wp.array(np.ascontiguousarray(mu, dtype=np.float32), dtype=wp.float32, device=self.default_device)
-        primal = wp.zeros(len(x), dtype=wp.vec3f, device=self.default_device)
-        dual = wp.zeros(len(x), dtype=wp.vec3f, device=self.default_device)
-        wp.launch(
-            kernel=project_onto_coulomb_cones_kernel,
-            dim=len(x),
-            inputs=[x_arg, mu_arg],
-            outputs=[primal, dual],
-            device=self.default_device,
-        )
-        return primal.numpy(), dual.numpy()
+    def assert_coulomb_cone_projection(
+        self, cone: str, case: str, mu: float, x: list[float], expected: list[float]
+    ):
+        """Assert one primal or dual Coulomb cone projection."""
+        is_primal = cone == "primal"
 
-    def test_12_coulomb_cone_projections_match_analytic_reference(self):
-        """Match a float64 reference projection for the Coulomb cone and its dual."""
-        x, mu = make_cone_projection_samples()
-        primal, dual = self.project_onto_coulomb_cones(x, mu)
+        @wp.kernel
+        def project(x: wp.array[wp.vec3f], mu: wp.array[wp.float32], y: wp.array[wp.vec3f]):
+            if wp.static(is_primal):
+                y[0] = project_to_coulomb_cone(x[0], mu[0])
+            else:
+                y[0] = project_to_coulomb_dual_cone(x[0], mu[0])
 
-        expected_primal = np.array([project_to_second_order_cone(x_i, mu_i) for x_i, mu_i in zip(x, mu, strict=True)])
-        expected_dual = np.array(
-            [
-                project_to_second_order_cone(x_i, np.inf if mu_i == 0.0 else 1.0 / mu_i)
-                for x_i, mu_i in zip(x, mu, strict=True)
-            ]
-        )
+        x_arg = wp.array(np.array([x], dtype=np.float32), dtype=wp.vec3f, device=self.default_device)
+        mu_arg = wp.array(np.array([mu], dtype=np.float32), dtype=wp.float32, device=self.default_device)
+        y = wp.zeros(1, dtype=wp.vec3f, device=self.default_device)
+        wp.launch(kernel=project, dim=1, inputs=[x_arg, mu_arg], outputs=[y], device=self.default_device)
+        with self.subTest(mu=mu, cone=cone, case=case):
+            np.testing.assert_allclose(y.numpy()[0], expected, rtol=1.0e-6, atol=1.0e-6)
 
-        # Projections are non-expansive, so accuracy is bounded in absolute terms
-        # relative to the magnitude of the input rather than that of the result.
-        magnitude = np.maximum(np.linalg.norm(np.float64(x), axis=1), 1.0)
-        primal_error = np.linalg.norm(np.float64(primal) - expected_primal, axis=1) / magnitude
-        dual_error = np.linalg.norm(np.float64(dual) - expected_dual, axis=1) / magnitude
-        self.assertLess(primal_error.max(), 1.0e-6)
-        self.assertLess(dual_error.max(), 1.0e-6)
+    def test_12_coulomb_cone_projections_handle_zero_friction(self):
+        """Handle the ray and half-space projections at zero friction."""
+        mu = 0.0
+
+        cone = "primal"
+        self.assert_coulomb_cone_projection(cone, "positive ray", mu, [0.0, 0.0, 1.0], [0.0, 0.0, 1.0])
+        self.assert_coulomb_cone_projection(cone, "polar", mu, [0.0, 0.0, -1.0], [0.0, 0.0, 0.0])
+        self.assert_coulomb_cone_projection(cone, "projection", mu, [1.0, 0.0, 1.0], [0.0, 0.0, 1.0])
+
+        cone = "dual"
+        self.assert_coulomb_cone_projection(cone, "pos. half-space", mu, [0.0, 0.0, 1.0], [0.0, 0.0, 1.0])
+        self.assert_coulomb_cone_projection(cone, "polar", mu, [0.0, 0.0, -1.0], [0.0, 0.0, 0.0])
+        self.assert_coulomb_cone_projection(cone, "projection", mu, [1.0, 0.0, -1.0], [1.0, 0.0, 0.0])
+
+    def test_13_coulomb_cone_projections_handle_all_branches(self):
+        """Handle interior, polar, and general projections at positive friction."""
+        for mu in (1.0e-6, 1.0, 1e6):
+            den = 1.0 + mu * mu
+
+            cone = "primal"
+            self.assert_coulomb_cone_projection(cone, "interior", mu, [0.5 * mu, 0.0, 1.0], [0.5 * mu, 0.0, 1.0])
+            self.assert_coulomb_cone_projection(cone, "polar", mu, [1.0, 0.0, -2.0 * mu], [0.0, 0.0, 0.0])
+            self.assert_coulomb_cone_projection(cone, "projection", mu, [1.0, 0.0, 0.0], [mu * mu / den, 0.0, mu / den])
+
+            cone = "dual"
+            self.assert_coulomb_cone_projection(cone, "interior", mu, [1.0, 0.0, 2.0 * mu], [1.0, 0.0, 2.0 * mu])
+            self.assert_coulomb_cone_projection(cone, "polar", mu, [1.0, 0.0, -2.0 / mu], [0.0, 0.0, 0.0])
+            self.assert_coulomb_cone_projection(cone, "projection", mu, [1.0, 0.0, 0.0], [1.0 / den, 0.0, mu / den])
 
 
 ###

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -989,9 +989,7 @@ class TestPADMMSolver(unittest.TestCase):
                 status = solver.data.status.numpy()
                 self.assertEqual([int(status[w][1]) for w in range(len(budgets))], budgets)
 
-    def assert_coulomb_cone_projection(
-        self, cone: str, case: str, mu: float, x: list[float], expected: list[float]
-    ):
+    def assert_coulomb_cone_projection(self, cone: str, case: str, mu: float, x: list[float], expected: list[float]):
         """Assert one primal or dual Coulomb cone projection."""
         is_primal = cone == "primal"
 

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -19,6 +19,10 @@ from newton._src.solvers.kamino._src.linalg.utils.range import in_range_via_gaus
 from newton._src.solvers.kamino._src.models.builders import basics
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.solvers.padmm import PADMMSolver, PADMMWarmStartMode
+from newton._src.solvers.kamino._src.solvers.padmm.math import (
+    project_to_coulomb_cone,
+    project_to_coulomb_dual_cone,
+)
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton.tests.kamino import setup_tests, test_context
 from newton.tests.kamino.utils.extract import (
@@ -429,6 +433,95 @@ def save_solver_info(solver: PADMMSolver, path: str | None = None, verbose: bool
     if path is not None:
         plt.savefig(path, format="pdf", dpi=300, bbox_inches="tight")
     plt.close()
+
+
+def project_to_second_order_cone(x: np.ndarray, aperture: float) -> np.ndarray:
+    """
+    Computes a float64 reference projection onto the second-order cone `{ ||x_t|| <= aperture * x_n }`.
+
+    The two degenerate apertures are handled separately, both because the general formula
+    cannot represent them and because a zero aperture would compare against `-0.0`:
+    a zero aperture denotes the ray `{ x_t = 0, x_n >= 0 }` and an infinite one the
+    half-space `{ x_n >= 0 }`.
+
+    Args:
+        x: The 3D vector to project, with the cone axis along the last component.
+        aperture: The half-angle tangent defining the cone.
+
+    Returns:
+        The projection of `x` onto the cone.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    tangent_norm = float(np.linalg.norm(x[:2]))
+
+    # Handle degenerate apertures
+    if aperture == 0.0:
+        return np.array([0.0, 0.0, max(x[2], 0.0)])
+    if np.isinf(aperture):
+        return np.array([x[0], x[1], max(x[2], 0.0)])
+
+    # Inside the cone the projection is the identity.
+    if tangent_norm <= aperture * x[2]:
+        return x.copy()
+    # Inside the polar cone the projection is zero.
+    if aperture * tangent_norm <= -x[2]:
+        return np.zeros(3)
+
+    # General case
+    scale = (aperture * tangent_norm + x[2]) / (aperture * aperture + 1.0)
+    tangent_scale = aperture * scale / tangent_norm
+    return np.array([tangent_scale * x[0], tangent_scale * x[1], scale])
+
+
+def make_cone_projection_samples() -> tuple[np.ndarray, np.ndarray]:
+    """
+    Builds float32 samples covering the interior, boundary, and polar cone of the Coulomb friction cone.
+
+    Returns:
+        The sampled vectors of shape `(num_samples, 3)` and their friction coefficients.
+    """
+    rng = np.random.default_rng(20260813)
+    count = 512
+
+    # Degenerate points on the cone axis and in the tangent plane.
+    vectors = [
+        np.array(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            dtype=np.float64,
+        )
+    ]
+    frictions = [np.zeros(5)]
+
+    # Sample points inside the cone, on the boundary, and in the polar cone.
+    for mu in (0.0, 1.0e-6, 0.3, 1.0, 5.0):
+        scale = 10.0 ** rng.uniform(-6.0, 6.0, size=count)
+        angle = rng.uniform(0.0, 2.0 * np.pi, size=count)
+        # Straddle both boundaries so that either side of each branch is exercised.
+        straddle = 1.0 + rng.normal(scale=1.0e-6, size=count)
+        axial = np.abs(rng.normal(size=count)) * scale
+        radial = np.abs(rng.normal(size=count)) * scale
+        vectors.extend(
+            [
+                rng.normal(size=(count, 3)) * scale[:, None],
+                np.c_[mu * axial * straddle * np.cos(angle), mu * axial * straddle * np.sin(angle), axial],
+                np.c_[radial * np.cos(angle), radial * np.sin(angle), -mu * radial * straddle],
+            ]
+        )
+        frictions.extend([np.full(count, mu)] * 3)
+
+    return np.concatenate(vectors).astype(np.float32), np.concatenate(frictions).astype(np.float32)
+
+
+@wp.kernel
+def project_onto_coulomb_cones_kernel(
+    x: wp.array[wp.vec3f],
+    mu: wp.array[wp.float32],
+    primal: wp.array[wp.vec3f],
+    dual: wp.array[wp.vec3f],
+):
+    i = wp.tid()
+    primal[i] = project_to_coulomb_cone(x[i], mu[i])
+    dual[i] = project_to_coulomb_dual_cone(x[i], mu[i])
 
 
 ###
@@ -985,6 +1078,41 @@ class TestPADMMSolver(unittest.TestCase):
                 status = solver.data.status.numpy()
                 self.assertEqual([int(status[w][1]) for w in range(len(budgets))], budgets)
 
+    def project_onto_coulomb_cones(self, x: np.ndarray, mu: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Evaluate the Coulomb cone and dual cone projections on the device."""
+        x_arg = wp.array(np.ascontiguousarray(x, dtype=np.float32), dtype=wp.vec3f, device=self.default_device)
+        mu_arg = wp.array(np.ascontiguousarray(mu, dtype=np.float32), dtype=wp.float32, device=self.default_device)
+        primal = wp.zeros(len(x), dtype=wp.vec3f, device=self.default_device)
+        dual = wp.zeros(len(x), dtype=wp.vec3f, device=self.default_device)
+        wp.launch(
+            kernel=project_onto_coulomb_cones_kernel,
+            dim=len(x),
+            inputs=[x_arg, mu_arg],
+            outputs=[primal, dual],
+            device=self.default_device,
+        )
+        return primal.numpy(), dual.numpy()
+
+    def test_12_coulomb_cone_projections_match_analytic_reference(self):
+        """Match a float64 reference projection for the Coulomb cone and its dual."""
+        x, mu = make_cone_projection_samples()
+        primal, dual = self.project_onto_coulomb_cones(x, mu)
+
+        expected_primal = np.array([project_to_second_order_cone(x_i, mu_i) for x_i, mu_i in zip(x, mu, strict=True)])
+        expected_dual = np.array(
+            [
+                project_to_second_order_cone(x_i, np.inf if mu_i == 0.0 else 1.0 / mu_i)
+                for x_i, mu_i in zip(x, mu, strict=True)
+            ]
+        )
+
+        # Projections are non-expansive, so accuracy is bounded in absolute terms
+        # relative to the magnitude of the input rather than that of the result.
+        magnitude = np.maximum(np.linalg.norm(np.float64(x), axis=1), 1.0)
+        primal_error = np.linalg.norm(np.float64(primal) - expected_primal, axis=1) / magnitude
+        dual_error = np.linalg.norm(np.float64(dual) - expected_dual, axis=1) / magnitude
+        self.assertLess(primal_error.max(), 1.0e-6)
+        self.assertLess(dual_error.max(), 1.0e-6)
 
 ###
 # Test execution


### PR DESCRIPTION
## Description

Fix branch ordering in `project_to_coulomb_dual_cone()` so the membership test runs before the polar-cone test. At `mu = 0` the dual cone is the half-space `xn >= 0`; evaluating the polar-cone condition first incorrectly maps feasible axis points `(0, 0, +xn)` to zero.

Add regression coverage that compares the Warp Coulomb cone and dual-cone projections against a float64 reference across interior, boundary, and polar-cone samples, including degenerate friction coefficients (`mu = 0`, `mu → ∞`).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_12_coulomb_cone_projections_match_analytic_reference
```

## Bug fix

**Steps to reproduce:**

1. Project `(0, 0, xn)` with `xn > 0` onto the Coulomb dual cone with `mu = 0`.
2. Observe the projection returns `(0, 0, 0)` instead of the input.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

from newton._src.solvers.kamino._src.solvers.padmm.math import project_to_coulomb_dual_cone

@wp.kernel
def project_kernel(x: wp.array[wp.vec3f], out: wp.array[wp.vec3f]):
    out[0] = project_to_coulomb_dual_cone(x[0], wp.float32(0.0))

x = wp.array([wp.vec3f(0.0, 0.0, 1.0)], dtype=wp.vec3f, device="cpu")
out = wp.zeros(1, dtype=wp.vec3f, device="cpu")
wp.launch(project_kernel, dim=1, inputs=[x], outputs=[out], device="cpu")

assert np.allclose(out.numpy()[0], [0.0, 0.0, 1.0])  # fails before this PR
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Coulomb cone projections for zero-friction cases, preserving valid vectors while correctly projecting invalid inputs.
  * Improved handling across interior, boundary, polar, and general projection scenarios.
  * Simplified projection behavior for more consistent results across friction levels.

* **Tests**
  * Added comprehensive validation for primal and dual Coulomb cone projections.
  * Expanded coverage across zero, small, unit, and large friction values, including representative projection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->