### PR TITLE
Honor --num-frames in the headless GL viewer

### DIFF
--- a/changelog/+viewer-gl-num-frames-6b41d0e7.fixed.md
+++ b/changelog/+viewer-gl-num-frames-6b41d0e7.fixed.md
@@ -1,0 +1,1 @@
+Honor `--num-frames` when running examples with the headless OpenGL viewer. `newton.viewer.ViewerGL` gained a `num_frames` argument; in headless mode `ViewerGL.is_running()` now returns False once that many frames have been rendered, so headless runs terminate instead of looping forever. Windowed runs still ignore `num_frames` and close with the window.

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -202,6 +202,7 @@ class ViewerGL(ViewerBase):
         headless: bool = False,
         paused: bool = False,
         plot_history_size: int = 250,
+        num_frames: int | None = None,
     ):
         """
         Initialize the OpenGL viewer and UI.
@@ -214,6 +215,9 @@ class ViewerGL(ViewerBase):
             paused: Start the viewer in paused mode.
             plot_history_size: Maximum number of samples kept per
                 :meth:`log_scalar` signal for the live time-series plots.
+            num_frames: Number of frames to render in headless mode before
+                :meth:`is_running` returns False. If None, headless rendering
+                is unbounded. Ignored in windowed mode.
         """
         if not isinstance(plot_history_size, int) or isinstance(plot_history_size, bool):
             raise TypeError("plot_history_size must be an integer")
@@ -254,6 +258,12 @@ class ViewerGL(ViewerBase):
         self._paused = paused
         self._step_requested = False
         self._reset_callback: Callable[[], None] | None = None
+
+        # Headless has no window-close event, so a frame budget is the only
+        # termination signal available to is_running().
+        self._headless = headless
+        self.num_frames = num_frames
+        self._frame_count = 0
 
         self.renderer.register_key_press(self.on_key_press)
         self.renderer.register_key_release(self.on_key_release)
@@ -1702,6 +1712,7 @@ class ViewerGL(ViewerBase):
         whether an exit was requested and early-out before touching GL if so.
         """
         self._update()
+        self._frame_count += 1
 
     @override
     def apply_forces(self, state: nt.State):
@@ -1861,10 +1872,18 @@ class ViewerGL(ViewerBase):
         """
         Check if the viewer is still running.
 
+        In headless mode the viewer stops once ``num_frames`` is reached. In
+        windowed mode it keeps running until the user closes the window,
+        ignoring ``num_frames`` so the window does not disappear unexpectedly.
+
         Returns:
-            bool: True if the window is open, False if closed.
+            bool: True if the viewer should keep rendering, False otherwise.
         """
-        return not self.renderer.has_exit()
+        if self.renderer.has_exit():
+            return False
+        if self._headless and self.num_frames is not None:
+            return self._frame_count < self.num_frames
+        return True
 
     @override
     def is_paused(self) -> bool:

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -217,12 +217,18 @@ class ViewerGL(ViewerBase):
                 :meth:`log_scalar` signal for the live time-series plots.
             num_frames: Number of frames to render in headless mode before
                 :meth:`is_running` returns False. If None, headless rendering
-                is unbounded. Ignored in windowed mode.
+                is unbounded; if 0, no frames are rendered. Ignored in
+                windowed mode.
         """
         if not isinstance(plot_history_size, int) or isinstance(plot_history_size, bool):
             raise TypeError("plot_history_size must be an integer")
         if plot_history_size <= 0:
             raise ValueError("plot_history_size must be > 0")
+        if num_frames is not None:
+            if not isinstance(num_frames, int) or isinstance(num_frames, bool):
+                raise TypeError("num_frames must be an integer or None")
+            if num_frames < 0:
+                raise ValueError("num_frames must be >= 0")
 
         # Rolling buffers for log_scalar() time-series plots.
         self._scalar_buffers: dict[str, collections.deque] = {}

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -910,7 +910,7 @@ def init(parser=None):
     # Create viewer based on type
     visible_gl = args.viewer == "gl" and not args.headless
     if args.viewer == "gl":
-        viewer = newton.viewer.ViewerGL(headless=args.headless, paused=args.paused)
+        viewer = newton.viewer.ViewerGL(headless=args.headless, paused=args.paused, num_frames=args.num_frames)
     elif args.viewer == "usd":
         if args.output_path is None:
             raise ValueError("--output-path is required when using usd viewer")

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -110,5 +110,55 @@ class TestViewerGLShouldStep(unittest.TestCase):
         self.assertFalse(ViewerGL.should_step(v))
 
 
+def _make_gl_running_state(headless: bool, num_frames: int | None, frame_count: int = 0) -> "ViewerGL":
+    # Stand-in carrying only the fields ViewerGL.is_running()/end_frame() read,
+    # so the frame budget can be exercised without a GL context.
+    return SimpleNamespace(  # type: ignore[return-value]
+        renderer=SimpleNamespace(has_exit=lambda: False),
+        _headless=headless,
+        num_frames=num_frames,
+        _frame_count=frame_count,
+        _update=lambda: None,
+    )
+
+
+class TestViewerGLFrameBudget(unittest.TestCase):
+    """ViewerGL.is_running() honours num_frames in headless mode."""
+
+    def test_headless_stops_once_num_frames_reached(self):
+        """Verify headless rendering stops after num_frames frames."""
+        v = _make_gl_running_state(headless=True, num_frames=3)
+        for _ in range(3):
+            self.assertTrue(ViewerGL.is_running(v))
+            ViewerGL.end_frame(v)
+        self.assertFalse(ViewerGL.is_running(v))
+
+    def test_headless_without_num_frames_runs_unbounded(self):
+        """Verify headless rendering is unbounded when num_frames is None."""
+        v = _make_gl_running_state(headless=True, num_frames=None)
+        for _ in range(5):
+            ViewerGL.end_frame(v)
+        self.assertTrue(ViewerGL.is_running(v))
+
+    def test_windowed_ignores_num_frames(self):
+        """Verify a visible window keeps running past num_frames."""
+        v = _make_gl_running_state(headless=False, num_frames=1)
+        for _ in range(3):
+            ViewerGL.end_frame(v)
+        self.assertTrue(ViewerGL.is_running(v))
+
+    def test_window_close_stops_headless_run_early(self):
+        """Verify an exit request wins over a remaining frame budget."""
+        v = _make_gl_running_state(headless=True, num_frames=10)
+        v.renderer.has_exit = lambda: True
+        self.assertFalse(ViewerGL.is_running(v))
+
+    def test_end_frame_counts_frames(self):
+        """Verify end_frame() advances the frame counter used by the budget."""
+        v = _make_gl_running_state(headless=True, num_frames=2)
+        ViewerGL.end_frame(v)
+        self.assertEqual(v._frame_count, 1)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -159,6 +159,36 @@ class TestViewerGLFrameBudget(unittest.TestCase):
         ViewerGL.end_frame(v)
         self.assertEqual(v._frame_count, 1)
 
+    def test_zero_num_frames_stops_before_the_first_frame(self):
+        """Verify a zero budget renders nothing at all."""
+        v = _make_gl_running_state(headless=True, num_frames=0)
+        self.assertFalse(ViewerGL.is_running(v))
+
+
+class TestViewerGLNumFramesValidation(unittest.TestCase):
+    """ViewerGL rejects num_frames values that would otherwise fail silently.
+
+    The budget is applied as ``_frame_count < num_frames``, so a non-integer
+    or negative value produces a surprising frame count rather than an error.
+    These inputs are rejected before any GL context is created, so the tests
+    need no display.
+    """
+
+    def test_rejects_non_integer_num_frames(self):
+        """Verify a float num_frames raises TypeError rather than rendering a fractional budget."""
+        with self.assertRaises(TypeError):
+            ViewerGL(num_frames=1.5)  # type: ignore[arg-type]
+
+    def test_rejects_bool_num_frames(self):
+        """Verify a bool num_frames raises TypeError rather than being treated as 0 or 1."""
+        with self.assertRaises(TypeError):
+            ViewerGL(num_frames=True)
+
+    def test_rejects_negative_num_frames(self):
+        """Verify a negative num_frames raises ValueError rather than silently rendering nothing."""
+        with self.assertRaises(ValueError):
+            ViewerGL(num_frames=-1)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

`--num-frames` had no effect on the OpenGL viewer in headless mode, so a run such as
`python -m newton.examples basic_pendulum --viewer gl --headless --num-frames 30` never
terminated.

`ViewerGL` was the only viewer that did not receive the flag. `newton/examples/__init__.py`
constructed `ViewerGL(headless=..., paused=...)`, while `ViewerUSD`, `ViewerRTX` and
`ViewerNull` were each passed `num_frames=args.num_frames`. `ViewerGL` had no such parameter,
and `ViewerGL.is_running()` returned `not self.renderer.has_exit()`, where `has_exit()` reads
`pyglet.app.event_loop.has_exit`. Nothing sets that flag when there is no window to close, so
`is_running()` stayed `True` indefinitely.

This adds a `num_frames` argument to `ViewerGL`, increments a frame counter in `end_frame()`,
and applies the budget in `is_running()` only when the viewer is headless, mirroring
`ViewerRTX.is_running()`. A visible window still closes on user action rather than
disappearing once the budget is reached.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k test_viewer_controls
```

`Ran 16 tests ... OK`. The five new tests in `TestViewerGLFrameBudget` drive `is_running()`
and `end_frame()` through stubs, so they need no GL context and run on machines without a
GPU. Reverting `newton/_src/viewer/viewer_gl.py` and `newton/examples/__init__.py` to their
previous contents and rerunning the same command gives `FAILED (failures=2)`, with
`test_headless_stops_once_num_frames_reached` asserting that `is_running()` is `False` and
getting `True`.

Verified end to end on a headless Linux machine (NVIDIA driver 580.126.16, GL 3.3):

```
PYGLET_HEADLESS=1 uv run -m newton.examples basic_pendulum \
    --viewer gl --headless --num-frames 30 --device cuda:0
```

now exits 0 rather than running forever, and
`PYGLET_HEADLESS=1 uv run --extra dev -m newton.tests -k test_viewer_get_frame` passes 8/8
with a non-uniform `get_frame()` readback.

`uvx pre-commit run -a` passes, and `docs/generate_api.py` produces no diff.

## Bug fix

**Steps to reproduce:**

1. Use a machine with no display, with pyglet in headless mode (`PYGLET_HEADLESS=1`).
2. Run `python -m newton.examples basic_pendulum --viewer gl --headless --num-frames 30`.
3. The example keeps rendering and never exits; the frame budget is ignored.

**Minimal reproduction:**

```python
import newton

viewer = newton.viewer.ViewerGL(headless=True)

# Before this change ViewerGL took no num_frames argument, and in headless mode
# is_running() never returned False, so any loop driven by it ran forever.
while viewer.is_running():
    viewer.begin_frame(0.0)
    viewer.end_frame()
```

## New feature / API change

`ViewerGL` gains an optional `num_frames` argument, matching `ViewerRTX`, so a headless run
can bound itself without an external frame counter:

```python
import newton

viewer = newton.viewer.ViewerGL(headless=True, num_frames=30)

while viewer.is_running():
    viewer.begin_frame(0.0)
    viewer.end_frame()
```

`num_frames` defaults to `None`, which keeps headless rendering unbounded, and it is ignored
in windowed mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for limiting headless OpenGL viewer runs to a specified number of frames.
  * Added the `num_frames` option to OpenGL viewer configuration.
  * Command-line example runs now honor the configured frame limit.

* **Bug Fixes**
  * Preserved continuous rendering for windowed viewers and runs without a frame limit.
  * Headless viewers now stop promptly when the renderer closes or an exit is requested.
  * Added validation for invalid frame-limit values.

* **Tests**
  * Added coverage for frame limits, unlimited runs, windowed behavior, validation, and early exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->