### PR TITLE
Use authored colors for imported shapes with no bound material

### DIFF
--- a/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
+++ b/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
@@ -1,1 +1,0 @@
-Honor `primvars:displayColor` on imported prims that bind no material, and give those that carry neither a material nor a display color the `UsdPreviewSurface` default instead of a shape-index color from `ModelBuilder`'s debug palette, so a stage renders in the colors it authored rather than colors it never did.

--- a/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
+++ b/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
@@ -1,0 +1,1 @@
+Give imported visual shapes that bind no material the `UsdPreviewSurface` default color rather than a shape-index color from `ModelBuilder`'s debug palette, so a stage renders in the colors it authored instead of colors it never did.

--- a/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
+++ b/changelog/+usd-unmaterialed-color-7c3e9a15.fixed.md
@@ -1,1 +1,1 @@
-Give imported visual shapes that bind no material the `UsdPreviewSurface` default color rather than a shape-index color from `ModelBuilder`'s debug palette, so a stage renders in the colors it authored instead of colors it never did.
+Honor `primvars:displayColor` on imported prims that bind no material, and give those that carry neither a material nor a display color the `UsdPreviewSurface` default instead of a shape-index color from `ModelBuilder`'s debug palette, so a stage renders in the colors it authored rather than colors it never did.

--- a/changelog/3910.fixed.md
+++ b/changelog/3910.fixed.md
@@ -1,0 +1,1 @@
+Use authored colors for imported shapes that bind no material, rather than a debug palette color.

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -2600,6 +2600,10 @@ def _coerce_color(value: Any) -> tuple[float, float, float] | None:
     """Coerce a value to an RGB color tuple, or None if not possible."""
     if value is None:
         return None
+    # A per-vertex or per-face primvar holds one entry per element and only the leading one
+    # is used, so take it before the numpy conversion rather than flattening the whole array.
+    if hasattr(value, "__len__") and len(value) > 0 and hasattr(value[0], "__len__"):
+        value = value[0]
     color_np = np.array(value, dtype=np.float32).reshape(-1)
     if color_np.size >= 3:
         return (float(color_np[0]), float(color_np[1]), float(color_np[2]))

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -2941,13 +2941,22 @@ def _resolve_prim_material_properties(target_prim: Usd.Prim) -> dict[str, Any] |
         if properties.get(key) is None and material_props.get(key) is not None:
             properties[key] = material_props[key]
     if properties["color"] is None and properties["texture"] is None:
-        display_color = UsdGeom.PrimvarsAPI(target_prim).GetPrimvar("displayColor")
-        if display_color:
-            color = _coerce_color(display_color.Get())
-            if color is not None:
-                properties["color"] = _color_to_display_space(color, display_color.GetAttr())
+        properties["color"] = _display_color_for_prim(target_prim)
 
     return properties
+
+
+def _display_color_for_prim(prim: Usd.Prim) -> tuple[float, float, float] | None:
+    """Read ``primvars:displayColor`` off a prim, in Newton's display color space."""
+    if UsdGeom is None or not prim or not prim.IsValid():
+        return None
+    display_color = UsdGeom.PrimvarsAPI(prim).GetPrimvar("displayColor")
+    if not display_color:
+        return None
+    color = _coerce_color(display_color.Get())
+    if color is None:
+        return None
+    return _color_to_display_space(color, display_color.GetAttr())
 
 
 def resolve_material_properties_for_prim(prim: Usd.Prim) -> dict[str, Any]:
@@ -3003,7 +3012,12 @@ def resolve_material_properties_for_prim(prim: Usd.Prim) -> dict[str, Any]:
             if fallback_props is not None:
                 return fallback_props
 
-    return _empty_material_properties()
+    # No material is bound anywhere, which is exactly when ``primvars:displayColor`` is the
+    # only color the prim carries. The fallback above only runs once a material has been
+    # resolved, so it never reaches these prims.
+    properties = _empty_material_properties()
+    properties["color"] = _display_color_for_prim(prim)
+    return properties
 
 
 def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -2947,10 +2947,14 @@ def _resolve_prim_material_properties(target_prim: Usd.Prim) -> dict[str, Any] |
 
 
 def _display_color_for_prim(prim: Usd.Prim) -> tuple[float, float, float] | None:
-    """Read ``primvars:displayColor`` off a prim, in Newton's display color space."""
+    """Read ``primvars:displayColor`` off a prim, in Newton's display color space.
+
+    Resolved with inheritance: a ``constant`` primvar applies to every descendant, so an
+    ancestor is a legitimate place to author the color for a whole subtree.
+    """
     if UsdGeom is None or not prim or not prim.IsValid():
         return None
-    display_color = UsdGeom.PrimvarsAPI(prim).GetPrimvar("displayColor")
+    display_color = UsdGeom.PrimvarsAPI(prim).FindPrimvarWithInheritance("displayColor")
     if not display_color:
         return None
     color = _coerce_color(display_color.Get())

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1368,9 +1368,11 @@ def parse_usd(
         visual_shape_cfg_for_prim.is_visible = is_site or _is_viewport_drawn(prim)
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
-        # A textured prim also resolves no scalar color, deliberately, so that the texture
-        # is not tinted. Substituting the neutral there would multiply into every texel.
-        if shape_color is None and material_props.get("texture") is None and visual_shape_cfg_for_prim.is_visible:
+        # A textured mesh resolves no scalar color on purpose, so the texture is not tinted;
+        # the mesh path gives it white. Geometry that never receives the texture still wants
+        # the neutral, otherwise it falls through to a palette color.
+        carries_texture = material_props.get("texture") is not None and type_name == "mesh"
+        if shape_color is None and not carries_texture and visual_shape_cfg_for_prim.is_visible:
             shape_color = _UNMATERIALED_VISUAL_COLOR
 
         if path_name not in path_shape_map:
@@ -3572,7 +3574,8 @@ def parse_usd(
                 shape_ka = shape_contact["ka"]
 
                 shape_color = material_props.get("color")
-                if shape_color is None and material_props.get("texture") is None and collider_is_visible:
+                carries_texture = material_props.get("texture") is not None and key == UsdPhysics.ObjectType.MeshShape
+                if shape_color is None and not carries_texture and collider_is_visible:
                     shape_color = _UNMATERIALED_VISUAL_COLOR
 
                 # SDF parameters. Applying NewtonSDFCollisionAPI is the canonical

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1368,7 +1368,9 @@ def parse_usd(
         visual_shape_cfg_for_prim.is_visible = is_site or _is_viewport_drawn(prim)
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
-        if shape_color is None and visual_shape_cfg_for_prim.is_visible:
+        # A textured prim also resolves no scalar color, deliberately, so that the texture
+        # is not tinted. Substituting the neutral there would multiply into every texel.
+        if shape_color is None and material_props.get("texture") is None and visual_shape_cfg_for_prim.is_visible:
             shape_color = _UNMATERIALED_VISUAL_COLOR
 
         if path_name not in path_shape_map:
@@ -3570,7 +3572,7 @@ def parse_usd(
                 shape_ka = shape_contact["ka"]
 
                 shape_color = material_props.get("color")
-                if shape_color is None and collider_is_visible:
+                if shape_color is None and material_props.get("texture") is None and collider_is_visible:
                     shape_color = _UNMATERIALED_VISUAL_COLOR
 
                 # SDF parameters. Applying NewtonSDFCollisionAPI is the canonical

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -53,6 +53,7 @@ from ..usd import require_newton_usd_schemas
 from ..usd import utils as usd
 from ..usd.schema_resolver import PrimType, SchemaResolver, SchemaResolverManager
 from ..usd.schemas import SchemaResolverNewton
+from .color import color_linear_to_srgb
 from .import_usd_deformable_attachments import (
     _deformable_import_attachments,
     _deformable_import_element_collision_filters,
@@ -75,6 +76,12 @@ _NEWTON_SRC_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pa
 
 # Stiffness used for a hard joint limit (NewtonJointAPI newton:limitStiffness == +inf).
 _HARD_LIMIT_KE = 1.0e8
+
+# `UsdPreviewSurface`'s schema default for `diffuseColor`. A visual shape whose prim binds no
+# material is given this rather than left for ModelBuilder's per-shape debug palette, which
+# would render an unmaterialed scene in colours the asset never authored. Display-encoded to
+# match the colours that are resolved from a material.
+_UNMATERIALED_VISUAL_COLOR = color_linear_to_srgb((0.18, 0.18, 0.18))
 
 
 def _resolve_newton_limit_ke(
@@ -1361,6 +1368,8 @@ def parse_usd(
         visual_shape_cfg_for_prim.is_visible = is_site or _is_viewport_drawn(prim)
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
+        if shape_color is None and visual_shape_cfg_for_prim.is_visible:
+            shape_color = _UNMATERIALED_VISUAL_COLOR
 
         if path_name not in path_shape_map:
             if type_name == "cube":
@@ -3561,6 +3570,8 @@ def parse_usd(
                 shape_ka = shape_contact["ka"]
 
                 shape_color = material_props.get("color")
+                if shape_color is None and collider_is_visible:
+                    shape_color = _UNMATERIALED_VISUAL_COLOR
 
                 # SDF parameters. Applying NewtonSDFCollisionAPI is the canonical
                 # signal that SDF generation is configured for this shape.

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -7398,9 +7398,13 @@ def Xform "Articulation" (
         builder = newton.ModelBuilder()
         result = builder.add_usd(stage)
 
-        src = builder.shape_source[result["path_shape_map"]["/Body/VisualMesh"]]
+        shape = result["path_shape_map"]["/Body/VisualMesh"]
+        src = builder.shape_source[shape]
         self.assertIsNotNone(src.texture)
         np.testing.assert_allclose(np.array(src.color), np.array([1.0, 1.0, 1.0]))
+        # The viewer reads shape_color, and ModelBuilder prefers it over src.color, so the
+        # white has to survive there too or the shader multiplies it into every texel.
+        np.testing.assert_allclose(np.array(builder.shape_color[shape]), np.array([1.0, 1.0, 1.0]))
 
     @staticmethod
     def _build_uvless_textured_visual_mesh_stage(*, material_subset: bool):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -32,6 +32,7 @@ from newton._src.solvers.mujoco.constants import (
     SOLREF_MODE_RAW,
 )
 from newton._src.solvers.mujoco.utils import MjcEqualityTargetKind
+from newton._src.utils.color import color_linear_to_srgb
 from newton._src.utils.import_usd import _is_uniform_scale
 from newton.math import quat_between_axes
 from newton.solvers import SolverMuJoCo
@@ -12440,6 +12441,36 @@ def Xform "Body" (
         self.assertEqual(builder.shape_count, 2)
         drawn = [s for s in range(builder.shape_count) if builder.shape_flags[s] & ShapeFlags.VISIBLE]
         self.assertEqual(drawn, [path_shape_map["/Body/VisualSphere"]])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_unmaterialed_visual_shape_uses_neutral_color(self):
+        """Verify a visual prim with no bound material gets the neutral default, not the palette.
+
+        ModelBuilder colors an uncolored shape from a per-shape debug palette, which suits
+        procedurally built scenes but makes an imported stage render in colors the asset
+        never authored. USD renderers draw an unmaterialed prim in UsdPreviewSurface's
+        ``diffuseColor`` default instead, so the importer supplies that.
+        """
+        from pxr import Usd, UsdGeom
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.Xform.Define(stage, "/World")
+        UsdGeom.Cube.Define(stage, "/World/Bare")
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage, load_visual_shapes=True)
+        shape = result["path_shape_map"]["/World/Bare"]
+
+        self.assertTrue(builder.shape_flags[shape] & ShapeFlags.VISIBLE)
+        color = builder.shape_color[shape]
+        # 0.18 linear, display-encoded the same way an authored color would be.
+        expected = color_linear_to_srgb((0.18, 0.18, 0.18))
+        for channel, want in zip(color, expected, strict=True):
+            self.assertAlmostEqual(channel, want, places=5)
+        # Guard the actual defect: the palette varies with shape index, a neutral does not.
+        self.assertAlmostEqual(color[0], color[1], places=6)
+        self.assertAlmostEqual(color[1], color[2], places=6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_fallback_with_material(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12473,6 +12473,30 @@ def Xform "Body" (
         self.assertAlmostEqual(color[1], color[2], places=6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_display_color_used_without_bound_material(self):
+        """Verify primvars:displayColor is honored on a prim that binds no material.
+
+        displayColor was only consulted once a material had been resolved but supplied no
+        color, so it never reached prims with no material at all -- the case where it is
+        the only color the prim carries.
+        """
+        from pxr import Usd, UsdGeom
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.Xform.Define(stage, "/World")
+        cube = UsdGeom.Cube.Define(stage, "/World/Colored")
+        cube.GetDisplayColorAttr().Set([(0.463, 0.725, 0.0)])
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage, load_visual_shapes=True)
+        color = builder.shape_color[result["path_shape_map"]["/World/Colored"]]
+
+        expected = color_linear_to_srgb((0.463, 0.725, 0.0))
+        for channel, want in zip(color, expected, strict=True):
+            self.assertAlmostEqual(channel, want, places=5)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_fallback_with_material(self):
         """Colliders with material stay visible when the body has no other visual shapes."""
         stage = self._create_stage_with_pbr_collision_mesh(

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12497,6 +12497,33 @@ def Xform "Body" (
             self.assertAlmostEqual(channel, want, places=5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_display_color_inherited_from_ancestor(self):
+        """Verify a constant displayColor authored on an ancestor reaches its descendants.
+
+        Constant primvars inherit down the hierarchy, so authoring one on an Xform is a
+        legitimate way to color a whole subtree. ``GetPrimvar`` only inspects the prim
+        itself and returns a primvar whose value is None, which reads as "no color".
+        """
+        from pxr import Sdf, Usd, UsdGeom
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        group = UsdGeom.Xform.Define(stage, "/World")
+        primvar = UsdGeom.PrimvarsAPI(group.GetPrim()).CreatePrimvar(
+            "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.constant
+        )
+        primvar.Set([(0.1, 0.2, 0.3)])
+        UsdGeom.Cube.Define(stage, "/World/Inheriting")
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage, load_visual_shapes=True)
+        color = builder.shape_color[result["path_shape_map"]["/World/Inheriting"]]
+
+        expected = color_linear_to_srgb((0.1, 0.2, 0.3))
+        for channel, want in zip(color, expected, strict=True):
+            self.assertAlmostEqual(channel, want, places=5)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_fallback_with_material(self):
         """Colliders with material stay visible when the body has no other visual shapes."""
         stage = self._create_stage_with_pbr_collision_mesh(


### PR DESCRIPTION
## Description

Closes #3910.

**The scope is wider than the issue describes, and the issue's proposed fix would have been wrong on its own.** #3910 reported that imported visual shapes with no bound material get a colour from `ModelBuilder`'s per-shape debug palette, and proposed substituting a neutral default. Building that revealed the larger half of the problem: those prims mostly *do* carry a colour, in `primvars:displayColor`, and the importer was never reading it.

`primvars:displayColor` was only consulted after a material had been resolved but supplied no colour. A prim that binds no material at all returns early from `resolve_material_properties_for_prim` with empty properties, so the one case where `displayColor` is the only colour the prim carries was precisely the case that never read it.

So this lands as two commits, and the order matters for review:

1. **`Use a neutral color for unmaterialed visual shapes`** — what #3910 asked for. A visual shape that resolves no colour takes `UsdPreviewSurface`'s `diffuseColor` default of `0.18` linear, which is what USD renderers draw an unmaterialed prim as, rather than a shape-index palette entry. Defined in linear and passed through the same `color_linear_to_srgb` as authored colours instead of hardcoding the encoded value.
2. **`Read displayColor when a prim binds no material`** — the actual bug. Moves the `displayColor` lookup into a helper and calls it from the no-material path too. This supersedes most of the first commit: on the sample asset, 77 prims author `displayColor` and would otherwise have gone grey.

Had only the neutral default landed, the result would have been *differently* wrong — grey where the asset authored chartreuse, green and blue.

The palette itself is left alone. It is correct for procedurally built scenes, where it is what makes shapes distinguishable and `ModelBuilder` genuinely cannot tell "the caller did not set a colour" from "this prim binds no material", and it is correct for collision shapes, where distinguishability is the point. Only the USD importer has the context to decide, so only the USD importer changes.

### Measured

On the [OpenUSD Exchange](https://github.com/NVIDIA-Omniverse/usd-exchange) sample stage — 105 shapes, mixed `UsdPreviewSurface`, MaterialX, textured, unmaterialed, plus `GeomSubset`s and instancing:

| | before | after |
| --- | --- | --- |
| shapes taking a palette colour | 52 | **0** |
| distinct colours in the scene | 18 | 15 |

Spot checks against the authored values:

| prim | source | result |
| --- | --- | --- |
| `/World/cubeMesh` | `displayColor (0.463, 0.725, 0)` | `(0.71, 0.868, 0.0)` |
| `/World/matrixXform/matrixCube` | `displayColor (0.5, 0.7, 1)` | `(0.735, 0.854, 1.0)` |
| `/World/groundXform/groundCube` | neither material nor `displayColor` | `(0.461, 0.461, 0.461)` |

Rendering the stage in the viewer alongside an RTX render of the same stage at matching framing, the colours now agree. The differences that remain are unrelated missing capability — no PBR, no opacity, and one light versus an HDRI with GI.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev --extra examples -m newton.tests -k usd --strict-warnings     # 608 tests, OK
uv run --extra dev --extra examples -m newton.tests -k viewer --strict-warnings  # 210 tests, OK
```

Two regression tests, each failing without its commit:

- `test_unmaterialed_visual_shape_uses_neutral_color` — asserts the neutral, and separately that the three channels are equal, since the palette varies with shape index and a neutral cannot. Without the fix: `0.2667 != 0.4614`.
- `test_display_color_used_without_bound_material` — a cube with authored `displayColor` and no material. Without the fix: `0.4614 != 0.7104`, grey where chartreuse belongs.

## Bug fix

**Steps to reproduce:**

1. Author a stage with a visual prim that binds no material — with `primvars:displayColor` for the second case, without it for the first.
2. `add_usd` the stage and read back `builder.shape_color`.
3. Observe a palette colour that varies with shape index, rather than the authored display colour or a neutral.

**Minimal reproduction:**

```python
import newton
from pxr import Usd, UsdGeom

stage = Usd.Stage.CreateInMemory()
UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
UsdGeom.Xform.Define(stage, "/World")
UsdGeom.Cube.Define(stage, "/World/Bare")
UsdGeom.Cube.Define(stage, "/World/Colored").GetDisplayColorAttr().Set([(0.463, 0.725, 0.0)])

builder = newton.ModelBuilder()
result = builder.add_usd(stage, load_visual_shapes=True)
for path in ("/World/Bare", "/World/Colored"):
    print(path, builder.shape_color[result["path_shape_map"][path]])

# before: two unrelated palette colours
# after:  (0.4614, 0.4614, 0.4614) and (0.7104, 0.8677, 0.0)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Imported visual and collision shapes without materials or textures now display a consistent dark-gray fallback color.
  - Authored and inherited display colors are now respected when importing shapes.
  - Color values are validated and converted correctly for display.
  - Textured meshes retain their expected white builder color while displaying their textures properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->