### PR TITLE
Import uniform mesh normals instead of dropping them

### DIFF
--- a/changelog/+usd-uniform-normals-9d2e5b41.fixed.md
+++ b/changelog/+usd-uniform-normals-9d2e5b41.fixed.md
@@ -1,0 +1,1 @@
+Import authored `uniform` mesh normals instead of dropping them.

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1584,6 +1584,21 @@ def get_mesh(
 
     if normals is not None:
         normals = np.array(normals, dtype=np.float64)
+        if normals_interpolation == UsdGeom.Tokens.uniform:
+            # One normal per face, commonly indexed so that flat-shaded geometry stores each
+            # distinct direction once. Resolve the indices and hand each face's normal to its
+            # own corners, which is the faceVarying form the rest of this function expects.
+            prim_path = str(prim.GetPath())
+            if normal_indices is not None and len(normal_indices) > 0:
+                normals = _expand_indexed_primvar(normals, normal_indices, "Normal", prim_path)
+                normal_indices = None
+            if len(normals) != len(counts):
+                raise ValueError(
+                    f"Length of uniform normals ({len(normals)}) does not match number of faces "
+                    f"({len(counts)}) for mesh {prim_path}"
+                )
+            normals = np.repeat(normals, np.asarray(counts, dtype=np.int32), axis=0)
+            normals_interpolation = UsdGeom.Tokens.faceVarying
         if normals_interpolation == UsdGeom.Tokens.faceVarying:
             prim_path = str(prim.GetPath())
             if normal_indices is not None and len(normal_indices) > 0:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12646,6 +12646,57 @@ def Xform "Body" (
             self.assertAlmostEqual(channel, want, places=5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_uniform_indexed_normals_are_expanded(self):
+        """Verify indexed uniform normals survive import rather than being dropped.
+
+        A flat-shaded mesh commonly authors one normal per face, indexed so each distinct
+        direction is stored once. Only faceVarying was handled, so the raw value count was
+        compared against the vertex and corner counts, matched neither, and the normals
+        were discarded with a warning.
+        """
+        from pxr import Sdf, Usd, UsdGeom, Vt
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        mesh = UsdGeom.Mesh.Define(stage, "/Mesh")
+        # Two quads meeting at a right angle, so the two face normals differ.
+        mesh.CreatePointsAttr().Set([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0), (1, 0, 1), (0, 1, 1)])
+        mesh.CreateFaceVertexCountsAttr().Set([4, 4])
+        mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 3, 1, 4, 5, 2])
+        normals = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+            "normals", Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.uniform
+        )
+        normals.Set(Vt.Vec3fArray([(0, 0, 1), (1, 0, 0)]))
+        normals.SetIndices(Vt.IntArray([0, 1]))
+        # Authored normals are only loaded for meshes carrying material subsets, so the
+        # subsets are what makes this reachable at all.
+        for name, face in (("a", 0), ("b", 1)):
+            subset = UsdGeom.Subset.Define(stage, f"/Mesh/{name}")
+            subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+            subset.CreateIndicesAttr().Set(Vt.IntArray([face]))
+            subset.CreateFamilyNameAttr().Set("materialBind")
+
+        builder = newton.ModelBuilder()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = builder.add_usd(stage, load_visual_shapes=True)
+        self.assertFalse([w for w in caught if "normals" in str(w.message).lower()])
+
+        directions = set()
+        for path, shape in result["path_shape_map"].items():
+            if not path.startswith("/Mesh"):
+                continue
+            source = builder.shape_source[shape]
+            self.assertIsNotNone(source.normals, f"{path} lost its normals")
+            imported = np.asarray(source.normals)
+            self.assertEqual(len(imported), len(source.vertices))
+            np.testing.assert_allclose(np.linalg.norm(imported, axis=1), 1.0, atol=1e-6)
+            directions.update(tuple(np.round(n, 4)) for n in imported)
+        # Both authored directions must survive; dropping the indices would collapse them.
+        self.assertIn((0.0, 0.0, 1.0), directions)
+        self.assertIn((1.0, 0.0, 0.0), directions)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_hide_collision_shapes_fallback_with_material(self):
         """Colliders with material stay visible when the body has no other visual shapes."""
         stage = self._create_stage_with_pbr_collision_mesh(


### PR DESCRIPTION
## Description

Authored `uniform` normals were discarded on import, with a warning, and the mesh rendered with none.

Normals have a single interpolation branch, `faceVarying`, and the indexed expansion lives inside it. A flat-shaded mesh authoring one normal per face — indexed so each distinct direction is stored once — therefore never had its indices applied. The raw value count was compared against the vertex count and the corner count, matched neither, and the normals were dropped:

```
UserWarning: Normals length (6) does not match vertices after UV splitting
for mesh /World/materialSampleGrid/meshWithGeomsubsets; dropping normals.
```

For that mesh: 12 points, 10 faces, 40 corners, and `primvars:normals` holding 6 values with `interpolation = uniform` and 10 indices. Entirely valid, and other renderers read it without complaint.

The fix resolves the indices, then hands each face's normal to its own corners, which is the `faceVarying` form the rest of the function already handles.

Worth knowing for review scope: authored normals are only loaded for meshes carrying material subsets (`load_normals=True` is passed in one place, the subset path), so that is the only path this reaches.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev --extra examples -m newton.tests -k usd --strict-warnings   # 607 tests, OK
```

`test_uniform_indexed_normals_are_expanded` builds two quads meeting at a right angle with an indexed `uniform` primvar holding both face directions, and subsets so the normals are loaded at all. It asserts no normals warning, one normal per vertex, unit length, and that both authored directions survive — dropping the indices would collapse them to one. Without the fix it fails at `2 != 6`.

Checked against the real asset as well: the mesh splits into `front` and `screen`, flat with a single direction each, and `body` with five distinct face directions.

## Bug fix

**Steps to reproduce:**

1. Author a mesh with `primvars:normals` at `uniform` interpolation, indexed, plus a material subset so the normals are loaded.
2. `add_usd` the stage.
3. Observe the "does not match vertices" warning and `shape_source[...].normals` of `None`.

**Minimal reproduction:**

```python
import newton
from pxr import Sdf, Usd, UsdGeom, Vt

stage = Usd.Stage.CreateInMemory()
UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
mesh = UsdGeom.Mesh.Define(stage, "/Mesh")
mesh.CreatePointsAttr().Set([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0), (1, 0, 1), (0, 1, 1)])
mesh.CreateFaceVertexCountsAttr().Set([4, 4])
mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 3, 1, 4, 5, 2])
normals = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
    "normals", Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.uniform
)
normals.Set(Vt.Vec3fArray([(0, 0, 1), (1, 0, 0)]))
normals.SetIndices(Vt.IntArray([0, 1]))
for name, face in (("a", 0), ("b", 1)):
    subset = UsdGeom.Subset.Define(stage, f"/Mesh/{name}")
    subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
    subset.CreateIndicesAttr().Set(Vt.IntArray([face]))
    subset.CreateFamilyNameAttr().Set("materialBind")

builder = newton.ModelBuilder()
result = builder.add_usd(stage, load_visual_shapes=True)
print(builder.shape_source[result["path_shape_map"]["/Mesh/a"]].normals)
# before: None, with a warning
# after:  four unit normals of (0, 0, 1)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * USD imports now preserve authored uniform mesh normals instead of discarding them.
  * Indexed face normals are correctly expanded across mesh corners, including meshes with material subsets.
  * Invalid normal counts now produce a clear validation error.

* **Tests**
  * Added regression coverage for importing uniform mesh normals without warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->