### PR TITLE
Add Kamino body inertia projection

### DIFF
--- a/changelog/3927.added.md
+++ b/changelog/3927.added.md
@@ -1,0 +1,1 @@
+Add a device-resident Kamino API for projecting rigid-body inertia through arbitrary body-twist bases.

--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -23,6 +23,7 @@ from .core.conversions import (
 from .core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType
 from .core.model import ModelKamino
 from .core.state import StateKamino
+from .dynamics.body_inertia import eval_body_inertia_projection
 from .geometry.contacts import (
     ContactsKamino,
     convert_contacts_kamino_to_newton,
@@ -57,6 +58,7 @@ __all__ = [
     "convert_model_joint_actuation",
     "convert_model_joint_transforms",
     "convert_model_materials",
+    "eval_body_inertia_projection",
     "msg",
     "validate_model_structural_updates",
 ]

--- a/newton/_src/solvers/kamino/_src/dynamics/body_inertia.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/body_inertia.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project rigid-body inertia through user-defined body-twist bases."""
+
+import warp as wp
+
+
+@wp.kernel
+def _eval_body_inertia_projection_kernel(
+    body_world_start: wp.array[wp.int32],
+    body_mass: wp.array[wp.float32],
+    body_inertia: wp.array[wp.mat33f],
+    body_q: wp.array[wp.transformf],
+    body_velocity_basis: wp.array2d[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
+    projection: wp.array3d[wp.float32],
+):
+    world_id, row, column = wp.tid()
+    if column < row:
+        return
+
+    value = float(0.0)
+    if not world_mask or world_mask[world_id]:
+        body_start = body_world_start[world_id]
+        body_end = body_world_start[world_id + 1]
+        for body_id in range(body_start, body_end):
+            twist_row = body_velocity_basis[row, body_id]
+            twist_column = body_velocity_basis[column, body_id]
+            linear_row = wp.spatial_top(twist_row)
+            linear_column = wp.spatial_top(twist_column)
+
+            rotation = wp.transform_get_rotation(body_q[body_id])
+            angular_row = wp.quat_rotate_inv(rotation, wp.spatial_bottom(twist_row))
+            angular_column = wp.quat_rotate_inv(rotation, wp.spatial_bottom(twist_column))
+
+            value += body_mass[body_id] * wp.dot(linear_row, linear_column)
+            value += wp.dot(angular_row, body_inertia[body_id] @ angular_column)
+
+    projection[world_id, row, column] = value
+    projection[world_id, column, row] = value
+
+
+def eval_body_inertia_projection(
+    body_world_start: wp.array[wp.int32],
+    body_mass: wp.array[wp.float32],
+    body_inertia: wp.array[wp.mat33f],
+    body_q: wp.array[wp.transformf],
+    body_velocity_basis: wp.array2d[wp.spatial_vectorf],
+    projection: wp.array3d[wp.float32],
+    world_mask: wp.array[wp.bool] | None = None,
+) -> None:
+    """Launch the body-inertia projection kernel."""
+    wp.launch(
+        _eval_body_inertia_projection_kernel,
+        dim=(projection.shape[0], projection.shape[1], projection.shape[2]),
+        inputs=[
+            body_world_start,
+            body_mass,
+            body_inertia,
+            body_q,
+            body_velocity_basis,
+            world_mask,
+        ],
+        outputs=[projection],
+        device=projection.device,
+    )

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -838,6 +838,86 @@ class SolverKamino(SolverBase, CouplingInterface):
         self._control_kamino = self._kamino.ControlKamino()
         self._control_kamino.finalize(self._model_kamino)
 
+    def eval_body_inertia_projection(
+        self,
+        state: State,
+        body_velocity_basis: wp.array2d[wp.spatial_vectorf],
+        projection: wp.array3d[wp.float32],
+        world_mask: wp.array[wp.bool] | None = None,
+    ) -> None:
+        """Project body inertias through a user-defined body-twist basis.
+
+        For every world, this method computes ``T.T @ M_body @ T``, where
+        ``T`` contains COM-referenced body twists in world coordinates and
+        ``M_body`` is the block-diagonal rigid-body inertia. The result contains
+        body-inertia contributions only; joint armature is not included.
+
+        This operation does not require the Kamino forward-kinematics solver.
+        All arrays are caller-owned and the operation does not allocate device
+        memory, making it suitable for CUDA graph capture.
+
+        Args:
+            state: Newton state providing body orientations at the projection
+                point.
+            body_velocity_basis: Body spatial-velocity basis [m/s, rad/s],
+                shape ``(basis_count, body_count)``.
+            projection: Per-world symmetric body-inertia projection, shape
+                ``(world_count, basis_count, basis_count)``. Entry units depend
+                on the corresponding basis vectors.
+            world_mask: Optional per-world mask, shape ``(world_count,)``.
+                Matrices for unselected worlds are cleared to zero.
+
+        Raises:
+            TypeError: If an array has an incompatible dtype.
+            ValueError: If the state or an array has an incompatible shape or
+                device, or if the basis is empty.
+        """
+        if state.body_q is None:
+            raise ValueError("state must contain body poses")
+
+        arrays = (
+            ("state body poses", state.body_q, wp.transformf),
+            ("body_velocity_basis", body_velocity_basis, wp.spatial_vectorf),
+            ("projection", projection, wp.float32),
+        )
+        for name, array, dtype in arrays:
+            if not isinstance(array, wp.array) or array.dtype != dtype:
+                raise TypeError(f"{name} must have dtype {dtype}")
+            if array.device != self.model.device:
+                raise ValueError(f"{name} must use the solver device")
+
+        if state.body_q.shape != (self.model.body_count,):
+            raise ValueError(f"state body poses must have shape ({self.model.body_count},)")
+        if body_velocity_basis.ndim != 2 or body_velocity_basis.shape[1] != self.model.body_count:
+            raise ValueError(
+                "body_velocity_basis must have shape "
+                f"(basis_count, {self.model.body_count}), got {body_velocity_basis.shape}"
+            )
+        basis_count = body_velocity_basis.shape[0]
+        if basis_count == 0:
+            raise ValueError("body_velocity_basis must contain at least one basis vector")
+        expected_projection_shape = (self.model.world_count, basis_count, basis_count)
+        if projection.shape != expected_projection_shape:
+            raise ValueError(f"projection must have shape {expected_projection_shape}, got {projection.shape}")
+
+        if world_mask is not None:
+            if not isinstance(world_mask, wp.array) or world_mask.dtype != wp.bool:
+                raise TypeError("world_mask must have dtype bool")
+            if world_mask.device != self.model.device:
+                raise ValueError("world_mask must use the solver device")
+            if world_mask.shape != (self.model.world_count,):
+                raise ValueError(f"world_mask must have shape ({self.model.world_count},)")
+
+        self._kamino.eval_body_inertia_projection(
+            body_world_start=self._model_kamino.info.bodies_offset,
+            body_mass=self._model_kamino.bodies.m_i,
+            body_inertia=self._model_kamino.bodies.i_I_i,
+            body_q=state.body_q,
+            body_velocity_basis=body_velocity_basis,
+            projection=projection,
+            world_mask=world_mask,
+        )
+
     @override
     def reset(
         self,

--- a/newton/tests/kamino/test_kamino_solver_kamino_inertia.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino_inertia.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test the public Kamino body-inertia projection API."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.tests.kamino import setup_tests, test_context
+
+
+class TestSolverKaminoBodyInertiaProjection(unittest.TestCase):
+    """Verify body-inertia projection in user-defined velocity coordinates."""
+
+    def setUp(self):
+        """Initialize the shared Kamino test device."""
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def tearDown(self):
+        """Release the test device reference."""
+        self.device = None
+
+    def _make_solver(self, world_count: int = 1):
+        source = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        newton.solvers.SolverKamino.register_custom_attributes(source)
+        source.add_body(
+            xform=wp.transform(
+                wp.vec3(0.2, -0.3, 0.4),
+                wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.5 * np.pi),
+            ),
+            mass=5.0,
+            inertia=wp.mat33(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0),
+            lock_inertia=True,
+        )
+
+        if world_count == 1:
+            builder = source
+        else:
+            builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+            newton.solvers.SolverKamino.register_custom_attributes(builder)
+            builder.replicate(source, world_count=world_count)
+
+        model = builder.finalize(device=self.device, skip_validation_joints=True)
+        return model, newton.solvers.SolverKamino(model)
+
+    @staticmethod
+    def _reference_projection(basis: np.ndarray) -> np.ndarray:
+        inertia_world = np.diag([3.0, 2.0, 4.0])
+        linear = basis[:, :3]
+        angular = basis[:, 3:]
+        return 5.0 * linear @ linear.T + angular @ inertia_world @ angular.T
+
+    def test_projection_matches_kinetic_energy(self):
+        """Project rotated body inertia through a non-orthogonal twist basis."""
+        model, solver = self._make_solver()
+        state = model.state()
+        basis_np = np.array(
+            [
+                [[1.0, -0.5, 0.25, 0.2, 0.4, -0.1]],
+                [[-0.3, 0.8, 0.1, -0.6, 0.2, 0.5]],
+                [[0.7, 0.2, -0.4, 0.3, -0.2, 0.9]],
+            ],
+            dtype=np.float32,
+        )
+        basis = wp.array(basis_np, dtype=wp.spatial_vectorf, device=self.device)
+        projection = wp.empty((1, 3, 3), dtype=wp.float32, device=self.device)
+
+        state_before = state.body_q.numpy().copy()
+        basis_before = basis.numpy().copy()
+        solver.eval_body_inertia_projection(state, basis, projection)
+
+        expected = self._reference_projection(basis_np[:, 0])
+        np.testing.assert_allclose(projection.numpy()[0], expected, rtol=1.0e-5, atol=1.0e-5)
+        np.testing.assert_allclose(projection.numpy()[0], projection.numpy()[0].T, atol=0.0)
+        np.testing.assert_array_equal(state.body_q.numpy(), state_before)
+        np.testing.assert_array_equal(basis.numpy(), basis_before)
+
+    def test_projection_separates_and_masks_worlds(self):
+        """Accumulate each world independently and clear masked output matrices."""
+        model, solver = self._make_solver(world_count=2)
+        state = model.state()
+        basis_np = np.zeros((2, 2, 6), dtype=np.float32)
+        basis_np[0, 0, 0] = 1.0
+        basis_np[1, 0, 3] = 2.0
+        basis_np[0, 1, 1] = 3.0
+        basis_np[1, 1, 4] = 4.0
+        basis = wp.array(basis_np, dtype=wp.spatial_vectorf, device=self.device)
+        projection = wp.empty((2, 2, 2), dtype=wp.float32, device=self.device)
+        world_mask = wp.array([True, False], dtype=wp.bool, device=self.device)
+
+        solver.eval_body_inertia_projection(state, basis, projection)
+
+        expected_world_0 = self._reference_projection(basis_np[:, 0])
+        expected_world_1 = self._reference_projection(basis_np[:, 1])
+        result = projection.numpy()
+        np.testing.assert_allclose(result[0], expected_world_0, rtol=1.0e-5, atol=1.0e-5)
+        np.testing.assert_allclose(result[1], expected_world_1, rtol=1.0e-5, atol=1.0e-5)
+
+        projection.fill_(17.0)
+        solver.eval_body_inertia_projection(state, basis, projection, world_mask)
+
+        result = projection.numpy()
+        np.testing.assert_allclose(result[0], expected_world_0, rtol=1.0e-5, atol=1.0e-5)
+        np.testing.assert_array_equal(result[1], np.zeros((2, 2), dtype=np.float32))
+
+    def test_projection_validates_arrays(self):
+        """Reject incompatible projection arrays before launching kernels."""
+        model, solver = self._make_solver()
+        state = model.state()
+        basis = wp.zeros((2, 1), dtype=wp.spatial_vectorf, device=self.device)
+        projection = wp.zeros((1, 2, 2), dtype=wp.float32, device=self.device)
+
+        with self.assertRaisesRegex(ValueError, "body_velocity_basis must have shape"):
+            solver.eval_body_inertia_projection(
+                state,
+                wp.zeros((2, 2), dtype=wp.spatial_vectorf, device=self.device),
+                projection,
+            )
+        with self.assertRaisesRegex(ValueError, "projection must have shape"):
+            solver.eval_body_inertia_projection(
+                state,
+                basis,
+                wp.zeros((1, 2, 3), dtype=wp.float32, device=self.device),
+            )
+        with self.assertRaisesRegex(TypeError, "projection must have dtype"):
+            solver.eval_body_inertia_projection(
+                state,
+                basis,
+                wp.zeros((1, 2, 2), dtype=wp.float64, device=self.device),
+            )
+        with self.assertRaisesRegex(ValueError, "world_mask must have shape"):
+            solver.eval_body_inertia_projection(
+                state,
+                basis,
+                projection,
+                wp.zeros(2, dtype=wp.bool, device=self.device),
+            )
+
+
+if __name__ == "__main__":
+    setup_tests()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Add `SolverKamino.eval_body_inertia_projection()` to compute a per-world `T_body.T @ M_body @ T_body` from caller-provided COM/world-frame body-twist bases.

The operation:

- supports heterogeneous batched worlds and optional world masks;
- rotates local COM inertia into each body orientation without mutating state;
- writes a symmetric caller-owned output without device allocations;
- remains independent of the FK solver and PR #3916;
- deliberately excludes joint armature and all bias/force terms.

Closes #3927.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k test_kamino_solver_kamino_inertia
CUDA_VISIBLE_DEVICES="" uv run --extra dev -m newton.tests -k test_kamino_solver_kamino_inertia
uv run --extra dev -m newton.tests -k test_kamino_solver_kamino --no-cache-clear
uv run docs/generate_api.py
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version 0.0.0 --date 2026-08-15
```

## New feature / API change

```python
basis_count = 18
body_velocity_basis = wp.empty(
    (basis_count, model.body_count),
    dtype=wp.spatial_vectorf,
    device=model.device,
)
body_inertia = wp.empty(
    (model.world_count, basis_count, basis_count),
    dtype=wp.float32,
    device=model.device,
)

solver.eval_body_inertia_projection(
    state,
    body_velocity_basis,
    body_inertia,
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added body-inertia projection through user-defined body velocity bases.
  - Supports per-world calculations, rotated inertias, optional world masking, and device-resident execution.
  - Exposed the functionality through the Kamino solver API.

- **Bug Fixes**
  - Ensures masked outputs are cleared and validates input shapes and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->