### PR TITLE
Use newton-usd-schemas 0.5.0

### DIFF
--- a/changelog/+newton-usd-schemas-0-5-0-b2f41d97.changed.md
+++ b/changelog/+newton-usd-schemas-0-5-0-b2f41d97.changed.md
@@ -1,0 +1,1 @@
+Require `newton-usd-schemas` 0.5.0 or newer for the deformable and MPM schemas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.4.1",
+    "newton-usd-schemas>=0.5.0",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -3948,7 +3948,7 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'rtx'" },
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.4.1" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.5.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
     { name = "ovrtx", marker = "extra == 'rtx'", specifier = ">=0.3" },
@@ -3987,11 +3987,11 @@ dev = [{ name = "asv", specifier = ">=0.6.4" }]
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5f/aad1672263880d7e0ee3a7ce9b877ef16e99dba45fb5eb8084181eb7ee1e/newton_usd_schemas-0.4.1.tar.gz", hash = "sha256:1f6946ce2741d7a86ca8e3e84d7b64328c88b42a3b29160a7607b2ce0c837bf4", size = 69561, upload-time = "2026-07-30T17:40:41.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/3b/602eea8123824daf2215fcdf4a61a0958507ea11e5c38e4313285f6b745f/newton_usd_schemas-0.5.0.tar.gz", hash = "sha256:a404232e9f89cfce130ee5ed5c8b6b23b187514e857803b5d7b08568bb2516e0", size = 76299, upload-time = "2026-08-14T00:02:50.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/24/d1d44f682dbd28392ef0b6f9e6f9e40374c6009af06e494fa6a9308f79e2/newton_usd_schemas-0.4.1-py3-none-any.whl", hash = "sha256:8911e846c65448426609a2945db6d1135d33e84bf4107efd888a62287b1aa93d", size = 19424, upload-time = "2026-07-30T17:40:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/78/bc/ffad9598cc4772cb0b8d8d47c6700493dac3d8d6518dead78c596a0325ed/newton_usd_schemas-0.5.0-py3-none-any.whl", hash = "sha256:edb559522474855fc03e6f395e0702b11074a13fe1c2ed9cce63fbb06516b342", size = 22280, upload-time = "2026-08-14T00:02:49.056Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bumps the `newton-usd-schemas` pin from `>=0.4.1` to `>=0.5.0`.

Version bump only. Nothing in the parser changes: the schemas added since 0.4.1 (`NewtonCurvesDeformableMaterialAPI`, `NewtonPointsDeformableSimAPI`, `NewtonMPMSceneAPI`, `NewtonMPMMaterialAPI`) are not read by Newton yet, and the other change in 0.5.0 corrects the documented units of `newton:torsionalFriction` and `newton:rollingFriction` to length-dimensioned rather than dimensionless, which is documentation only. Attribute names, types, defaults and limits are unchanged, so every value Newton already resolves resolves identically.

Same shape as the previous schemas bump, plus a `changed` fragment, since the `importers` extra now rejects 0.4.x and that is a requirement change users have to act on.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev --extra examples -m newton.tests -k usd --strict-warnings              # 606 tests, OK
uv run --extra dev --extra examples -m newton.tests -k schema_resolver --strict-warnings  # 35 tests, OK
```

Confirmed the new version is the one actually registered, and that the friction defaults are unchanged by the units correction:

```
installed newton-usd-schemas: 0.5.0
NewtonMaterialAPI applies: True
newton:torsionalFriction default: 0.004999999888241291
```

Leaving the full suite to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional importer dependency to require `newton-usd-schemas` version 0.5.0 or newer.
  * Added a changelog entry documenting the updated requirement for deformable and MPM schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->