### PR TITLE
Document pyglet headless requirement for ViewerGL

### DIFF
--- a/changelog/+docs-viewergl-headless-pyglet-3f7a9c21.skip
+++ b/changelog/+docs-viewergl-headless-pyglet-3f7a9c21.skip
@@ -1,0 +1,1 @@
+Documentation only: records the existing pyglet headless requirement for ViewerGL.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -188,6 +188,30 @@ Warp array on the viewer device:
     # Returns a wp.array with shape (height, width, 3), dtype wp.uint8
     frame = viewer.get_frame()
 
+.. note::
+
+    On a machine without a display, pyglet must also be put in headless mode. pyglet binds its
+    display backend the first time that backend is imported, and Newton imports pyglet's window
+    and display modules when the first :class:`~newton.viewer.ViewerGL` is constructed, so the
+    option has to be set before that point. Otherwise the snippet above fails with
+    ``pyglet.display.xlib.NoSuchDisplayException: Cannot connect to "None"`` on Linux, since
+    pyglet defaults to Xlib. Either set the environment variable::
+
+        PYGLET_HEADLESS=1 python your_script.py
+
+    or set the option in Python before creating the viewer::
+
+        import newton
+        import pyglet
+
+        pyglet.options["headless"] = True
+
+        viewer = newton.viewer.ViewerGL(headless=True)
+
+    On a machine with several GPUs, ``PYGLET_HEADLESS_DEVICE`` (or
+    ``pyglet.options["headless_device"]``) selects which one renders; it defaults to ``0``,
+    which is not necessarily the device the rest of the simulation runs on.
+
 **Custom UI panels:**
 
 :meth:`~newton.viewer.ViewerGL.register_ui_callback` adds custom imgui UI elements to the viewer.


### PR DESCRIPTION
## Description

`docs/guide/visualization.rst` presents `ViewerGL(headless=True)` followed by `get_frame()` as a
self-contained snippet, but on a machine without a display it raises
`pyglet.display.xlib.NoSuchDisplayException: Cannot connect to "None"` at construction. pyglet
selects its windowing backend when `pyglet.window` is first imported and defaults to Xlib on
Linux; Newton reads `pyglet.options["headless"]` in `newton/_src/viewer/gl/opengl.py` but never
sets it, and neither `newton/` nor `docs/` mentions `PYGLET_HEADLESS`.

This adds a note beside that snippet recording the requirement and both ways to satisfy it —
`PYGLET_HEADLESS=1` in the environment, or `pyglet.options["headless"] = True` set before
`newton` is imported — along with `PYGLET_HEADLESS_DEVICE` for choosing the GPU on a machine with
more than one.

Documentation only; no behavior change.

Refs #3931, which proposes having `ViewerGL.__init__` set the option itself. If that lands, this
note shrinks to a sentence.

## Checklist

- [ ] New or existing tests cover these changes — not applicable, documentation only
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)
      — added `changelog/+docs-viewergl-headless-pyglet-3f7a9c21.skip`, as there is no
      user-facing code change

## Test plan

```
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

Builds clean with warnings as errors, which is the same invocation `.github/workflows/pr.yml`
uses. `uvx pre-commit run -a` passes.

The statements in the note were checked against the pyglet in the lockfile (2.1.14) rather than
written from memory:

- `pyglet/__init__.py` resolves every option from `PYGLET_<OPTION_NAME>`, so `PYGLET_HEADLESS`
  and `PYGLET_HEADLESS_DEVICE` correspond to the `headless` and `headless_device` options.
- `headless_device` defaults to `0`.
- The exception raised when the option is not set is `pyglet.display.xlib.NoSuchDisplayException`
  (`pyglet.canvas` was renamed to `pyglet.display` in pyglet 2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling pyglet headless mode before using ViewerGL on Linux.
  * Documented environment-variable and Python configuration options.
  * Added instructions for selecting the GPU used in headless mode.
  * Recorded the existing headless-mode requirement in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->