### PR TITLE
Fix PADMM solver_info iterate residuals to use L2 norm

### DIFF
--- a/changelog/+padmm-solver-info-iterate-norms-a3f7b2c1.skip
+++ b/changelog/+padmm-solver-info-iterate-norms-a3f7b2c1.skip
@@ -1,0 +1,1 @@
+Internal PADMM solver_info iterate residual metric fix; no user-facing API change.

--- a/changelog/+padmm-solver-info-iterate-norms-a3f7b2c1.skip
+++ b/changelog/+padmm-solver-info-iterate-norms-a3f7b2c1.skip
@@ -1,1 +1,0 @@
-Internal PADMM solver_info iterate residual metric fix; no user-facing API change.

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -670,7 +670,7 @@ def compute_preconditioned_iterate_residual(
     ncts: wp.int32, vio: wp.int32, P: wp.array[wp.float32], x: wp.array[wp.float32], x_p: wp.array[wp.float32]
 ) -> wp.float32:
     """
-    Computes the iterate residual as: `r_dx := || P @ (x - x_p) ||_inf`
+    Computes the iterate residual as: `r_dx := || P @ (x - x_p) ||_2`
 
     Args:
         ncts: The number of active constraints in the world.
@@ -679,17 +679,18 @@ def compute_preconditioned_iterate_residual(
         x_p: The previous solution vector.
 
     Returns:
-        The maximum iterate residual across all active constraints, computed as the infinity norm.
+        The iterate residual across all active constraints, computed as the L2 norm.
     """
     # Initialize the iterate residual
-    r_dx = float(0.0)
+    r_dx_squared = float(0.0)
     for i in range(ncts):
         # Compute the index offset of the vector block of the world
         v_i = vio + i
         # Update the iterate and proximal-point residuals
-        r_dx = wp.max(r_dx, P[v_i] * wp.abs(x[v_i] - x_p[v_i]))
-    # Return the maximum iterate residual
-    return r_dx
+        delta = P[v_i] * (x[v_i] - x_p[v_i])
+        r_dx_squared += delta * delta
+    # Return the iterate residual
+    return wp.sqrt(r_dx_squared)
 
 
 @wp.func
@@ -697,7 +698,7 @@ def compute_inverse_preconditioned_iterate_residual(
     ncts: wp.int32, vio: wp.int32, P: wp.array[wp.float32], x: wp.array[wp.float32], x_p: wp.array[wp.float32]
 ) -> wp.float32:
     """
-    Computes the iterate residual as: `r_dx := || P^{-1} @ (x - x_p) ||_inf`
+    Computes the iterate residual as: `r_dx := || P^{-1} @ (x - x_p) ||_2`
 
     Args:
         ncts: The number of active constraints in the world.
@@ -706,14 +707,15 @@ def compute_inverse_preconditioned_iterate_residual(
         x_p: The previous solution vector.
 
     Returns:
-        The maximum iterate residual across all active constraints, computed as the infinity norm.
+        The iterate residual across all active constraints, computed as the L2 norm.
     """
     # Initialize the iterate residual
-    r_dx = float(0.0)
+    r_dx_squared = float(0.0)
     for i in range(ncts):
         # Compute the index offset of the vector block of the world
         v_i = vio + i
         # Update the iterate and proximal-point residuals
-        r_dx = wp.max(r_dx, (1.0 / P[v_i]) * wp.abs(x[v_i] - x_p[v_i]))
-    # Return the maximum iterate residual
-    return r_dx
+        delta = (1.0 / P[v_i]) * (x[v_i] - x_p[v_i])
+        r_dx_squared += delta * delta
+    # Return the iterate residual
+    return wp.sqrt(r_dx_squared)


### PR DESCRIPTION
## Summary

- Fix `compute_preconditioned_iterate_residual` and `compute_inverse_preconditioned_iterate_residual` to report L2 norms instead of infinity norms.
- The non-accelerated `solver_info` path in `kernels.py` uses these helpers when acceleration is disabled, while the accelerated path reads `status.r_dx`, `status.r_dy`, and `status.r_dz` that are already computed as L2 norms.
- This aligns reported `r_dx`, `r_dy`, and `r_dz` with `PADMMSolverStatus` documentation and the accelerated code path. The PADMM solve itself is unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k test_kamino_solvers_padmm
```

## Bug fix

**Steps to reproduce:**

1. Run PADMM with acceleration disabled and `collect_info=True`.
2. Compare reported `solver_info.r_dx`, `r_dy`, and `r_dz` against the accelerated path or against manual L2-norm computation of the preconditioned iterate deltas.
3. Observe that the non-accelerated path previously reported infinity norms while the accelerated path and status docs use L2 norms.

**Minimal reproduction:**

```python
# The inconsistency appears in solver_info diagnostics only; the solve result is unaffected.
# Enable PADMM info collection with and without acceleration and compare r_dx/r_dy/r_dz scaling.
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PADMM solver iteration residual metrics to use L2 norms for more accurate convergence reporting.
  * Updated residual calculations for both preconditioned and inverse-preconditioned variants.

* **Documentation**
  * Clarified that the reported residuals use L2 norms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->