### PR TITLE
Add topology-independent entity views

### DIFF
--- a/changelog/+entity-views-a41c7e2d.added.md
+++ b/changelog/+entity-views-a41c7e2d.added.md
@@ -1,1 +1,0 @@
-Add topology-independent `JointView` and `BodyView` selections for closed-loop mechanisms and other labeled model entities, with optional exact per-world label-prefix normalization.

--- a/changelog/+entity-views-a41c7e2d.added.md
+++ b/changelog/+entity-views-a41c7e2d.added.md
@@ -1,0 +1,1 @@
+Add topology-independent `JointView` and `BodyView` selections for closed-loop mechanisms and other labeled model entities.

--- a/changelog/+entity-views-a41c7e2d.added.md
+++ b/changelog/+entity-views-a41c7e2d.added.md
@@ -1,1 +1,1 @@
-Add topology-independent `JointView` and `BodyView` selections for closed-loop mechanisms and other labeled model entities.
+Add topology-independent `JointView` and `BodyView` selections for closed-loop mechanisms and other labeled model entities, with optional exact per-world label-prefix normalization.

--- a/changelog/3174.added.md
+++ b/changelog/3174.added.md
@@ -1,0 +1,1 @@
+Add topology-independent `JointView` and `BodyView` selections for labeled closed-loop mechanisms, with explicit per-world label-prefix normalization and non-contiguous attribute gather/scatter.

--- a/docs/api/newton_actuators.rst
+++ b/docs/api/newton_actuators.rst
@@ -4,6 +4,9 @@
 newton.actuators
 ================
 
+.. py:module:: newton.actuators
+.. currentmodule:: newton.actuators
+
 GPU-accelerated actuator models for physics simulations.
 
 This module provides a modular library of actuator components — controllers,
@@ -16,9 +19,6 @@ construction.
 
     The actuator API may change without prior notice. Feedback is welcome —
     please file issues or discussion threads.
-
-.. py:module:: newton.actuators
-.. currentmodule:: newton.actuators
 
 .. rubric:: Classes
 

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -4,6 +4,9 @@
 newton.controllers
 ==================
 
+.. py:module:: newton.controllers
+.. currentmodule:: newton.controllers
+
 GPU-accelerated, vectorized control laws.
 
 This module provides standalone controllers that compute signals
@@ -11,9 +14,6 @@ for the robot to track. Each controller is a concrete
 subclass of :class:`ControllerBase`.
 
 .. experimental::
-
-.. py:module:: newton.controllers
-.. currentmodule:: newton.controllers
 
 .. rubric:: Classes
 

--- a/docs/api/newton_ik.rst
+++ b/docs/api/newton_ik.rst
@@ -4,10 +4,10 @@
 newton.ik
 =========
 
-Public inverse-kinematics API for defining objectives and solving IK problems.
-
 .. py:module:: newton.ik
 .. currentmodule:: newton.ik
+
+Public inverse-kinematics API for defining objectives and solving IK problems.
 
 .. rubric:: Classes
 

--- a/docs/api/newton_selection.rst
+++ b/docs/api/newton_selection.rst
@@ -4,14 +4,14 @@
 newton.selection
 ================
 
+.. py:module:: newton.selection
+.. currentmodule:: newton.selection
+
 Structured selection views for model entities.
 
 Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
 operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
 attribute access and masks, including closed-loop mechanisms without articulations.
-
-.. py:module:: newton.selection
-.. currentmodule:: newton.selection
 
 .. rubric:: Classes
 

--- a/docs/api/newton_selection.rst
+++ b/docs/api/newton_selection.rst
@@ -6,9 +6,9 @@ newton.selection
 
 Structured selection views for model entities.
 
-Use :class:`ArticulationView` for tree-specific roots, masks, and reduced-coordinate
+Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
 operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
-attribute access, including closed-loop mechanisms without articulations.
+attribute access and masks, including closed-loop mechanisms without articulations.
 
 .. py:module:: newton.selection
 .. currentmodule:: newton.selection

--- a/docs/api/newton_selection.rst
+++ b/docs/api/newton_selection.rst
@@ -4,12 +4,6 @@
 newton.selection
 ================
 
-Structured selection views for model entities.
-
-Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
-operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
-attribute access and masks, including closed-loop mechanisms without articulations.
-
 .. py:module:: newton.selection
 .. currentmodule:: newton.selection
 
@@ -20,5 +14,3 @@ attribute access and masks, including closed-loop mechanisms without articulatio
    :nosignatures:
 
    ArticulationView
-   BodyView
-   JointView

--- a/docs/api/newton_selection.rst
+++ b/docs/api/newton_selection.rst
@@ -4,6 +4,12 @@
 newton.selection
 ================
 
+Structured selection views for model entities.
+
+Use :class:`ArticulationView` for tree-specific roots, masks, and reduced-coordinate
+operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
+attribute access, including closed-loop mechanisms without articulations.
+
 .. py:module:: newton.selection
 .. currentmodule:: newton.selection
 
@@ -14,3 +20,5 @@ newton.selection
    :nosignatures:
 
    ArticulationView
+   BodyView
+   JointView

--- a/docs/api/newton_selection.rst
+++ b/docs/api/newton_selection.rst
@@ -4,6 +4,12 @@
 newton.selection
 ================
 
+Structured selection views for model entities.
+
+Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
+operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
+attribute access and masks, including closed-loop mechanisms without articulations.
+
 .. py:module:: newton.selection
 .. currentmodule:: newton.selection
 
@@ -14,3 +20,5 @@ newton.selection
    :nosignatures:
 
    ArticulationView
+   BodyView
+   JointView

--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -4,6 +4,9 @@
 newton.solvers
 ==============
 
+.. py:module:: newton.solvers
+.. currentmodule:: newton.solvers
+
 Solvers integrate the dynamics of a :class:`~newton.Model` through the common
 :class:`~newton.solvers.SolverBase` interface. Newton provides backends for
 rigid articulated systems, maximal-coordinate constraints, particles, and
@@ -13,9 +16,6 @@ For solver-selection guidance and the feature, contact-material, joint-support,
 and differentiability comparisons, see the :doc:`Solvers guide </solvers/index>`.
 Installed-wheel users can use the stable hosted guide at
 https://newton-physics.github.io/newton/stable/solvers/index.html.
-
-.. py:module:: newton.solvers
-.. currentmodule:: newton.solvers
 
 .. toctree::
    :hidden:

--- a/docs/api/newton_solvers_experimental.rst
+++ b/docs/api/newton_solvers_experimental.rst
@@ -4,12 +4,12 @@
 newton.solvers.experimental
 ===========================
 
+.. py:module:: newton.solvers.experimental
+.. currentmodule:: newton.solvers.experimental
+
 Experimental solver namespaces.
 
 .. experimental::
-
-.. py:module:: newton.solvers.experimental
-.. currentmodule:: newton.solvers.experimental
 
 .. toctree::
    :hidden:

--- a/docs/api/newton_solvers_experimental_coupled.rst
+++ b/docs/api/newton_solvers_experimental_coupled.rst
@@ -4,12 +4,12 @@
 newton.solvers.experimental.coupled
 ===================================
 
+.. py:module:: newton.solvers.experimental.coupled
+.. currentmodule:: newton.solvers.experimental.coupled
+
 Experimental coupled-solver framework.
 
 .. experimental::
-
-.. py:module:: newton.solvers.experimental.coupled
-.. currentmodule:: newton.solvers.experimental.coupled
 
 .. rubric:: Classes
 

--- a/docs/api/newton_solvers_style3d.rst
+++ b/docs/api/newton_solvers_style3d.rst
@@ -4,11 +4,6 @@
 newton.solvers.style3d
 ======================
 
-Style3D solver module.
-
-This module provides helper functions for setting up Style3D cloth assets.
-Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver class.
-
 .. note::
 
    This page documents helper functions exposed through the ``newton.solvers.style3d`` attribute.
@@ -16,6 +11,11 @@ Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver class.
    ``from newton.solvers import style3d`` instead of ``import newton.solvers.style3d``.
 
 .. currentmodule:: newton._src.solvers.style3d
+
+Style3D solver module.
+
+This module provides helper functions for setting up Style3D cloth assets.
+Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver class.
 
 .. rubric:: Functions
 

--- a/docs/api/newton_usd.rst
+++ b/docs/api/newton_usd.rst
@@ -4,13 +4,13 @@
 newton.usd
 ==========
 
+.. py:module:: newton.usd
+.. currentmodule:: newton.usd
+
 Utilities for working with the Universal Scene Description (USD) format.
 
 This module provides both low-level USD utility helpers and public schema
 resolver types used by :meth:`newton.ModelBuilder.add_usd`.
-
-.. py:module:: newton.usd
-.. currentmodule:: newton.usd
 
 .. rubric:: Classes
 

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -263,10 +263,7 @@ def write_module_page(mod_name: str, api_toctree_modules: set[str] | None = None
         "",
     ]
 
-    # Module docstring if available
     doc = (module.__doc__ or "").strip()
-    if doc:
-        lines.extend([doc, ""])
 
     if uses_internal_solver_module:
         lines.extend(
@@ -283,6 +280,10 @@ def write_module_page(mod_name: str, api_toctree_modules: set[str] | None = None
         )
     else:
         lines.extend([f".. py:module:: {mod_name}", f".. currentmodule:: {mod_name}", ""])
+
+    # Resolve short cross-references in module prose against its public module.
+    if doc:
+        lines.extend([doc, ""])
 
     # Render submodules as direct document links instead of autosummary stubs.
     # Child module pages still need hidden toctree edges to satisfy Sphinx.

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -285,7 +285,18 @@ def _scatter_mapped_4d_kernel(
         dst[mapping[world, value], component] = values[world, instance, value, component]
 
 
-for _dtype in [float, int, wp.transform, wp.spatial_vector]:
+for _dtype in (
+    float,
+    int,
+    wp.bool,
+    wp.uint64,
+    wp.vec2i,
+    wp.vec3i,
+    wp.vec3,
+    wp.mat33,
+    wp.transform,
+    wp.spatial_vector,
+):
     wp.overload(
         _gather_mapped_3d_kernel,
         {"src": wp.array[_dtype], "dst": wp.array3d[_dtype]},

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -214,6 +214,105 @@ for _dtype in [float, wp.transform, wp.spatial_vector]:
 
 
 # ========================================================================================
+# Differentiable gather/scatter kernels for explicit per-world entity mappings
+
+
+@wp.kernel
+def _gather_mapped_3d_kernel(
+    src: Any,  # 1d source attribute
+    mapping: wp.array2d[int],
+    dst: Any,  # (world, instance, value)
+):
+    world, instance, value = wp.tid()
+    dst[world, instance, value] = src[mapping[world, value]]
+
+
+@wp.kernel
+def _gather_mapped_4d_kernel(
+    src: Any,  # 2d source attribute
+    mapping: wp.array2d[int],
+    dst: Any,  # (world, instance, value, component)
+):
+    world, instance, value, component = wp.tid()
+    dst[world, instance, value, component] = src[mapping[world, value], component]
+
+
+@wp.kernel
+def _scatter_mapped_3d_per_world_kernel(
+    mask: wp.array[bool],
+    values: Any,
+    mapping: wp.array2d[int],
+    dst: Any,
+):
+    world, instance, value = wp.tid()
+    if mask[world]:
+        dst[mapping[world, value]] = values[world, instance, value]
+
+
+@wp.kernel
+def _scatter_mapped_4d_per_world_kernel(
+    mask: wp.array[bool],
+    values: Any,
+    mapping: wp.array2d[int],
+    dst: Any,
+):
+    world, instance, value, component = wp.tid()
+    if mask[world]:
+        dst[mapping[world, value], component] = values[world, instance, value, component]
+
+
+@wp.kernel
+def _scatter_mapped_3d_kernel(
+    mask: wp.array2d[bool],
+    values: Any,
+    mapping: wp.array2d[int],
+    dst: Any,
+):
+    world, instance, value = wp.tid()
+    if mask[world, instance]:
+        dst[mapping[world, value]] = values[world, instance, value]
+
+
+@wp.kernel
+def _scatter_mapped_4d_kernel(
+    mask: wp.array2d[bool],
+    values: Any,
+    mapping: wp.array2d[int],
+    dst: Any,
+):
+    world, instance, value, component = wp.tid()
+    if mask[world, instance]:
+        dst[mapping[world, value], component] = values[world, instance, value, component]
+
+
+for _dtype in [float, int, wp.transform, wp.spatial_vector]:
+    wp.overload(
+        _gather_mapped_3d_kernel,
+        {"src": wp.array[_dtype], "dst": wp.array3d[_dtype]},
+    )
+    wp.overload(
+        _gather_mapped_4d_kernel,
+        {"src": wp.array2d[_dtype], "dst": wp.array4d[_dtype]},
+    )
+    wp.overload(
+        _scatter_mapped_3d_per_world_kernel,
+        {"values": wp.array3d[_dtype], "dst": wp.array[_dtype]},
+    )
+    wp.overload(
+        _scatter_mapped_4d_per_world_kernel,
+        {"values": wp.array4d[_dtype], "dst": wp.array2d[_dtype]},
+    )
+    wp.overload(
+        _scatter_mapped_3d_kernel,
+        {"values": wp.array3d[_dtype], "dst": wp.array[_dtype]},
+    )
+    wp.overload(
+        _scatter_mapped_4d_kernel,
+        {"values": wp.array4d[_dtype], "dst": wp.array2d[_dtype]},
+    )
+
+
+# ========================================================================================
 # Actuator scatter/gather kernels
 
 
@@ -352,6 +451,7 @@ class FrequencyLayout:
         value_count: int,
         indices: list[int],
         device,
+        mapping: list[list[int]] | None = None,
     ):
         self.offset = offset  # number of values to skip at the beginning of attribute array
         self.stride_between_worlds = stride_between_worlds
@@ -359,7 +459,10 @@ class FrequencyLayout:
         self.value_count = value_count
         self.slice = None
         self.indices = None
-        if len(indices) == 0:
+        self.mapping = None
+        if mapping is not None:
+            self.mapping = wp.array2d(mapping, dtype=int, device=device)
+        elif len(indices) == 0:
             self.slice = slice(0, 0)
         elif is_contiguous_slice(indices):
             self.slice = slice(indices[0], indices[-1] + 1)
@@ -368,17 +471,19 @@ class FrequencyLayout:
 
     @property
     def is_contiguous(self):
-        return self.slice is not None
+        return self.mapping is None and self.slice is not None
 
     @property
     def selected_value_count(self):
-        if self.slice is not None:
+        if self.mapping is not None:
+            return self.mapping.shape[1]
+        elif self.slice is not None:
             return self.slice.stop - self.slice.start
         else:
             return len(self.indices)
 
     def __str__(self):
-        indices = self.indices if self.indices is not None else self.slice
+        indices = self.mapping if self.mapping is not None else self.indices if self.indices is not None else self.slice
         return f"FrequencyLayout(\n    offset: {self.offset}\n    stride_between_worlds: {self.stride_between_worlds}\n    stride_within_worlds: {self.stride_within_worlds}\n    indices: {indices}\n)"
 
 
@@ -1284,6 +1389,20 @@ class ArticulationView:
         elif not isinstance(_slice, (NoneType, int, slice)):
             raise ValueError(f"Invalid slice type: expected slice or int, got {type(_slice)}")
 
+        if layout.mapping is not None:
+            if _slice is not None:
+                raise NotImplementedError("Explicit entity mappings do not support custom attribute slices")
+            shape = (self.world_count, self.count_per_world, layout.value_count, *attrib.shape[1:])
+            result = wp.empty(
+                shape,
+                dtype=attrib.dtype,
+                device=attrib.device,
+                requires_grad=attrib.requires_grad,
+            )
+            result._mapped_source = attrib
+            result._mapped_indices = layout.mapping
+            return result
+
         if _slice is None:
             value_slice = layout.indices if is_indexed else layout.slice
             value_count = layout.value_count
@@ -1359,6 +1478,16 @@ class ArticulationView:
 
     def _get_attribute_values(self, name: str, source: Model | State | Control, _slice: slice | None = None):
         attrib = self._get_attribute_array(name, source, _slice=_slice)
+        if hasattr(attrib, "_mapped_source"):
+            kernel = _gather_mapped_4d_kernel if attrib.ndim == 4 else _gather_mapped_3d_kernel
+            wp.launch(
+                kernel,
+                dim=attrib.shape,
+                inputs=[attrib._mapped_source, attrib._mapped_indices],
+                outputs=[attrib],
+                device=self.device,
+            )
+            return attrib
         if hasattr(attrib, "_staging_array"):
             if hasattr(attrib, "_gather_src"):
                 kernel = _gather_indexed_4d_kernel if attrib.ndim == 4 else _gather_indexed_3d_kernel
@@ -1401,6 +1530,22 @@ class ArticulationView:
             mask = self.full_mask
         else:
             mask = self._resolve_mask(mask)
+
+        if hasattr(attrib, "_mapped_source"):
+            if mask.ndim == 1:
+                kernel = (
+                    _scatter_mapped_4d_per_world_kernel if attrib.ndim == 4 else _scatter_mapped_3d_per_world_kernel
+                )
+            else:
+                kernel = _scatter_mapped_4d_kernel if attrib.ndim == 4 else _scatter_mapped_3d_kernel
+            wp.launch(
+                kernel,
+                dim=attrib.shape,
+                inputs=[mask, values, attrib._mapped_indices],
+                outputs=[attrib._mapped_source],
+                device=self.device,
+            )
+            return
 
         # launch appropriate kernel based on attribute dimensionality
         # TODO: cache concrete overload per attribute?
@@ -2119,16 +2264,26 @@ def _get_group_labels(
     entity_name: str,
 ) -> list[list[str]]:
     grouped_labels = [[labels[selected_id] for selected_id in selected_ids] for selected_ids in grouped_ids]
+    return _normalize_group_labels(grouped_labels, label_prefixes, global_only, view_name, entity_name)
+
+
+def _normalize_group_labels(
+    grouped_labels: list[list[str | None]],
+    label_prefixes: list[str] | tuple[str, ...] | None,
+    global_only: bool,
+    view_name: str,
+    entity_name: str,
+) -> list[list[str | None]]:
     if label_prefixes is None:
         return grouped_labels
     if global_only:
         raise ValueError(f"{view_name} label_prefixes cannot be used with a global-only selection")
     if not isinstance(label_prefixes, (list, tuple)):
         raise TypeError(f"{view_name} label_prefixes must be a list or tuple of strings")
-    if len(label_prefixes) != len(grouped_ids):
+    if len(label_prefixes) != len(grouped_labels):
         raise ValueError(
             f"{view_name} label_prefixes length {len(label_prefixes)} must match selected model world count "
-            f"{len(grouped_ids)}"
+            f"{len(grouped_labels)}"
         )
 
     normalized_groups = []
@@ -2140,6 +2295,9 @@ def _get_group_labels(
         prefix_with_separator = f"{prefix}/"
         normalized_labels = []
         for label in world_labels:
+            if label is None:
+                normalized_labels.append(None)
+                continue
             if not label.startswith(prefix_with_separator):
                 raise ValueError(
                     f"{view_name} {entity_name} label '{label}' in world {world} does not start with "
@@ -2172,16 +2330,16 @@ def _make_entity_frequency_layout(
     relative_indices = [
         [index - start for index in indices] for indices, start in zip(grouped_indices, starts, strict=True)
     ]
-    if not all_equal(relative_indices):
-        raise ValueError(
-            f"{view_name} requires a uniform {frequency_name} layout across worlds; "
-            "selected indices have different relative layouts"
-        )
-
     outer_strides = [starts[i] - starts[i - 1] for i in range(1, len(starts))]
-    if outer_strides and not all_equal(outer_strides):
-        raise ValueError(
-            f"{view_name} requires a uniform {frequency_name} layout across worlds; world strides are {outer_strides}"
+    if not all_equal(relative_indices) or (outer_strides and not all_equal(outer_strides)):
+        return FrequencyLayout(
+            0,
+            0,
+            0,
+            len(grouped_indices[0]),
+            [],
+            device,
+            mapping=grouped_indices,
         )
 
     local_indices = relative_indices[0]
@@ -2350,6 +2508,38 @@ class JointView(_EntityView):
             raise ValueError(
                 "JointView requires a uniform joint layout across worlds; "
                 "selected joint types or coordinate/DOF dimensions differ"
+            )
+
+        model_joint_parent = model.joint_parent.numpy()
+        model_joint_child = model.joint_child.numpy()
+        parent_labels = _normalize_group_labels(
+            [
+                [
+                    None if model_joint_parent[joint_id] < 0 else model.body_label[model_joint_parent[joint_id]]
+                    for joint_id in ids
+                ]
+                for ids in joint_ids
+            ],
+            label_prefixes,
+            global_only,
+            "JointView",
+            "joint parent body",
+        )
+        child_labels = _normalize_group_labels(
+            [[model.body_label[model_joint_child[joint_id]] for joint_id in ids] for ids in joint_ids],
+            label_prefixes,
+            global_only,
+            "JointView",
+            "joint child body",
+        )
+        topology = [
+            list(zip(parents, children, strict=True))
+            for parents, children in zip(parent_labels, child_labels, strict=True)
+        ]
+        if not all_equal(topology):
+            raise ValueError(
+                "JointView requires a uniform joint topology across worlds; "
+                f"parent/child body labels differ: {topology}"
             )
 
         joint_coord_ids = [

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -1517,13 +1517,16 @@ class ArticulationView:
         assert values.shape == attrib.shape
         assert values.dtype == attrib.dtype
 
-        # early out for in-place modifications
-        if isinstance(attrib, wp.array) and isinstance(values, wp.array):
-            if values.ptr == attrib.ptr:
-                return
-        if isinstance(attrib, wp.indexedarray) and isinstance(values, wp.indexedarray):
-            if values.data.ptr == attrib.data.ptr:
-                return
+        is_mapped = hasattr(attrib, "_mapped_source")
+
+        # Only direct views already modify target storage when values alias attrib.
+        if not is_mapped:
+            if isinstance(attrib, wp.array) and isinstance(values, wp.array):
+                if values.ptr == attrib.ptr:
+                    return
+            if isinstance(attrib, wp.indexedarray) and isinstance(values, wp.indexedarray):
+                if values.data.ptr == attrib.data.ptr:
+                    return
 
         # get mask
         if mask is None:
@@ -1531,7 +1534,7 @@ class ArticulationView:
         else:
             mask = self._resolve_mask(mask)
 
-        if hasattr(attrib, "_mapped_source"):
+        if is_mapped:
             if mask.ndim == 1:
                 kernel = (
                     _scatter_mapped_4d_per_world_kernel if attrib.ndim == 4 else _scatter_mapped_3d_per_world_kernel

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -2085,7 +2085,7 @@ def _resolve_entity_groups(
     labels: list[str],
     world_ids,
     entity_name: str,
-) -> tuple[list[list[int]], int]:
+) -> tuple[list[list[int]], int, bool]:
     grouped_ids, global_ids = find_matching_ids(
         pattern,
         labels,
@@ -2101,49 +2101,53 @@ def _resolve_entity_groups(
         )
     if not per_world_count and global_ids:
         grouped_ids = [global_ids]
+        global_only = True
     elif not per_world_count:
         raise KeyError(f"No {entity_name}s matching pattern '{pattern}'")
+    else:
+        global_only = False
 
-    return grouped_ids, len(grouped_ids)
+    return grouped_ids, len(grouped_ids), global_only
 
 
-def _canonical_group_labels(labels: list[str], grouped_ids: list[list[int]]) -> list[list[str]]:
-    label_parts = [
-        [[part for part in labels[selected_id].split("/") if part] for selected_id in selected_ids]
-        for selected_ids in grouped_ids
-    ]
-    raw_groups = [["/".join(parts) for parts in group] for group in label_parts]
-    if len(label_parts) < 2 or not label_parts[0]:
-        return raw_groups
+def _get_group_labels(
+    labels: list[str],
+    grouped_ids: list[list[int]],
+    label_prefixes: list[str] | tuple[str, ...] | None,
+    global_only: bool,
+    view_name: str,
+    entity_name: str,
+) -> list[list[str]]:
+    grouped_labels = [[labels[selected_id] for selected_id in selected_ids] for selected_ids in grouped_ids]
+    if label_prefixes is None:
+        return grouped_labels
+    if global_only:
+        raise ValueError(f"{view_name} label_prefixes cannot be used with a global-only selection")
+    if not isinstance(label_prefixes, (list, tuple)):
+        raise TypeError(f"{view_name} label_prefixes must be a list or tuple of strings")
+    if len(label_prefixes) != len(grouped_ids):
+        raise ValueError(
+            f"{view_name} label_prefixes length {len(label_prefixes)} must match selected model world count "
+            f"{len(grouped_ids)}"
+        )
 
-    differing_components = set()
-    for column, template_parts in enumerate(label_parts[0]):
-        column_parts = [group[column] for group in label_parts]
-        if any(len(parts) != len(template_parts) for parts in column_parts[1:]):
-            return raw_groups
-        for component in range(len(template_parts)):
-            if any(parts[component] != template_parts[component] for parts in column_parts[1:]):
-                differing_components.add(component)
-
-    # add_world() prepends one world namespace. Normalize only one uniformly
-    # varying non-leaf component so semantic path differences remain visible.
-    if len(differing_components) != 1:
-        return raw_groups
-    prefix_component = differing_components.pop()
-    if any(prefix_component >= len(parts) - 1 for group in label_parts for parts in group):
-        return raw_groups
-    if any(len({parts[prefix_component] for parts in group}) != 1 for group in label_parts):
-        return raw_groups
-
-    canonical_groups = []
-    for group in label_parts:
-        canonical_group = []
-        for parts in group:
-            canonical_parts = parts.copy()
-            canonical_parts[prefix_component] = "<world>"
-            canonical_group.append("/".join(canonical_parts))
-        canonical_groups.append(canonical_group)
-    return canonical_groups
+    normalized_groups = []
+    for world, (prefix, world_labels) in enumerate(zip(label_prefixes, grouped_labels, strict=True)):
+        if not isinstance(prefix, str):
+            raise TypeError(f"{view_name} label prefix for world {world} must be a string")
+        if not prefix:
+            raise ValueError(f"{view_name} label prefix for world {world} must not be empty")
+        prefix_with_separator = f"{prefix}/"
+        normalized_labels = []
+        for label in world_labels:
+            if not label.startswith(prefix_with_separator):
+                raise ValueError(
+                    f"{view_name} {entity_name} label '{label}' in world {world} does not start with "
+                    f"label prefix '{prefix_with_separator}'"
+                )
+            normalized_labels.append(label[len(prefix_with_separator) :])
+        normalized_groups.append(normalized_labels)
+    return normalized_groups
 
 
 def _require_uniform_groups(grouped_ids: list[list[int]], entity_name: str) -> None:
@@ -2242,18 +2246,41 @@ class JointView(_EntityView):
 
     The selected joints form one instance per world. Joint, coordinate, and DOF
     attributes use ``(world, instance, value)`` layout. Every world must have the
-    same ordered canonical joint labels, joint types, and coordinate/DOF
-    dimensions. A selection containing only global entities is represented as one
-    synthetic world. Matching both global and per-world entities is rejected.
+    same ordered full joint labels, joint types, and coordinate/DOF dimensions.
+    Exact per-world label prefixes can be removed explicitly before comparing
+    labels. A selection containing only global entities is represented as one
+    synthetic world; ``label_prefixes`` is rejected for such a selection. Matching
+    both global and per-world entities is also rejected.
 
     Args:
         model: Model containing the joints.
         pattern: Full-label glob, list of full-label globs, compiled regular
             expression, or list of absolute joint indices. Regular expressions use
             full matching. Indices must be unique and in ascending order.
+        label_prefixes: Exact label prefix for each selected model world, in
+            world-index order. For example, ``["env_0", "env_1"]`` strips
+            ``"env_0/"`` and ``"env_1/"`` respectively before full-label column
+            comparison. Prefixes are not inferred or treated as patterns. The
+            length must equal the selected model world count. Must be None for a
+            global-only selection.
         include_joint_types: Joint types to include from the pattern matches.
         exclude_joint_types: Joint types to exclude from the pattern matches.
         verbose: If True, print a selection summary.
+
+    Raises:
+        TypeError: If ``label_prefixes`` is not a list or tuple of strings.
+        ValueError: If world layouts or full labels differ, a prefix count or
+            boundary is invalid, prefixes are provided for global-only entities,
+            or the pattern mixes global and per-world entities.
+
+    Example:
+        Select matching joint columns from explicitly prefixed worlds::
+
+            view = JointView(
+                model,
+                "env_*/robot/*",
+                label_prefixes=["env_0", "env_1"],
+            )
     """
 
     @deprecate_nonkeyword_arguments
@@ -2262,6 +2289,7 @@ class JointView(_EntityView):
         model: Model,
         pattern: str | list[str] | re.Pattern[str] | list[int],
         *,
+        label_prefixes: list[str] | tuple[str, ...] | None = None,
         include_joint_types: list[int] | None = None,
         exclude_joint_types: list[int] | None = None,
         verbose: bool | None = None,
@@ -2275,7 +2303,9 @@ class JointView(_EntityView):
         model_joint_type = model.joint_type.numpy()
         model_joint_q_start = model.joint_q_start.numpy()
         model_joint_qd_start = model.joint_qd_start.numpy()
-        joint_ids, world_count = _resolve_entity_groups(model, pattern, model.joint_label, model_joint_world, "joint")
+        joint_ids, world_count, global_only = _resolve_entity_groups(
+            model, pattern, model.joint_label, model_joint_world, "joint"
+        )
 
         include_types = None if include_joint_types is None else {int(value) for value in include_joint_types}
         exclude_types = set() if exclude_joint_types is None else {int(value) for value in exclude_joint_types}
@@ -2291,11 +2321,18 @@ class JointView(_EntityView):
             raise KeyError(f"No joints matching pattern '{pattern}' after applying joint type filters")
         _require_uniform_groups(joint_ids, "joint")
 
-        canonical_joint_labels = _canonical_group_labels(model.joint_label, joint_ids)
-        if not all_equal(canonical_joint_labels):
+        normalized_joint_labels = _get_group_labels(
+            model.joint_label,
+            joint_ids,
+            label_prefixes,
+            global_only,
+            "JointView",
+            "joint",
+        )
+        if not all_equal(normalized_joint_labels):
             raise ValueError(
-                "JointView requires a uniform joint layout across worlds; canonical joint labels differ: "
-                f"{canonical_joint_labels}"
+                "JointView requires a uniform joint layout across worlds; selected joint labels differ: "
+                f"{normalized_joint_labels}"
             )
 
         signatures = [
@@ -2456,16 +2493,40 @@ class BodyView(_EntityView):
 
     The selected bodies form one instance per world. Body and shape attributes use
     ``(world, instance, value)`` layout. Every world must have the same ordered
-    canonical body labels and the same ordered canonical shapes per selected body.
-    A selection containing only global entities is represented as one synthetic
-    world. Matching both global and per-world entities is rejected.
+    full body labels and the same ordered full shape labels per selected body.
+    Exact per-world label prefixes can be removed explicitly before comparing
+    labels. A selection containing only global entities is represented as one
+    synthetic world; ``label_prefixes`` is rejected for such a selection. Matching
+    both global and per-world entities is also rejected.
 
     Args:
         model: Model containing the bodies.
         pattern: Full-label glob, list of full-label globs, compiled regular
             expression, or list of absolute body indices. Regular expressions use
             full matching. Indices must be unique and in ascending order.
+        label_prefixes: Exact label prefix for each selected model world, in
+            world-index order. For example, ``["env_0", "env_1"]`` strips
+            ``"env_0/"`` and ``"env_1/"`` respectively before full-label column
+            comparison. Prefixes are not inferred or treated as patterns. The
+            length must equal the selected model world count. Must be None for a
+            global-only selection.
         verbose: If True, print a selection summary.
+
+    Raises:
+        TypeError: If ``label_prefixes`` is not a list or tuple of strings.
+        ValueError: If world layouts, full labels, or per-body shape ownership
+            differ; a prefix count or boundary is invalid; prefixes are provided
+            for global-only entities; or the pattern mixes global and per-world
+            entities.
+
+    Example:
+        Select matching body columns from explicitly prefixed worlds::
+
+            view = BodyView(
+                model,
+                "env_*/robot/*",
+                label_prefixes=["env_0", "env_1"],
+            )
     """
 
     @deprecate_nonkeyword_arguments
@@ -2474,6 +2535,7 @@ class BodyView(_EntityView):
         model: Model,
         pattern: str | list[str] | re.Pattern[str] | list[int],
         *,
+        label_prefixes: list[str] | tuple[str, ...] | None = None,
         verbose: bool | None = None,
     ):
         self.model = model
@@ -2481,16 +2543,23 @@ class BodyView(_EntityView):
         if verbose is None:
             verbose = wp.config.log_level <= wp.LOG_DEBUG
 
-        body_ids, world_count = _resolve_entity_groups(
+        body_ids, world_count, global_only = _resolve_entity_groups(
             model, pattern, model.body_label, model.body_world.numpy(), "body"
         )
         _require_uniform_groups(body_ids, "body")
 
-        canonical_body_labels = _canonical_group_labels(model.body_label, body_ids)
-        if not all_equal(canonical_body_labels):
+        normalized_body_labels = _get_group_labels(
+            model.body_label,
+            body_ids,
+            label_prefixes,
+            global_only,
+            "BodyView",
+            "body",
+        )
+        if not all_equal(normalized_body_labels):
             raise ValueError(
-                "BodyView requires a uniform body layout across worlds; canonical body labels differ: "
-                f"{canonical_body_labels}"
+                "BodyView requires a uniform body layout across worlds; selected body labels differ: "
+                f"{normalized_body_labels}"
             )
 
         shape_counts = [[len(model.body_shapes[body_id]) for body_id in world_body_ids] for world_body_ids in body_ids]
@@ -2502,20 +2571,27 @@ class BodyView(_EntityView):
             [shape_id for body_id in world_body_ids for shape_id in model.body_shapes[body_id]]
             for world_body_ids in body_ids
         ]
-        canonical_shape_labels = _canonical_group_labels(model.shape_label, shape_ids)
-        canonical_shape_ownership = []
+        normalized_shape_labels = _get_group_labels(
+            model.shape_label,
+            shape_ids,
+            label_prefixes,
+            global_only,
+            "BodyView",
+            "shape",
+        )
+        normalized_shape_ownership = []
         for world, world_body_ids in enumerate(body_ids):
             offset = 0
             world_ownership = []
             for body_id in world_body_ids:
                 shape_count = len(model.body_shapes[body_id])
-                world_ownership.append(tuple(canonical_shape_labels[world][offset : offset + shape_count]))
+                world_ownership.append(tuple(normalized_shape_labels[world][offset : offset + shape_count]))
                 offset += shape_count
-            canonical_shape_ownership.append(world_ownership)
-        if not all_equal(canonical_shape_ownership):
+            normalized_shape_ownership.append(world_ownership)
+        if not all_equal(normalized_shape_ownership):
             raise ValueError(
-                "BodyView requires a uniform shape layout across worlds; canonical shape ownership differs: "
-                f"{canonical_shape_ownership}"
+                "BodyView requires a uniform shape layout across worlds; selected shape ownership differs: "
+                f"{normalized_shape_ownership}"
             )
 
         template_body_ids = body_ids[0]

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -1264,7 +1264,7 @@ class ArticulationView:
             else:
                 raise AttributeError(
                     f"Attribute '{name}' has custom frequency '{frequency}' which is not "
-                    f"supported by ArticulationView. Custom frequencies are for custom entity types "
+                    f"supported by {type(self).__name__}. Custom frequencies are for custom entity types "
                     f"that are not part of articulations."
                 )
         else:
@@ -2076,3 +2076,353 @@ class ArticulationView:
             outputs=[dst],
             device=self.device,
         )
+
+
+def _resolve_entity_groups(
+    model: Model,
+    pattern: str | list[str] | re.Pattern[str] | list[int],
+    labels: list[str],
+    world_ids,
+    entity_name: str,
+) -> tuple[list[list[int]], int]:
+    matching_ids = match_labels(labels, pattern)
+    if isinstance(pattern, list) and pattern and isinstance(pattern[0], int):
+        for index in matching_ids:
+            if index < 0 or index >= len(labels):
+                raise ValueError(f"{entity_name.title()} indices must be in range [0, {len(labels)}), got {index}")
+        if any(matching_ids[i] <= matching_ids[i - 1] for i in range(1, len(matching_ids))):
+            raise ValueError(f"{entity_name.title()} indices must be unique and in ascending order")
+
+    grouped_ids = [[] for _ in range(model.world_count)]
+    global_ids = []
+    for index in matching_ids:
+        world = int(world_ids[index])
+        if world == -1:
+            global_ids.append(index)
+        elif 0 <= world < model.world_count:
+            grouped_ids[world].append(index)
+        else:
+            raise ValueError(f"World index out of range: {world}")
+
+    per_world_count = sum(len(ids) for ids in grouped_ids)
+    if per_world_count and global_ids:
+        raise ValueError(
+            f"{entity_name.title()} pattern '{pattern}' matches global and per-world entities, which is not supported"
+        )
+    if not per_world_count and global_ids:
+        grouped_ids = [global_ids]
+    elif not per_world_count:
+        raise KeyError(f"No {entity_name}s matching pattern '{pattern}'")
+
+    return grouped_ids, len(grouped_ids)
+
+
+def _require_uniform_groups(grouped_ids: list[list[int]], entity_name: str) -> None:
+    counts = [len(ids) for ids in grouped_ids]
+    if not all_equal(counts):
+        raise ValueError(
+            f"{entity_name.title()}View requires a uniform {entity_name} layout across worlds; "
+            f"selected counts are {counts}"
+        )
+
+
+def _make_entity_frequency_layout(
+    grouped_indices: list[list[int]],
+    entity_name: str,
+    device,
+) -> FrequencyLayout:
+    if not grouped_indices[0]:
+        return FrequencyLayout(0, 0, 0, 0, [], device)
+
+    starts = [indices[0] for indices in grouped_indices]
+    relative_indices = [
+        [index - start for index in indices] for indices, start in zip(grouped_indices, starts, strict=True)
+    ]
+    if not all_equal(relative_indices):
+        raise ValueError(
+            f"{entity_name.title()}View requires a uniform {entity_name} layout across worlds; "
+            "selected indices have different relative layouts"
+        )
+
+    outer_strides = [starts[i] - starts[i - 1] for i in range(1, len(starts))]
+    if outer_strides and not all_equal(outer_strides):
+        raise ValueError(
+            f"{entity_name.title()}View requires a uniform {entity_name} layout across worlds; "
+            f"world strides are {outer_strides}"
+        )
+
+    local_indices = relative_indices[0]
+    value_count = local_indices[-1] + 1
+    outer_stride = outer_strides[0] if outer_strides else value_count
+    return FrequencyLayout(
+        starts[0],
+        outer_stride,
+        value_count,
+        value_count,
+        local_indices,
+        device,
+    )
+
+
+class _EntityView:
+    """Share ArticulationView's frequency-driven attribute access without its topology."""
+
+    _get_attribute_array = ArticulationView._get_attribute_array
+    _get_attribute_values = ArticulationView._get_attribute_values
+    _set_attribute_values = ArticulationView._set_attribute_values
+    _resolve_mask = ArticulationView._resolve_mask
+
+    def get_attribute(self, name: str, source: Model | State | Control):
+        """Get a selected attribute from a model, state, or control."""
+        return self._get_attribute_values(name, source)
+
+    def set_attribute(
+        self,
+        name: str,
+        target: Model | State | Control,
+        values: wp.array[Any],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set a selected attribute, optionally restricted by a world or instance mask.
+
+        Args:
+            name: Attribute name.
+            target: Model, state, or control containing the attribute.
+            values: Values in ``(world, instance, value)`` layout.
+            mask: Boolean mask with shape ``(world_count,)`` or
+                ``(world_count, count_per_world)``.
+        """
+        self._set_attribute_values(name, target, values, mask=mask)
+
+
+class JointView(_EntityView):
+    """Select joints by full label and world, independently of articulation topology.
+
+    The selected joints form one instance per world. Joint, coordinate, and DOF
+    attributes use the ``(world, instance, value)`` layout shared with
+    :class:`ArticulationView`. Every world must have the same selected joint types
+    and coordinate/DOF dimensions.
+
+    Args:
+        model: Model containing the joints.
+        pattern: Full-label glob, list of full-label globs, compiled regular
+            expression, or list of absolute joint indices. Regular expressions use
+            full matching. Indices must be unique and in ascending order.
+        include_joint_types: Joint types to include from the pattern matches.
+        exclude_joint_types: Joint types to exclude from the pattern matches.
+        verbose: If True, print a selection summary.
+    """
+
+    @deprecate_nonkeyword_arguments
+    def __init__(
+        self,
+        model: Model,
+        pattern: str | list[str] | re.Pattern[str] | list[int],
+        *,
+        include_joint_types: list[int] | None = None,
+        exclude_joint_types: list[int] | None = None,
+        verbose: bool | None = None,
+    ):
+        self.model = model
+        self.device = model.device
+        if verbose is None:
+            verbose = wp.config.log_level <= wp.LOG_DEBUG
+
+        model_joint_world = model.joint_world.numpy()
+        model_joint_type = model.joint_type.numpy()
+        model_joint_q_start = model.joint_q_start.numpy()
+        model_joint_qd_start = model.joint_qd_start.numpy()
+        joint_ids, world_count = _resolve_entity_groups(model, pattern, model.joint_label, model_joint_world, "joint")
+
+        include_types = None if include_joint_types is None else {int(value) for value in include_joint_types}
+        exclude_types = set() if exclude_joint_types is None else {int(value) for value in exclude_joint_types}
+        for world in range(world_count):
+            joint_ids[world] = [
+                joint_id
+                for joint_id in joint_ids[world]
+                if (include_types is None or int(model_joint_type[joint_id]) in include_types)
+                and int(model_joint_type[joint_id]) not in exclude_types
+            ]
+
+        if not any(joint_ids):
+            raise KeyError(f"No joints matching pattern '{pattern}' after applying joint type filters")
+        _require_uniform_groups(joint_ids, "joint")
+
+        signatures = [
+            [
+                (
+                    int(model_joint_type[joint_id]),
+                    int(model_joint_q_start[joint_id + 1] - model_joint_q_start[joint_id]),
+                    int(model_joint_qd_start[joint_id + 1] - model_joint_qd_start[joint_id]),
+                )
+                for joint_id in world_joint_ids
+            ]
+            for world_joint_ids in joint_ids
+        ]
+        if not all_equal(signatures):
+            raise ValueError(
+                "JointView requires a uniform joint layout across worlds; "
+                "selected joint types or coordinate/DOF dimensions differ"
+            )
+
+        joint_coord_ids = [
+            [
+                coord_id
+                for joint_id in world_joint_ids
+                for coord_id in range(model_joint_q_start[joint_id], model_joint_q_start[joint_id + 1])
+            ]
+            for world_joint_ids in joint_ids
+        ]
+        joint_dof_ids = [
+            [
+                dof_id
+                for joint_id in world_joint_ids
+                for dof_id in range(model_joint_qd_start[joint_id], model_joint_qd_start[joint_id + 1])
+            ]
+            for world_joint_ids in joint_ids
+        ]
+
+        template_joint_ids = joint_ids[0]
+        self.joint_labels = [model.joint_label[joint_id] for joint_id in template_joint_ids]
+        self.joint_names = [get_name_from_label(label) for label in self.joint_labels]
+        self.joint_coord_counts = [signature[1] for signature in signatures[0]]
+        self.joint_dof_counts = [signature[2] for signature in signatures[0]]
+        self.joint_coord_names = []
+        self.joint_dof_names = []
+        for name, coord_count, dof_count in zip(
+            self.joint_names, self.joint_coord_counts, self.joint_dof_counts, strict=True
+        ):
+            self.joint_coord_names.extend([name] if coord_count == 1 else [f"{name}:{i}" for i in range(coord_count)])
+            self.joint_dof_names.extend([name] if dof_count == 1 else [f"{name}:{i}" for i in range(dof_count)])
+
+        self.count = world_count
+        self.world_count = world_count
+        self.count_per_world = 1
+        self.joint_count = len(template_joint_ids)
+        self.joint_coord_count = len(joint_coord_ids[0])
+        self.joint_dof_count = len(joint_dof_ids[0])
+        self.frequency_layouts = {
+            AttributeFrequency.JOINT: _make_entity_frequency_layout(joint_ids, "joint", self.device),
+            AttributeFrequency.JOINT_COORD: _make_entity_frequency_layout(joint_coord_ids, "joint", self.device),
+            AttributeFrequency.JOINT_DOF: _make_entity_frequency_layout(joint_dof_ids, "joint", self.device),
+        }
+        self.joints_contiguous = self.frequency_layouts[AttributeFrequency.JOINT].is_contiguous
+        self.joint_coords_contiguous = self.frequency_layouts[AttributeFrequency.JOINT_COORD].is_contiguous
+        self.joint_dofs_contiguous = self.frequency_layouts[AttributeFrequency.JOINT_DOF].is_contiguous
+        self.joint_ids = wp.array([[ids] for ids in joint_ids], dtype=int, device=self.device)
+        self.full_mask = wp.full(world_count, True, dtype=bool, device=self.device)
+
+        if verbose:
+            print(f"Joint '{pattern}': {self.count}")
+            print(f"  Joint count: {self.joint_count}")
+            print(f"  Coordinate count: {self.joint_coord_count}")
+            print(f"  DOF count: {self.joint_dof_count}")
+
+    get_dof_positions = ArticulationView.get_dof_positions
+    set_dof_positions = ArticulationView.set_dof_positions
+    get_dof_velocities = ArticulationView.get_dof_velocities
+    set_dof_velocities = ArticulationView.set_dof_velocities
+    get_dof_forces = ArticulationView.get_dof_forces
+    set_dof_forces = ArticulationView.set_dof_forces
+
+
+class BodyView(_EntityView):
+    """Select bodies and their shapes by full label and world.
+
+    The selected bodies form one instance per world. Body and shape attributes
+    use the ``(world, instance, value)`` layout shared with
+    :class:`ArticulationView`. Every world must have the same number of selected
+    bodies and the same number of shapes per selected body.
+
+    Args:
+        model: Model containing the bodies.
+        pattern: Full-label glob, list of full-label globs, compiled regular
+            expression, or list of absolute body indices. Regular expressions use
+            full matching. Indices must be unique and in ascending order.
+        verbose: If True, print a selection summary.
+    """
+
+    @deprecate_nonkeyword_arguments
+    def __init__(
+        self,
+        model: Model,
+        pattern: str | list[str] | re.Pattern[str] | list[int],
+        *,
+        verbose: bool | None = None,
+    ):
+        self.model = model
+        self.device = model.device
+        if verbose is None:
+            verbose = wp.config.log_level <= wp.LOG_DEBUG
+
+        body_ids, world_count = _resolve_entity_groups(
+            model, pattern, model.body_label, model.body_world.numpy(), "body"
+        )
+        _require_uniform_groups(body_ids, "body")
+
+        shape_counts = [[len(model.body_shapes[body_id]) for body_id in world_body_ids] for world_body_ids in body_ids]
+        if not all_equal(shape_counts):
+            raise ValueError(
+                "BodyView requires a uniform body layout across worlds; selected bodies have different shape counts"
+            )
+        shape_ids = [
+            sorted(shape_id for body_id in world_body_ids for shape_id in model.body_shapes[body_id])
+            for world_body_ids in body_ids
+        ]
+
+        template_body_ids = body_ids[0]
+        template_shape_ids = shape_ids[0]
+        self.body_labels = [model.body_label[body_id] for body_id in template_body_ids]
+        self.body_names = [get_name_from_label(label) for label in self.body_labels]
+        self.shape_labels = [model.shape_label[shape_id] for shape_id in template_shape_ids]
+        self.shape_names = [get_name_from_label(label) for label in self.shape_labels]
+        shape_positions = {shape_id: index for index, shape_id in enumerate(template_shape_ids)}
+        self.body_shapes = [
+            [shape_positions[shape_id] for shape_id in model.body_shapes[body_id]] for body_id in template_body_ids
+        ]
+
+        self.count = world_count
+        self.world_count = world_count
+        self.count_per_world = 1
+        self.body_count = len(template_body_ids)
+        self.shape_count = len(template_shape_ids)
+        self.frequency_layouts = {
+            AttributeFrequency.BODY: _make_entity_frequency_layout(body_ids, "body", self.device),
+            AttributeFrequency.SHAPE: _make_entity_frequency_layout(shape_ids, "body", self.device),
+        }
+        self.bodies_contiguous = self.frequency_layouts[AttributeFrequency.BODY].is_contiguous
+        self.shapes_contiguous = self.frequency_layouts[AttributeFrequency.SHAPE].is_contiguous
+        self.body_ids = wp.array([[ids] for ids in body_ids], dtype=int, device=self.device)
+        self.shape_ids = wp.array([[ids] for ids in shape_ids], dtype=int, device=self.device)
+        self.full_mask = wp.full(world_count, True, dtype=bool, device=self.device)
+
+        if verbose:
+            print(f"Body '{pattern}': {self.count}")
+            print(f"  Body count: {self.body_count}")
+            print(f"  Shape count: {self.shape_count}")
+
+    def get_body_transforms(self, source: Model | State):
+        """Get selected body transforms [m, unitless quaternion]."""
+        return self._get_attribute_values("body_q", source)
+
+    def set_body_transforms(
+        self,
+        target: Model | State,
+        values: wp.array[wp.transform],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set selected body transforms [m, unitless quaternion]."""
+        self._set_attribute_values("body_q", target, values, mask=mask)
+
+    def get_body_velocities(self, source: Model | State):
+        """Get selected body spatial velocities [m/s, rad/s]."""
+        return self._get_attribute_values("body_qd", source)
+
+    def set_body_velocities(
+        self,
+        target: Model | State,
+        values: wp.array[wp.spatial_vector],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set selected body spatial velocities [m/s, rad/s]."""
+        self._set_attribute_values("body_qd", target, values, mask=mask)

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -399,16 +399,17 @@ def find_matching_ids(
     labels: list[str],
     world_ids,
     world_count: int,
+    entity_name: str = "Articulation",
 ) -> tuple[list[list[int]], list[int]]:
     matching_ids = match_labels(labels, pattern)
 
     if isinstance(pattern, list) and pattern and isinstance(pattern[0], int):
-        # ArticulationView derives its layouts from model order. String patterns already produce this order.
+        # Views derive layouts from model order. String patterns already produce this order.
         for idx in range(1, len(matching_ids)):
             if matching_ids[idx] <= matching_ids[idx - 1]:
-                raise ValueError("Articulation indices must be unique and in ascending order")
+                raise ValueError(f"{entity_name} indices must be unique and in ascending order")
         if matching_ids[0] < 0 or matching_ids[-1] >= len(labels):
-            raise ValueError(f"Articulation indices must be in range [0, {len(labels)})")
+            raise ValueError(f"{entity_name} indices must be in range [0, {len(labels)})")
 
     grouped_ids = [[] for _ in range(world_count)]  # ids grouped by world (exclude world -1)
     global_ids = []  # ids in world -1
@@ -2085,24 +2086,13 @@ def _resolve_entity_groups(
     world_ids,
     entity_name: str,
 ) -> tuple[list[list[int]], int]:
-    matching_ids = match_labels(labels, pattern)
-    if isinstance(pattern, list) and pattern and isinstance(pattern[0], int):
-        for index in matching_ids:
-            if index < 0 or index >= len(labels):
-                raise ValueError(f"{entity_name.title()} indices must be in range [0, {len(labels)}), got {index}")
-        if any(matching_ids[i] <= matching_ids[i - 1] for i in range(1, len(matching_ids))):
-            raise ValueError(f"{entity_name.title()} indices must be unique and in ascending order")
-
-    grouped_ids = [[] for _ in range(model.world_count)]
-    global_ids = []
-    for index in matching_ids:
-        world = int(world_ids[index])
-        if world == -1:
-            global_ids.append(index)
-        elif 0 <= world < model.world_count:
-            grouped_ids[world].append(index)
-        else:
-            raise ValueError(f"World index out of range: {world}")
+    grouped_ids, global_ids = find_matching_ids(
+        pattern,
+        labels,
+        world_ids,
+        model.world_count,
+        entity_name=entity_name.title(),
+    )
 
     per_world_count = sum(len(ids) for ids in grouped_ids)
     if per_world_count and global_ids:
@@ -2117,6 +2107,45 @@ def _resolve_entity_groups(
     return grouped_ids, len(grouped_ids)
 
 
+def _canonical_group_labels(labels: list[str], grouped_ids: list[list[int]]) -> list[list[str]]:
+    label_parts = [
+        [[part for part in labels[selected_id].split("/") if part] for selected_id in selected_ids]
+        for selected_ids in grouped_ids
+    ]
+    raw_groups = [["/".join(parts) for parts in group] for group in label_parts]
+    if len(label_parts) < 2 or not label_parts[0]:
+        return raw_groups
+
+    differing_components = set()
+    for column, template_parts in enumerate(label_parts[0]):
+        column_parts = [group[column] for group in label_parts]
+        if any(len(parts) != len(template_parts) for parts in column_parts[1:]):
+            return raw_groups
+        for component in range(len(template_parts)):
+            if any(parts[component] != template_parts[component] for parts in column_parts[1:]):
+                differing_components.add(component)
+
+    # add_world() prepends one world namespace. Normalize only one uniformly
+    # varying non-leaf component so semantic path differences remain visible.
+    if len(differing_components) != 1:
+        return raw_groups
+    prefix_component = differing_components.pop()
+    if any(prefix_component >= len(parts) - 1 for group in label_parts for parts in group):
+        return raw_groups
+    if any(len({parts[prefix_component] for parts in group}) != 1 for group in label_parts):
+        return raw_groups
+
+    canonical_groups = []
+    for group in label_parts:
+        canonical_group = []
+        for parts in group:
+            canonical_parts = parts.copy()
+            canonical_parts[prefix_component] = "<world>"
+            canonical_group.append("/".join(canonical_parts))
+        canonical_groups.append(canonical_group)
+    return canonical_groups
+
+
 def _require_uniform_groups(grouped_ids: list[list[int]], entity_name: str) -> None:
     counts = [len(ids) for ids in grouped_ids]
     if not all_equal(counts):
@@ -2128,31 +2157,31 @@ def _require_uniform_groups(grouped_ids: list[list[int]], entity_name: str) -> N
 
 def _make_entity_frequency_layout(
     grouped_indices: list[list[int]],
-    entity_name: str,
+    view_name: str,
+    frequency_name: str,
     device,
 ) -> FrequencyLayout:
     if not grouped_indices[0]:
         return FrequencyLayout(0, 0, 0, 0, [], device)
 
-    starts = [indices[0] for indices in grouped_indices]
+    starts = [min(indices) for indices in grouped_indices]
     relative_indices = [
         [index - start for index in indices] for indices, start in zip(grouped_indices, starts, strict=True)
     ]
     if not all_equal(relative_indices):
         raise ValueError(
-            f"{entity_name.title()}View requires a uniform {entity_name} layout across worlds; "
+            f"{view_name} requires a uniform {frequency_name} layout across worlds; "
             "selected indices have different relative layouts"
         )
 
     outer_strides = [starts[i] - starts[i - 1] for i in range(1, len(starts))]
     if outer_strides and not all_equal(outer_strides):
         raise ValueError(
-            f"{entity_name.title()}View requires a uniform {entity_name} layout across worlds; "
-            f"world strides are {outer_strides}"
+            f"{view_name} requires a uniform {frequency_name} layout across worlds; world strides are {outer_strides}"
         )
 
     local_indices = relative_indices[0]
-    value_count = local_indices[-1] + 1
+    value_count = max(local_indices) + 1
     outer_stride = outer_strides[0] if outer_strides else value_count
     return FrequencyLayout(
         starts[0],
@@ -2165,15 +2194,23 @@ def _make_entity_frequency_layout(
 
 
 class _EntityView:
-    """Share ArticulationView's frequency-driven attribute access without its topology."""
+    """Provide frequency-driven attribute access for entity selections."""
 
     _get_attribute_array = ArticulationView._get_attribute_array
     _get_attribute_values = ArticulationView._get_attribute_values
     _set_attribute_values = ArticulationView._set_attribute_values
     _resolve_mask = ArticulationView._resolve_mask
 
-    def get_attribute(self, name: str, source: Model | State | Control):
-        """Get a selected attribute from a model, state, or control."""
+    def get_attribute(self, name: str, source: Model | State | Control) -> wp.array[Any]:
+        """Get selected attribute values.
+
+        Args:
+            name: Attribute name.
+            source: Model, state, or control containing the attribute.
+
+        Returns:
+            Attribute values in ``(world, instance, value, ...)`` layout.
+        """
         return self._get_attribute_values(name, source)
 
     def set_attribute(
@@ -2191,6 +2228,11 @@ class _EntityView:
             values: Values in ``(world, instance, value)`` layout.
             mask: Boolean mask with shape ``(world_count,)`` or
                 ``(world_count, count_per_world)``.
+
+        .. note::
+            After setting model attributes, call
+            :meth:`newton.solvers.SolverBase.notify_model_changed` when required
+            by the active solver.
         """
         self._set_attribute_values(name, target, values, mask=mask)
 
@@ -2199,9 +2241,10 @@ class JointView(_EntityView):
     """Select joints by full label and world, independently of articulation topology.
 
     The selected joints form one instance per world. Joint, coordinate, and DOF
-    attributes use the ``(world, instance, value)`` layout shared with
-    :class:`ArticulationView`. Every world must have the same selected joint types
-    and coordinate/DOF dimensions.
+    attributes use ``(world, instance, value)`` layout. Every world must have the
+    same ordered canonical joint labels, joint types, and coordinate/DOF
+    dimensions. A selection containing only global entities is represented as one
+    synthetic world. Matching both global and per-world entities is rejected.
 
     Args:
         model: Model containing the joints.
@@ -2247,6 +2290,13 @@ class JointView(_EntityView):
         if not any(joint_ids):
             raise KeyError(f"No joints matching pattern '{pattern}' after applying joint type filters")
         _require_uniform_groups(joint_ids, "joint")
+
+        canonical_joint_labels = _canonical_group_labels(model.joint_label, joint_ids)
+        if not all_equal(canonical_joint_labels):
+            raise ValueError(
+                "JointView requires a uniform joint layout across worlds; canonical joint labels differ: "
+                f"{canonical_joint_labels}"
+            )
 
         signatures = [
             [
@@ -2302,9 +2352,13 @@ class JointView(_EntityView):
         self.joint_coord_count = len(joint_coord_ids[0])
         self.joint_dof_count = len(joint_dof_ids[0])
         self.frequency_layouts = {
-            AttributeFrequency.JOINT: _make_entity_frequency_layout(joint_ids, "joint", self.device),
-            AttributeFrequency.JOINT_COORD: _make_entity_frequency_layout(joint_coord_ids, "joint", self.device),
-            AttributeFrequency.JOINT_DOF: _make_entity_frequency_layout(joint_dof_ids, "joint", self.device),
+            AttributeFrequency.JOINT: _make_entity_frequency_layout(joint_ids, "JointView", "joint", self.device),
+            AttributeFrequency.JOINT_COORD: _make_entity_frequency_layout(
+                joint_coord_ids, "JointView", "joint coordinate", self.device
+            ),
+            AttributeFrequency.JOINT_DOF: _make_entity_frequency_layout(
+                joint_dof_ids, "JointView", "joint DOF", self.device
+            ),
         }
         self.joints_contiguous = self.frequency_layouts[AttributeFrequency.JOINT].is_contiguous
         self.joint_coords_contiguous = self.frequency_layouts[AttributeFrequency.JOINT_COORD].is_contiguous
@@ -2318,21 +2372,93 @@ class JointView(_EntityView):
             print(f"  Coordinate count: {self.joint_coord_count}")
             print(f"  DOF count: {self.joint_dof_count}")
 
-    get_dof_positions = ArticulationView.get_dof_positions
-    set_dof_positions = ArticulationView.set_dof_positions
-    get_dof_velocities = ArticulationView.get_dof_velocities
-    set_dof_velocities = ArticulationView.set_dof_velocities
-    get_dof_forces = ArticulationView.get_dof_forces
-    set_dof_forces = ArticulationView.set_dof_forces
+    def get_dof_positions(self, source: Model | State) -> wp.array[float]:
+        """Get selected joint coordinate positions [m or rad].
+
+        Args:
+            source: Model or state containing the positions.
+
+        Returns:
+            Positions in ``(world, instance, joint_coord)`` layout.
+        """
+        return self._get_attribute_values("joint_q", source)
+
+    def set_dof_positions(
+        self,
+        target: Model | State,
+        values: wp.array[float],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set selected joint coordinate positions [m or rad].
+
+        Args:
+            target: Model or state containing the positions.
+            values: Positions in ``(world, instance, joint_coord)`` layout.
+            mask: Boolean mask selecting worlds or individual instances.
+        """
+        self._set_attribute_values("joint_q", target, values, mask=mask)
+
+    def get_dof_velocities(self, source: Model | State) -> wp.array[float]:
+        """Get selected joint coordinate velocities [m/s or rad/s].
+
+        Args:
+            source: Model or state containing the velocities.
+
+        Returns:
+            Velocities in ``(world, instance, joint_dof)`` layout.
+        """
+        return self._get_attribute_values("joint_qd", source)
+
+    def set_dof_velocities(
+        self,
+        target: Model | State,
+        values: wp.array[float],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set selected joint coordinate velocities [m/s or rad/s].
+
+        Args:
+            target: Model or state containing the velocities.
+            values: Velocities in ``(world, instance, joint_dof)`` layout.
+            mask: Boolean mask selecting worlds or individual instances.
+        """
+        self._set_attribute_values("joint_qd", target, values, mask=mask)
+
+    def get_dof_forces(self, source: Control) -> wp.array[float]:
+        """Get selected joint forces [N or N·m].
+
+        Args:
+            source: Control containing the forces.
+
+        Returns:
+            Forces in ``(world, instance, joint_dof)`` layout.
+        """
+        return self._get_attribute_values("joint_f", source)
+
+    def set_dof_forces(
+        self,
+        target: Control,
+        values: wp.array[float],
+        mask: wp.array[bool] | wp.array2d[bool] | None = None,
+    ) -> None:
+        """Set selected joint forces [N or N·m].
+
+        Args:
+            target: Control containing the forces.
+            values: Forces in ``(world, instance, joint_dof)`` layout.
+            mask: Boolean mask selecting worlds or individual instances.
+        """
+        self._set_attribute_values("joint_f", target, values, mask=mask)
 
 
 class BodyView(_EntityView):
     """Select bodies and their shapes by full label and world.
 
-    The selected bodies form one instance per world. Body and shape attributes
-    use the ``(world, instance, value)`` layout shared with
-    :class:`ArticulationView`. Every world must have the same number of selected
-    bodies and the same number of shapes per selected body.
+    The selected bodies form one instance per world. Body and shape attributes use
+    ``(world, instance, value)`` layout. Every world must have the same ordered
+    canonical body labels and the same ordered canonical shapes per selected body.
+    A selection containing only global entities is represented as one synthetic
+    world. Matching both global and per-world entities is rejected.
 
     Args:
         model: Model containing the bodies.
@@ -2360,15 +2486,37 @@ class BodyView(_EntityView):
         )
         _require_uniform_groups(body_ids, "body")
 
+        canonical_body_labels = _canonical_group_labels(model.body_label, body_ids)
+        if not all_equal(canonical_body_labels):
+            raise ValueError(
+                "BodyView requires a uniform body layout across worlds; canonical body labels differ: "
+                f"{canonical_body_labels}"
+            )
+
         shape_counts = [[len(model.body_shapes[body_id]) for body_id in world_body_ids] for world_body_ids in body_ids]
         if not all_equal(shape_counts):
             raise ValueError(
-                "BodyView requires a uniform body layout across worlds; selected bodies have different shape counts"
+                "BodyView requires a uniform shape layout across worlds; selected bodies have different shape counts"
             )
         shape_ids = [
-            sorted(shape_id for body_id in world_body_ids for shape_id in model.body_shapes[body_id])
+            [shape_id for body_id in world_body_ids for shape_id in model.body_shapes[body_id]]
             for world_body_ids in body_ids
         ]
+        canonical_shape_labels = _canonical_group_labels(model.shape_label, shape_ids)
+        canonical_shape_ownership = []
+        for world, world_body_ids in enumerate(body_ids):
+            offset = 0
+            world_ownership = []
+            for body_id in world_body_ids:
+                shape_count = len(model.body_shapes[body_id])
+                world_ownership.append(tuple(canonical_shape_labels[world][offset : offset + shape_count]))
+                offset += shape_count
+            canonical_shape_ownership.append(world_ownership)
+        if not all_equal(canonical_shape_ownership):
+            raise ValueError(
+                "BodyView requires a uniform shape layout across worlds; canonical shape ownership differs: "
+                f"{canonical_shape_ownership}"
+            )
 
         template_body_ids = body_ids[0]
         template_shape_ids = shape_ids[0]
@@ -2387,8 +2535,8 @@ class BodyView(_EntityView):
         self.body_count = len(template_body_ids)
         self.shape_count = len(template_shape_ids)
         self.frequency_layouts = {
-            AttributeFrequency.BODY: _make_entity_frequency_layout(body_ids, "body", self.device),
-            AttributeFrequency.SHAPE: _make_entity_frequency_layout(shape_ids, "body", self.device),
+            AttributeFrequency.BODY: _make_entity_frequency_layout(body_ids, "BodyView", "body", self.device),
+            AttributeFrequency.SHAPE: _make_entity_frequency_layout(shape_ids, "BodyView", "shape", self.device),
         }
         self.bodies_contiguous = self.frequency_layouts[AttributeFrequency.BODY].is_contiguous
         self.shapes_contiguous = self.frequency_layouts[AttributeFrequency.SHAPE].is_contiguous
@@ -2401,8 +2549,15 @@ class BodyView(_EntityView):
             print(f"  Body count: {self.body_count}")
             print(f"  Shape count: {self.shape_count}")
 
-    def get_body_transforms(self, source: Model | State):
-        """Get selected body transforms [m, unitless quaternion]."""
+    def get_body_transforms(self, source: Model | State) -> wp.array[wp.transform]:
+        """Get selected body transforms [m, unitless quaternion].
+
+        Args:
+            source: Model or state containing the transforms.
+
+        Returns:
+            Transforms in ``(world, instance, body)`` layout.
+        """
         return self._get_attribute_values("body_q", source)
 
     def set_body_transforms(
@@ -2411,11 +2566,24 @@ class BodyView(_EntityView):
         values: wp.array[wp.transform],
         mask: wp.array[bool] | wp.array2d[bool] | None = None,
     ) -> None:
-        """Set selected body transforms [m, unitless quaternion]."""
+        """Set selected body transforms [m, unitless quaternion].
+
+        Args:
+            target: Model or state containing the transforms.
+            values: Transforms in ``(world, instance, body)`` layout.
+            mask: Boolean mask selecting worlds or individual instances.
+        """
         self._set_attribute_values("body_q", target, values, mask=mask)
 
-    def get_body_velocities(self, source: Model | State):
-        """Get selected body spatial velocities [m/s, rad/s]."""
+    def get_body_velocities(self, source: Model | State) -> wp.array[wp.spatial_vector]:
+        """Get selected body spatial velocities [m/s, rad/s].
+
+        Args:
+            source: Model or state containing the velocities.
+
+        Returns:
+            Velocities in ``(world, instance, body)`` layout.
+        """
         return self._get_attribute_values("body_qd", source)
 
     def set_body_velocities(
@@ -2424,5 +2592,11 @@ class BodyView(_EntityView):
         values: wp.array[wp.spatial_vector],
         mask: wp.array[bool] | wp.array2d[bool] | None = None,
     ) -> None:
-        """Set selected body spatial velocities [m/s, rad/s]."""
+        """Set selected body spatial velocities [m/s, rad/s].
+
+        Args:
+            target: Model or state containing the velocities.
+            values: Velocities in ``(world, instance, body)`` layout.
+            mask: Boolean mask selecting worlds or individual instances.
+        """
         self._set_attribute_values("body_qd", target, values, mask=mask)

--- a/newton/selection.py
+++ b/newton/selection.py
@@ -1,17 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""Structured selection views for model entities.
-
-Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
-operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
-attribute access and masks, including closed-loop mechanisms without articulations.
-"""
-
-from ._src.utils.selection import ArticulationView, BodyView, JointView
+from ._src.utils.selection import ArticulationView
 
 __all__ = [
     "ArticulationView",
-    "BodyView",
-    "JointView",
 ]

--- a/newton/selection.py
+++ b/newton/selection.py
@@ -1,8 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from ._src.utils.selection import ArticulationView
+"""Structured selection views for model entities.
+
+Use :class:`ArticulationView` for tree-specific roots, masks, and reduced-coordinate
+operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
+attribute access, including closed-loop mechanisms without articulations.
+"""
+
+from ._src.utils.selection import ArticulationView, BodyView, JointView
 
 __all__ = [
     "ArticulationView",
+    "BodyView",
+    "JointView",
 ]

--- a/newton/selection.py
+++ b/newton/selection.py
@@ -3,9 +3,9 @@
 
 """Structured selection views for model entities.
 
-Use :class:`ArticulationView` for tree-specific roots, masks, and reduced-coordinate
+Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
 operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
-attribute access, including closed-loop mechanisms without articulations.
+attribute access and masks, including closed-loop mechanisms without articulations.
 """
 
 from ._src.utils.selection import ArticulationView, BodyView, JointView

--- a/newton/selection.py
+++ b/newton/selection.py
@@ -1,8 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from ._src.utils.selection import ArticulationView
+"""Structured selection views for model entities.
+
+Use :class:`ArticulationView` for tree-specific roots and reduced-coordinate
+operators. Use :class:`JointView` or :class:`BodyView` for topology-independent
+attribute access and masks, including closed-loop mechanisms without articulations.
+"""
+
+from ._src.utils.selection import ArticulationView, BodyView, JointView
 
 __all__ = [
     "ArticulationView",
+    "BodyView",
+    "JointView",
 ]

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -30,6 +30,173 @@ def origin_velocity_from_body_qd(model, body_q, body_qd, body_idx):
     return body_qd[body_idx, :3] - np.cross(body_qd[body_idx, 3:6], com_world)
 
 
+def make_closed_loop_selection_world():
+    """Build an articulation-free closed loop with interleaved unrelated entities."""
+    builder = newton.ModelBuilder()
+    shape_cfg = newton.ModelBuilder.ShapeConfig(density=0.0)
+    base = builder.add_link(label="robot/base")
+    prop = builder.add_link(label="prop/tip")
+    left = builder.add_link(label="robot/left/tip")
+    right = builder.add_link(label="robot/right/tip")
+
+    for body, label in (
+        (base, "robot/base/shape"),
+        (prop, "prop/shape"),
+        (left, "robot/left/shape"),
+        (right, "robot/right/shape"),
+    ):
+        builder.add_shape_box(body, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label=label)
+
+    builder.add_joint_fixed(-1, base, label="robot/base/mount")
+    builder.add_joint_revolute(base, left, label="robot/left/hinge")
+    builder.add_joint_revolute(-1, prop, label="prop/hinge")
+    builder.add_joint_fixed(base, right, label="robot/right/hinge")
+    builder.add_joint_ball(right, left, label="robot/loop/closure")
+    return builder
+
+
+class TestEntityViews(unittest.TestCase):
+    def test_joint_view_selects_articulation_free_closed_loops(self):
+        """Select complete closed-loop joint layouts without articulations."""
+        scene = newton.ModelBuilder()
+        scene.replicate(make_closed_loop_selection_world(), world_count=2)
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        self.assertEqual(model.articulation_count, 0)
+        view = newton.selection.JointView(model, "robot/*")
+
+        self.assertEqual(view.count, 2)
+        self.assertEqual(view.world_count, 2)
+        self.assertEqual(view.count_per_world, 1)
+        self.assertEqual(view.joint_count, 4)
+        self.assertEqual(view.joint_dof_count, 4)
+        self.assertEqual(view.joint_coord_count, 5)
+        self.assertEqual(view.joint_names, ["mount", "hinge", "hinge", "closure"])
+        self.assertEqual(
+            view.joint_labels,
+            ["robot/base/mount", "robot/left/hinge", "robot/right/hinge", "robot/loop/closure"],
+        )
+        assert_np_equal(view.joint_ids.numpy(), [[[0, 1, 3, 4]], [[5, 6, 8, 9]]])
+        self.assertFalse(view.joints_contiguous)
+        self.assertFalse(view.joint_dofs_contiguous)
+        self.assertEqual(view.get_attribute("joint_type", model).shape, (2, 1, 4))
+        self.assertEqual(view.get_dof_positions(model).shape, (2, 1, 5))
+        self.assertEqual(view.get_dof_velocities(model).shape, (2, 1, 4))
+
+    def test_joint_view_gathers_and_mask_scatters_noncontiguous_dofs(self):
+        """Gather selected DOFs and scatter only into worlds enabled by a mask."""
+        scene = newton.ModelBuilder()
+        scene.replicate(make_closed_loop_selection_world(), world_count=2)
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+        state = model.state()
+        view = newton.selection.JointView(model, "robot/*")
+
+        values = np.array([[[10.0, 20.0, 30.0, 40.0]], [[50.0, 60.0, 70.0, 80.0]]], dtype=np.float32)
+        view.set_dof_velocities(state, values, mask=[True, False])
+
+        assert_np_equal(view.get_dof_velocities(state).numpy(), np.array([values[0], np.zeros((1, 4))]))
+        assert_np_equal(state.joint_qd.numpy(), [10.0, 0.0, 20.0, 30.0, 40.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def test_joint_view_matches_full_labels_and_filters_types(self):
+        """Match full labels while preserving duplicate leaves and joint-type filters."""
+        scene = newton.ModelBuilder()
+        scene.replicate(make_closed_loop_selection_world(), world_count=2)
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        regex_view = newton.selection.JointView(model, re.compile(r"robot/(left|right)/hinge"))
+        self.assertEqual(regex_view.joint_labels, ["robot/left/hinge", "robot/right/hinge"])
+
+        revolute_view = newton.selection.JointView(
+            model,
+            ["robot/*", "prop/*"],
+            include_joint_types=[newton.JointType.REVOLUTE],
+        )
+        self.assertEqual(revolute_view.joint_labels, ["robot/left/hinge", "prop/hinge"])
+
+        non_fixed_view = newton.selection.JointView(
+            model,
+            "robot/*",
+            exclude_joint_types=[newton.JointType.FIXED],
+        )
+        self.assertEqual(non_fixed_view.joint_labels, ["robot/left/hinge", "robot/loop/closure"])
+
+        with self.assertRaisesRegex(KeyError, "No joints matching pattern"):
+            newton.selection.JointView(model, "missing/*")
+
+    def test_entity_views_reject_unequal_world_layouts(self):
+        """Reject selected entity layouts that differ between worlds."""
+        complete = make_closed_loop_selection_world()
+        incomplete = make_closed_loop_selection_world()
+        incomplete.joint_label[-1] = "other/closure"
+        incomplete.body_label[-1] = "other/tip"
+
+        scene = newton.ModelBuilder()
+        scene.add_world(complete)
+        scene.add_world(incomplete)
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "uniform joint layout across worlds"):
+            newton.selection.JointView(model, "robot/*")
+        with self.assertRaisesRegex(ValueError, "uniform body layout across worlds"):
+            newton.selection.BodyView(model, "robot/*")
+
+    def test_body_view_selects_shapes_and_mask_scatters_attributes(self):
+        """Select body and shape values and scatter masked non-contiguous attributes."""
+        scene = newton.ModelBuilder()
+        scene.replicate(make_closed_loop_selection_world(), world_count=2)
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+        view = newton.selection.BodyView(model, "robot/*")
+
+        self.assertEqual(view.count, 2)
+        self.assertEqual(view.body_count, 3)
+        self.assertEqual(view.shape_count, 3)
+        self.assertEqual(view.body_names, ["base", "tip", "tip"])
+        self.assertEqual(view.body_labels, ["robot/base", "robot/left/tip", "robot/right/tip"])
+        self.assertEqual(view.body_shapes, [[0], [1], [2]])
+        assert_np_equal(view.body_ids.numpy(), [[[0, 2, 3]], [[4, 6, 7]]])
+        assert_np_equal(view.shape_ids.numpy(), [[[0, 2, 3]], [[4, 6, 7]]])
+        self.assertFalse(view.bodies_contiguous)
+        self.assertFalse(view.shapes_contiguous)
+        self.assertEqual(view.get_body_transforms(model).shape, (2, 1, 3))
+        self.assertEqual(view.get_attribute("shape_margin", model).shape, (2, 1, 3))
+
+        masses = np.array([[[1.0, 2.0, 3.0]], [[4.0, 5.0, 6.0]]], dtype=np.float32)
+        view.set_attribute("body_mass", model, masses, mask=[False, True])
+        assert_np_equal(view.get_attribute("body_mass", model).numpy()[1], masses[1])
+        assert_np_equal(model.body_mass.numpy()[:4], np.zeros(4))
+        assert_np_equal(model.body_mass.numpy()[4:], [4.0, 0.0, 5.0, 6.0])
+
+    def test_entity_views_match_articulation_view_on_trees(self):
+        """Match ArticulationView attribute layouts for an equivalent tree selection."""
+        tree = newton.ModelBuilder()
+        root = tree.add_link(label="tree/root")
+        tip = tree.add_link(label="tree/tip")
+        j_root = tree.add_joint_fixed(-1, root, label="tree/root_joint")
+        j_tip = tree.add_joint_revolute(root, tip, label="tree/tip_joint")
+        tree.add_shape_box(root, hx=0.1, hy=0.1, hz=0.1, label="tree/root_shape")
+        tree.add_shape_box(tip, hx=0.1, hy=0.1, hz=0.1, label="tree/tip_shape")
+        tree.add_articulation([j_root, j_tip], label="tree")
+
+        scene = newton.ModelBuilder()
+        scene.replicate(tree, world_count=2)
+        model = scene.finalize(device="cpu")
+        articulation_view = ArticulationView(model, "tree")
+        joint_view = newton.selection.JointView(model, "tree/*_joint")
+        body_view = newton.selection.BodyView(model, ["tree/root", "tree/tip"])
+
+        assert_np_equal(joint_view.get_dof_positions(model).numpy(), articulation_view.get_dof_positions(model).numpy())
+        assert_np_equal(
+            joint_view.get_dof_velocities(model).numpy(), articulation_view.get_dof_velocities(model).numpy()
+        )
+        assert_np_equal(
+            body_view.get_body_transforms(model).numpy(), articulation_view.get_link_transforms(model).numpy()
+        )
+        assert_np_equal(
+            body_view.get_attribute("shape_margin", model).numpy(),
+            articulation_view.get_attribute("shape_margin", model).numpy(),
+        )
+
+
 class TestSelection(unittest.TestCase):
     def test_compiled_regex_selectors(self):
         builder = newton.ModelBuilder()

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -198,10 +198,10 @@ class TestEntityViews(unittest.TestCase):
                 label_prefixes=["env_0", "env_1"],
             )
 
-    def test_entity_views_remain_internal_until_api_ownership_is_approved(self):
-        """Keep provisional entity view names out of the public selection module."""
-        self.assertFalse(hasattr(newton.selection, "JointView"))
-        self.assertFalse(hasattr(newton.selection, "BodyView"))
+    def test_entity_views_are_exported_from_selection(self):
+        """Export the validated entity views from the public selection module."""
+        self.assertIs(newton.selection.JointView, _JointView)
+        self.assertIs(newton.selection.BodyView, _BodyView)
 
     def test_joint_view_selects_articulation_free_closed_loops(self):
         """Select complete closed-loop joint layouts without articulations."""

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -10,6 +10,7 @@ import warp as wp
 
 import newton
 import newton.examples
+from newton._src.utils import selection as _selection_utils
 from newton._src.utils.selection import BodyView as _BodyView
 from newton._src.utils.selection import JointView as _JointView
 from newton.selection import ArticulationView
@@ -96,6 +97,125 @@ def make_joint_topology_world(parent_label: str):
 
 
 class TestEntityViews(unittest.TestCase):
+    def test_mapped_kernels_declare_core_dtype_overloads(self):
+        """Declare mapped gather and scatter overloads for every core attribute dtype."""
+        dtypes = (
+            float,
+            int,
+            wp.bool,
+            wp.uint64,
+            wp.vec2i,
+            wp.vec3i,
+            wp.vec3,
+            wp.mat33,
+            wp.transform,
+            wp.spatial_vector,
+        )
+        overloads = (
+            (
+                _selection_utils._gather_mapped_3d_kernel,
+                lambda dtype: [wp.array[dtype], wp.array2d[int], wp.array3d[dtype]],
+            ),
+            (
+                _selection_utils._gather_mapped_4d_kernel,
+                lambda dtype: [wp.array2d[dtype], wp.array2d[int], wp.array4d[dtype]],
+            ),
+            (
+                _selection_utils._scatter_mapped_3d_per_world_kernel,
+                lambda dtype: [wp.array[bool], wp.array3d[dtype], wp.array2d[int], wp.array[dtype]],
+            ),
+            (
+                _selection_utils._scatter_mapped_4d_per_world_kernel,
+                lambda dtype: [wp.array[bool], wp.array4d[dtype], wp.array2d[int], wp.array2d[dtype]],
+            ),
+            (
+                _selection_utils._scatter_mapped_3d_kernel,
+                lambda dtype: [wp.array2d[bool], wp.array3d[dtype], wp.array2d[int], wp.array[dtype]],
+            ),
+            (
+                _selection_utils._scatter_mapped_4d_kernel,
+                lambda dtype: [wp.array2d[bool], wp.array4d[dtype], wp.array2d[int], wp.array2d[dtype]],
+            ),
+        )
+
+        for kernel, signature in overloads:
+            for dtype in dtypes:
+                with self.subTest(kernel=kernel.key, dtype=dtype):
+                    self.assertIsNotNone(kernel.get_overload(signature(dtype)))
+
+    def _assert_mapped_core_attribute_dtypes(self, device):
+        scene = newton.ModelBuilder()
+        scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")
+        scene.add_world(make_irregular_packing_world(1, 2), label_prefix="env_1")
+        model = scene.finalize(device=device, skip_validation_joints=True)
+        prefixes = ["env_0", "env_1"]
+        body_view = _BodyView(model, "env_*/mechanism/*", label_prefixes=prefixes)
+        joint_view = _JointView(model, "env_*/mechanism/*/joint", label_prefixes=prefixes)
+
+        cases = (
+            (
+                body_view,
+                "body_com",
+                np.arange(12, dtype=np.float32).reshape(2, 1, 2, 3),
+            ),
+            (
+                body_view,
+                "body_inertia",
+                np.arange(36, dtype=np.float32).reshape(2, 1, 2, 3, 3),
+            ),
+            (
+                body_view,
+                "shape_is_solid",
+                np.array([[[True, False]], [[False, True]]], dtype=np.bool_),
+            ),
+            (
+                body_view,
+                "shape_source_ptr",
+                np.array([[[101, 102]], [[103, 104]]], dtype=np.uint64),
+            ),
+            (
+                body_view,
+                "shape_edge_range",
+                np.arange(8, dtype=np.int32).reshape(2, 1, 2, 2),
+            ),
+            (
+                body_view,
+                "_shape_voxel_resolution",
+                np.arange(12, dtype=np.int32).reshape(2, 1, 2, 3),
+            ),
+            (
+                joint_view,
+                "joint_enabled",
+                np.array([[[True, False]], [[False, True]]], dtype=np.bool_),
+            ),
+            (
+                joint_view,
+                "joint_axis",
+                np.arange(12, dtype=np.float32).reshape(2, 1, 2, 3),
+            ),
+            (
+                joint_view,
+                "joint_dof_dim",
+                np.arange(8, dtype=np.int32).reshape(2, 1, 2, 2),
+            ),
+        )
+
+        for view, attribute, expected in cases:
+            with self.subTest(attribute=attribute, device=device):
+                values = view.get_attribute(attribute, model)
+                values.assign(expected)
+                view.set_attribute(attribute, model, values)
+                assert_np_equal(view.get_attribute(attribute, model).numpy(), expected)
+
+    def test_mapped_core_attribute_dtypes_cpu(self):
+        """Round-trip mapped core attribute dtypes on CPU."""
+        self._assert_mapped_core_attribute_dtypes("cpu")
+
+    @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
+    def test_mapped_core_attribute_dtypes_cuda(self):
+        """Round-trip mapped core attribute dtypes directly on CUDA."""
+        self._assert_mapped_core_attribute_dtypes("cuda:0")
+
     def _assert_mapped_attribute_read_modify_write(self, device):
         scene = newton.ModelBuilder()
         scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -140,6 +140,75 @@ class TestEntityViews(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "uniform body layout across worlds"):
             newton.selection.BodyView(model, "robot/*")
 
+    def test_joint_view_rejects_equal_count_label_order_mismatch(self):
+        """Reject equal-size joint columns with different canonical labels."""
+        expected = make_closed_loop_selection_world()
+        mismatched = make_closed_loop_selection_world()
+        mismatched.joint_label[0], mismatched.joint_label[3] = (
+            mismatched.joint_label[3],
+            mismatched.joint_label[0],
+        )
+
+        scene = newton.ModelBuilder()
+        scene.add_world(expected, label_prefix="env_0")
+        scene.add_world(mismatched, label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "canonical joint labels differ"):
+            newton.selection.JointView(model, "env_*/robot/*")
+
+    def test_joint_view_rejects_same_leaf_under_different_paths(self):
+        """Reject semantic path mismatches hidden by equal joint leaf names."""
+        expected = newton.ModelBuilder()
+        expected_body = expected.add_link(label="robot_a/body")
+        expected.add_joint_revolute(-1, expected_body, label="robot_a/shared")
+
+        mismatched = newton.ModelBuilder()
+        mismatched_body = mismatched.add_link(label="robot_b/body")
+        mismatched.add_joint_revolute(-1, mismatched_body, label="robot_b/shared")
+
+        scene = newton.ModelBuilder()
+        scene.add_world(expected, label_prefix="env_0")
+        scene.add_world(mismatched, label_prefix="env_1")
+        model = scene.finalize(device="cpu")
+
+        with self.assertRaisesRegex(ValueError, "canonical joint labels differ"):
+            newton.selection.JointView(model, "env_*/*/shared")
+
+    def test_body_view_rejects_equal_count_body_order_mismatch(self):
+        """Reject equal-size body columns with different canonical labels."""
+        expected = make_closed_loop_selection_world()
+        mismatched = make_closed_loop_selection_world()
+        mismatched.body_label[0], mismatched.body_label[2] = (
+            mismatched.body_label[2],
+            mismatched.body_label[0],
+        )
+
+        scene = newton.ModelBuilder()
+        scene.add_world(expected, label_prefix="env_0")
+        scene.add_world(mismatched, label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "canonical body labels differ"):
+            newton.selection.BodyView(model, "env_*/robot/*")
+
+    def test_body_view_rejects_equal_count_shape_ownership_mismatch(self):
+        """Reject equal-size shape columns assigned to different canonical bodies."""
+        expected = make_closed_loop_selection_world()
+        mismatched = make_closed_loop_selection_world()
+        mismatched.shape_label[0], mismatched.shape_label[2] = (
+            mismatched.shape_label[2],
+            mismatched.shape_label[0],
+        )
+
+        scene = newton.ModelBuilder()
+        scene.add_world(expected, label_prefix="env_0")
+        scene.add_world(mismatched, label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "canonical shape ownership differs"):
+            newton.selection.BodyView(model, "env_*/robot/*")
+
     def test_body_view_selects_shapes_and_mask_scatters_attributes(self):
         """Select body and shape values and scatter masked non-contiguous attributes."""
         scene = newton.ModelBuilder()
@@ -165,6 +234,41 @@ class TestEntityViews(unittest.TestCase):
         assert_np_equal(view.get_attribute("body_mass", model).numpy()[1], masses[1])
         assert_np_equal(model.body_mass.numpy()[:4], np.zeros(4))
         assert_np_equal(model.body_mass.numpy()[4:], [4.0, 0.0, 5.0, 6.0])
+
+    def test_body_view_preserves_per_body_shape_order(self):
+        """Preserve body traversal order when shape IDs are not monotonic."""
+        world = newton.ModelBuilder()
+        first = world.add_link(label="robot/first")
+        second = world.add_link(label="robot/second")
+        world.add_shape_box(
+            second,
+            hx=0.1,
+            hy=0.1,
+            hz=0.1,
+            cfg=newton.ModelBuilder.ShapeConfig(margin=0.2),
+            label="robot/second/shape",
+        )
+        world.add_shape_box(
+            first,
+            hx=0.1,
+            hy=0.1,
+            hz=0.1,
+            cfg=newton.ModelBuilder.ShapeConfig(margin=0.1),
+            label="robot/first/shape",
+        )
+
+        scene = newton.ModelBuilder()
+        scene.add_world(world, label_prefix="env_0")
+        scene.add_world(world, label_prefix="env_1")
+        model = scene.finalize(device="cpu")
+        view = newton.selection.BodyView(model, "env_*/robot/*")
+
+        self.assertEqual(view.body_shapes, [[0], [1]])
+        assert_np_equal(view.shape_ids.numpy(), [[[1, 0]], [[3, 2]]])
+        assert_np_equal(
+            view.get_attribute("shape_margin", model).numpy(),
+            np.array([[[0.1, 0.2]], [[0.1, 0.2]]], dtype=np.float32),
+        )
 
     def test_entity_views_match_articulation_view_on_trees(self):
         """Match ArticulationView attribute layouts for an equivalent tree selection."""

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -63,6 +63,9 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         self.assertEqual(model.articulation_count, 0)
+        with self.assertRaisesRegex(KeyError, "No articulations matching pattern"):
+            ArticulationView(model, "robot/*")
+
         view = newton.selection.JointView(model, "robot/*")
 
         self.assertEqual(view.count, 2)
@@ -141,7 +144,7 @@ class TestEntityViews(unittest.TestCase):
             newton.selection.BodyView(model, "robot/*")
 
     def test_joint_view_rejects_equal_count_label_order_mismatch(self):
-        """Reject equal-size joint columns with different canonical labels."""
+        """Reject equal-size joint columns with different normalized labels."""
         expected = make_closed_loop_selection_world()
         mismatched = make_closed_loop_selection_world()
         mismatched.joint_label[0], mismatched.joint_label[3] = (
@@ -154,11 +157,15 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(mismatched, label_prefix="env_1")
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
-        with self.assertRaisesRegex(ValueError, "canonical joint labels differ"):
-            newton.selection.JointView(model, "env_*/robot/*")
+        with self.assertRaisesRegex(ValueError, "joint labels differ"):
+            newton.selection.JointView(
+                model,
+                "env_*/robot/*",
+                label_prefixes=["env_0", "env_1"],
+            )
 
-    def test_joint_view_rejects_same_leaf_under_different_paths(self):
-        """Reject semantic path mismatches hidden by equal joint leaf names."""
+    def test_entity_views_reject_same_leaf_under_different_paths(self):
+        """Reject semantic path mismatches hidden by equal entity leaf names."""
         expected = newton.ModelBuilder()
         expected_body = expected.add_link(label="robot_a/body")
         expected.add_joint_revolute(-1, expected_body, label="robot_a/shared")
@@ -168,15 +175,17 @@ class TestEntityViews(unittest.TestCase):
         mismatched.add_joint_revolute(-1, mismatched_body, label="robot_b/shared")
 
         scene = newton.ModelBuilder()
-        scene.add_world(expected, label_prefix="env_0")
-        scene.add_world(mismatched, label_prefix="env_1")
+        scene.add_world(expected)
+        scene.add_world(mismatched)
         model = scene.finalize(device="cpu")
 
-        with self.assertRaisesRegex(ValueError, "canonical joint labels differ"):
-            newton.selection.JointView(model, "env_*/*/shared")
+        with self.assertRaisesRegex(ValueError, "joint labels differ"):
+            newton.selection.JointView(model, "robot_*/shared")
+        with self.assertRaisesRegex(ValueError, "body labels differ"):
+            newton.selection.BodyView(model, "robot_*/body")
 
     def test_body_view_rejects_equal_count_body_order_mismatch(self):
-        """Reject equal-size body columns with different canonical labels."""
+        """Reject equal-size body columns with different normalized labels."""
         expected = make_closed_loop_selection_world()
         mismatched = make_closed_loop_selection_world()
         mismatched.body_label[0], mismatched.body_label[2] = (
@@ -189,11 +198,15 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(mismatched, label_prefix="env_1")
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
-        with self.assertRaisesRegex(ValueError, "canonical body labels differ"):
-            newton.selection.BodyView(model, "env_*/robot/*")
+        with self.assertRaisesRegex(ValueError, "body labels differ"):
+            newton.selection.BodyView(
+                model,
+                "env_*/robot/*",
+                label_prefixes=["env_0", "env_1"],
+            )
 
     def test_body_view_rejects_equal_count_shape_ownership_mismatch(self):
-        """Reject equal-size shape columns assigned to different canonical bodies."""
+        """Reject equal-size shape columns assigned to different normalized bodies."""
         expected = make_closed_loop_selection_world()
         mismatched = make_closed_loop_selection_world()
         mismatched.shape_label[0], mismatched.shape_label[2] = (
@@ -206,8 +219,74 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(mismatched, label_prefix="env_1")
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
-        with self.assertRaisesRegex(ValueError, "canonical shape ownership differs"):
+        with self.assertRaisesRegex(ValueError, "shape ownership differs"):
+            newton.selection.BodyView(
+                model,
+                "env_*/robot/*",
+                label_prefixes=["env_0", "env_1"],
+            )
+
+    def test_entity_views_accept_explicit_world_label_prefixes(self):
+        """Strip exact world prefixes before validating entity columns."""
+        scene = newton.ModelBuilder()
+        scene.add_world(make_closed_loop_selection_world(), label_prefix="env_0")
+        scene.add_world(make_closed_loop_selection_world(), label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        joint_view = newton.selection.JointView(
+            model,
+            "env_*/robot/*",
+            label_prefixes=("env_0", "env_1"),
+        )
+        body_view = newton.selection.BodyView(
+            model,
+            "env_*/robot/*",
+            label_prefixes=["env_0", "env_1"],
+        )
+
+        self.assertEqual(joint_view.joint_count, 4)
+        self.assertEqual(body_view.body_count, 3)
+
+    def test_entity_views_require_explicit_valid_world_label_prefixes(self):
+        """Reject missing, incomplete, or non-matching world prefixes."""
+        scene = newton.ModelBuilder()
+        scene.add_world(make_closed_loop_selection_world(), label_prefix="env_0")
+        scene.add_world(make_closed_loop_selection_world(), label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "joint labels differ"):
+            newton.selection.JointView(model, "env_*/robot/*")
+        with self.assertRaisesRegex(ValueError, "body labels differ"):
             newton.selection.BodyView(model, "env_*/robot/*")
+
+        for view_type in (newton.selection.JointView, newton.selection.BodyView):
+            with self.subTest(view_type=view_type.__name__, error="length"):
+                with self.assertRaisesRegex(ValueError, "label_prefixes length"):
+                    view_type(model, "env_*/robot/*", label_prefixes=["env_0"])
+            with self.subTest(view_type=view_type.__name__, error="boundary"):
+                with self.assertRaisesRegex(ValueError, "does not start with label prefix"):
+                    view_type(model, "env_*/robot/*", label_prefixes=["env", "env_1"])
+            with self.subTest(view_type=view_type.__name__, error="world"):
+                with self.assertRaisesRegex(ValueError, "does not start with label prefix"):
+                    view_type(model, "env_*/robot/*", label_prefixes=["env_0", "env_0"])
+            with self.subTest(view_type=view_type.__name__, error="empty"):
+                with self.assertRaisesRegex(ValueError, "must not be empty"):
+                    view_type(model, "env_*/robot/*", label_prefixes=["env_0", ""])
+            with self.subTest(view_type=view_type.__name__, error="type"):
+                with self.assertRaisesRegex(TypeError, "must be a string"):
+                    view_type(model, "env_*/robot/*", label_prefixes=["env_0", 1])
+
+    def test_entity_views_reject_label_prefixes_for_global_entities(self):
+        """Reject world prefixes for a synthetic global-only world."""
+        model = make_closed_loop_selection_world().finalize(device="cpu", skip_validation_joints=True)
+
+        self.assertEqual(newton.selection.JointView(model, "robot/*").world_count, 1)
+        self.assertEqual(newton.selection.BodyView(model, "robot/*").world_count, 1)
+
+        for view_type in (newton.selection.JointView, newton.selection.BodyView):
+            with self.subTest(view_type=view_type.__name__):
+                with self.assertRaisesRegex(ValueError, "global-only selection"):
+                    view_type(model, "robot/*", label_prefixes=["env_0"])
 
     def test_body_view_selects_shapes_and_mask_scatters_attributes(self):
         """Select body and shape values and scatter masked non-contiguous attributes."""
@@ -261,7 +340,11 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(world, label_prefix="env_0")
         scene.add_world(world, label_prefix="env_1")
         model = scene.finalize(device="cpu")
-        view = newton.selection.BodyView(model, "env_*/robot/*")
+        view = newton.selection.BodyView(
+            model,
+            "env_*/robot/*",
+            label_prefixes=["env_0", "env_1"],
+        )
 
         self.assertEqual(view.body_shapes, [[0], [1]])
         assert_np_equal(view.shape_ids.numpy(), [[[1, 0]], [[3, 2]]])

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -10,6 +10,8 @@ import warp as wp
 
 import newton
 import newton.examples
+from newton._src.utils.selection import BodyView as _BodyView
+from newton._src.utils.selection import JointView as _JointView
 from newton.selection import ArticulationView
 from newton.tests.unittest_utils import assert_np_equal
 
@@ -55,7 +57,125 @@ def make_closed_loop_selection_world():
     return builder
 
 
+def make_irregular_packing_world(noise_before: int, noise_between: int, noise_after: int = 0):
+    """Build equivalent selected entities with configurable unrelated packing."""
+    builder = newton.ModelBuilder()
+    shape_cfg = newton.ModelBuilder.ShapeConfig(density=0.0)
+
+    before = [builder.add_link(label=f"noise/before_{i}") for i in range(noise_before)]
+    first = builder.add_link(label="mechanism/first")
+    between = [builder.add_link(label=f"noise/between_{i}") for i in range(noise_between)]
+    second = builder.add_link(label="mechanism/second")
+
+    for body in before:
+        builder.add_shape_box(body, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label=f"noise/shape_{body}")
+        builder.add_joint_revolute(-1, body, label=f"noise/joint_{body}")
+    builder.add_shape_box(first, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label="mechanism/first/shape")
+    builder.add_joint_revolute(-1, first, label="mechanism/first/joint")
+    for body in between:
+        builder.add_shape_box(body, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label=f"noise/shape_{body}")
+        builder.add_joint_revolute(-1, body, label=f"noise/joint_{body}")
+    builder.add_shape_box(second, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label="mechanism/second/shape")
+    builder.add_joint_revolute(first, second, label="mechanism/second/joint")
+    for i in range(noise_after):
+        body = builder.add_link(label=f"noise/after_{i}")
+        builder.add_shape_box(body, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg, label=f"noise/after_shape_{i}")
+        builder.add_joint_revolute(-1, body, label=f"noise/after_joint_{i}")
+    return builder
+
+
+def make_joint_topology_world(parent_label: str):
+    """Build a labeled joint whose parent can vary without changing its signature."""
+    builder = newton.ModelBuilder()
+    base = builder.add_link(label="mechanism/base")
+    alternate = builder.add_link(label="mechanism/alternate")
+    tip = builder.add_link(label="mechanism/tip")
+    parents = {"base": base, "alternate": alternate}
+    builder.add_joint_revolute(parents[parent_label], tip, label="mechanism/hinge")
+    return builder
+
+
 class TestEntityViews(unittest.TestCase):
+    def _assert_irregular_packing_access(self, device):
+        scene = newton.ModelBuilder()
+        scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")
+        scene.add_world(make_irregular_packing_world(1, 2), label_prefix="env_1")
+        model = scene.finalize(device=device, skip_validation_joints=True)
+        state = model.state()
+        prefixes = ["env_0", "env_1"]
+        joint_view = _JointView(model, "env_*/mechanism/*/joint", label_prefixes=prefixes)
+        body_view = _BodyView(model, "env_*/mechanism/*", label_prefixes=prefixes)
+
+        assert_np_equal(joint_view.joint_ids.numpy(), [[[0, 2]], [[4, 7]]])
+        assert_np_equal(
+            joint_view.get_attribute("joint_type", model).numpy(),
+            np.full((2, 1, 2), int(newton.JointType.REVOLUTE), dtype=np.int32),
+        )
+        assert_np_equal(body_view.body_ids.numpy(), [[[0, 2]], [[4, 7]]])
+        assert_np_equal(body_view.shape_ids.numpy(), [[[0, 2]], [[4, 7]]])
+
+        velocities = np.array([[[11.0, 21.0]], [[31.0, 41.0]]], dtype=np.float32)
+        joint_view.set_dof_velocities(state, velocities)
+        assert_np_equal(joint_view.get_dof_velocities(state).numpy(), velocities)
+        assert_np_equal(state.joint_qd.numpy(), [11.0, 0.0, 21.0, 0.0, 31.0, 0.0, 0.0, 41.0])
+
+        masses = np.array([[[1.0, 2.0]], [[3.0, 4.0]]], dtype=np.float32)
+        body_view.set_attribute("body_mass", model, masses, mask=[False, True])
+        assert_np_equal(body_view.get_attribute("body_mass", model).numpy()[1], masses[1])
+        assert_np_equal(model.body_mass.numpy(), [0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 4.0])
+
+        margins = np.array([[[0.11, 0.21]], [[0.31, 0.41]]], dtype=np.float32)
+        body_view.set_attribute("shape_margin", model, margins)
+        assert_np_equal(body_view.get_attribute("shape_margin", model).numpy(), margins)
+
+    def test_entity_views_support_irregular_world_packing_cpu(self):
+        """Gather and scatter explicit entity IDs across irregular CPU packing."""
+        self._assert_irregular_packing_access("cpu")
+
+    def test_entity_views_support_nonconstant_world_strides(self):
+        """Use explicit IDs when equivalent worlds have nonconstant global spacing."""
+        scene = newton.ModelBuilder()
+        scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")
+        scene.add_world(make_irregular_packing_world(0, 1, 2), label_prefix="env_1")
+        scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_2")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+        state = model.state()
+        view = _JointView(
+            model,
+            "env_*/mechanism/*/joint",
+            label_prefixes=["env_0", "env_1", "env_2"],
+        )
+
+        assert_np_equal(view.joint_ids.numpy(), [[[0, 2]], [[3, 5]], [[8, 10]]])
+        values = np.array([[[1.0, 2.0]], [[3.0, 4.0]], [[5.0, 6.0]]], dtype=np.float32)
+        view.set_dof_velocities(state, values)
+        assert_np_equal(view.get_dof_velocities(state).numpy(), values)
+        assert_np_equal(state.joint_qd.numpy(), [1.0, 0.0, 2.0, 3.0, 0.0, 4.0, 0.0, 0.0, 5.0, 0.0, 6.0])
+
+    @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
+    def test_entity_views_support_irregular_world_packing_cuda(self):
+        """Gather and scatter explicit entity IDs directly on CUDA."""
+        self._assert_irregular_packing_access("cuda:0")
+
+    def test_joint_view_rejects_parent_child_topology_mismatch(self):
+        """Reject matching joint signatures attached to different relative bodies."""
+        scene = newton.ModelBuilder()
+        scene.add_world(make_joint_topology_world("base"), label_prefix="env_0")
+        scene.add_world(make_joint_topology_world("alternate"), label_prefix="env_1")
+        model = scene.finalize(device="cpu", skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "parent/child body labels differ"):
+            _JointView(
+                model,
+                "env_*/mechanism/hinge",
+                label_prefixes=["env_0", "env_1"],
+            )
+
+    def test_entity_views_remain_internal_until_api_ownership_is_approved(self):
+        """Keep provisional entity view names out of the public selection module."""
+        self.assertFalse(hasattr(newton.selection, "JointView"))
+        self.assertFalse(hasattr(newton.selection, "BodyView"))
+
     def test_joint_view_selects_articulation_free_closed_loops(self):
         """Select complete closed-loop joint layouts without articulations."""
         scene = newton.ModelBuilder()
@@ -66,7 +186,7 @@ class TestEntityViews(unittest.TestCase):
         with self.assertRaisesRegex(KeyError, "No articulations matching pattern"):
             ArticulationView(model, "robot/*")
 
-        view = newton.selection.JointView(model, "robot/*")
+        view = _JointView(model, "robot/*")
 
         self.assertEqual(view.count, 2)
         self.assertEqual(view.world_count, 2)
@@ -92,7 +212,7 @@ class TestEntityViews(unittest.TestCase):
         scene.replicate(make_closed_loop_selection_world(), world_count=2)
         model = scene.finalize(device="cpu", skip_validation_joints=True)
         state = model.state()
-        view = newton.selection.JointView(model, "robot/*")
+        view = _JointView(model, "robot/*")
 
         values = np.array([[[10.0, 20.0, 30.0, 40.0]], [[50.0, 60.0, 70.0, 80.0]]], dtype=np.float32)
         view.set_dof_velocities(state, values, mask=[True, False])
@@ -106,17 +226,17 @@ class TestEntityViews(unittest.TestCase):
         scene.replicate(make_closed_loop_selection_world(), world_count=2)
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
-        regex_view = newton.selection.JointView(model, re.compile(r"robot/(left|right)/hinge"))
+        regex_view = _JointView(model, re.compile(r"robot/(left|right)/hinge"))
         self.assertEqual(regex_view.joint_labels, ["robot/left/hinge", "robot/right/hinge"])
 
-        revolute_view = newton.selection.JointView(
+        revolute_view = _JointView(
             model,
             ["robot/*", "prop/*"],
             include_joint_types=[newton.JointType.REVOLUTE],
         )
         self.assertEqual(revolute_view.joint_labels, ["robot/left/hinge", "prop/hinge"])
 
-        non_fixed_view = newton.selection.JointView(
+        non_fixed_view = _JointView(
             model,
             "robot/*",
             exclude_joint_types=[newton.JointType.FIXED],
@@ -124,7 +244,7 @@ class TestEntityViews(unittest.TestCase):
         self.assertEqual(non_fixed_view.joint_labels, ["robot/left/hinge", "robot/loop/closure"])
 
         with self.assertRaisesRegex(KeyError, "No joints matching pattern"):
-            newton.selection.JointView(model, "missing/*")
+            _JointView(model, "missing/*")
 
     def test_entity_views_reject_unequal_world_layouts(self):
         """Reject selected entity layouts that differ between worlds."""
@@ -139,9 +259,9 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         with self.assertRaisesRegex(ValueError, "uniform joint layout across worlds"):
-            newton.selection.JointView(model, "robot/*")
+            _JointView(model, "robot/*")
         with self.assertRaisesRegex(ValueError, "uniform body layout across worlds"):
-            newton.selection.BodyView(model, "robot/*")
+            _BodyView(model, "robot/*")
 
     def test_joint_view_rejects_equal_count_label_order_mismatch(self):
         """Reject equal-size joint columns with different normalized labels."""
@@ -158,7 +278,7 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         with self.assertRaisesRegex(ValueError, "joint labels differ"):
-            newton.selection.JointView(
+            _JointView(
                 model,
                 "env_*/robot/*",
                 label_prefixes=["env_0", "env_1"],
@@ -180,9 +300,9 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu")
 
         with self.assertRaisesRegex(ValueError, "joint labels differ"):
-            newton.selection.JointView(model, "robot_*/shared")
+            _JointView(model, "robot_*/shared")
         with self.assertRaisesRegex(ValueError, "body labels differ"):
-            newton.selection.BodyView(model, "robot_*/body")
+            _BodyView(model, "robot_*/body")
 
     def test_body_view_rejects_equal_count_body_order_mismatch(self):
         """Reject equal-size body columns with different normalized labels."""
@@ -199,7 +319,7 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         with self.assertRaisesRegex(ValueError, "body labels differ"):
-            newton.selection.BodyView(
+            _BodyView(
                 model,
                 "env_*/robot/*",
                 label_prefixes=["env_0", "env_1"],
@@ -220,7 +340,7 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         with self.assertRaisesRegex(ValueError, "shape ownership differs"):
-            newton.selection.BodyView(
+            _BodyView(
                 model,
                 "env_*/robot/*",
                 label_prefixes=["env_0", "env_1"],
@@ -233,12 +353,12 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(make_closed_loop_selection_world(), label_prefix="env_1")
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
-        joint_view = newton.selection.JointView(
+        joint_view = _JointView(
             model,
             "env_*/robot/*",
             label_prefixes=("env_0", "env_1"),
         )
-        body_view = newton.selection.BodyView(
+        body_view = _BodyView(
             model,
             "env_*/robot/*",
             label_prefixes=["env_0", "env_1"],
@@ -255,11 +375,11 @@ class TestEntityViews(unittest.TestCase):
         model = scene.finalize(device="cpu", skip_validation_joints=True)
 
         with self.assertRaisesRegex(ValueError, "joint labels differ"):
-            newton.selection.JointView(model, "env_*/robot/*")
+            _JointView(model, "env_*/robot/*")
         with self.assertRaisesRegex(ValueError, "body labels differ"):
-            newton.selection.BodyView(model, "env_*/robot/*")
+            _BodyView(model, "env_*/robot/*")
 
-        for view_type in (newton.selection.JointView, newton.selection.BodyView):
+        for view_type in (_JointView, _BodyView):
             with self.subTest(view_type=view_type.__name__, error="length"):
                 with self.assertRaisesRegex(ValueError, "label_prefixes length"):
                     view_type(model, "env_*/robot/*", label_prefixes=["env_0"])
@@ -280,10 +400,10 @@ class TestEntityViews(unittest.TestCase):
         """Reject world prefixes for a synthetic global-only world."""
         model = make_closed_loop_selection_world().finalize(device="cpu", skip_validation_joints=True)
 
-        self.assertEqual(newton.selection.JointView(model, "robot/*").world_count, 1)
-        self.assertEqual(newton.selection.BodyView(model, "robot/*").world_count, 1)
+        self.assertEqual(_JointView(model, "robot/*").world_count, 1)
+        self.assertEqual(_BodyView(model, "robot/*").world_count, 1)
 
-        for view_type in (newton.selection.JointView, newton.selection.BodyView):
+        for view_type in (_JointView, _BodyView):
             with self.subTest(view_type=view_type.__name__):
                 with self.assertRaisesRegex(ValueError, "global-only selection"):
                     view_type(model, "robot/*", label_prefixes=["env_0"])
@@ -293,7 +413,7 @@ class TestEntityViews(unittest.TestCase):
         scene = newton.ModelBuilder()
         scene.replicate(make_closed_loop_selection_world(), world_count=2)
         model = scene.finalize(device="cpu", skip_validation_joints=True)
-        view = newton.selection.BodyView(model, "robot/*")
+        view = _BodyView(model, "robot/*")
 
         self.assertEqual(view.count, 2)
         self.assertEqual(view.body_count, 3)
@@ -340,7 +460,7 @@ class TestEntityViews(unittest.TestCase):
         scene.add_world(world, label_prefix="env_0")
         scene.add_world(world, label_prefix="env_1")
         model = scene.finalize(device="cpu")
-        view = newton.selection.BodyView(
+        view = _BodyView(
             model,
             "env_*/robot/*",
             label_prefixes=["env_0", "env_1"],
@@ -368,8 +488,8 @@ class TestEntityViews(unittest.TestCase):
         scene.replicate(tree, world_count=2)
         model = scene.finalize(device="cpu")
         articulation_view = ArticulationView(model, "tree")
-        joint_view = newton.selection.JointView(model, "tree/*_joint")
-        body_view = newton.selection.BodyView(model, ["tree/root", "tree/tip"])
+        joint_view = _JointView(model, "tree/*_joint")
+        body_view = _BodyView(model, ["tree/root", "tree/tip"])
 
         assert_np_equal(joint_view.get_dof_positions(model).numpy(), articulation_view.get_dof_positions(model).numpy())
         assert_np_equal(

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -96,6 +96,33 @@ def make_joint_topology_world(parent_label: str):
 
 
 class TestEntityViews(unittest.TestCase):
+    def _assert_mapped_attribute_read_modify_write(self, device):
+        scene = newton.ModelBuilder()
+        scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")
+        scene.add_world(make_irregular_packing_world(1, 2), label_prefix="env_1")
+        model = scene.finalize(device=device, skip_validation_joints=True)
+        view = _BodyView(
+            model,
+            "env_*/mechanism/*",
+            label_prefixes=["env_0", "env_1"],
+        )
+
+        values = view.get_attribute("body_mass", model)
+        values.assign(values.numpy() + np.array([[[1.0, 2.0]], [[3.0, 4.0]]], dtype=np.float32))
+        view.set_attribute("body_mass", model, values)
+
+        assert_np_equal(view.get_attribute("body_mass", model).numpy(), [[[1.0, 2.0]], [[3.0, 4.0]]])
+        assert_np_equal(model.body_mass.numpy(), [1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 0.0, 4.0])
+
+    def test_mapped_attribute_read_modify_write_cpu(self):
+        """Scatter a mapped CPU attribute when reusing the exact gathered array."""
+        self._assert_mapped_attribute_read_modify_write("cpu")
+
+    @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
+    def test_mapped_attribute_read_modify_write_cuda(self):
+        """Scatter a mapped CUDA attribute when reusing the exact gathered array."""
+        self._assert_mapped_attribute_read_modify_write("cuda:0")
+
     def _assert_irregular_packing_access(self, device):
         scene = newton.ModelBuilder()
         scene.add_world(make_irregular_packing_world(0, 1), label_prefix="env_0")


### PR DESCRIPTION
## Description

Add public `JointView` and `BodyView` selection abstractions that do not require articulation ownership.

These views select complete-label joint or body columns per world and reuse Newton's existing `(world, instance, value)` attribute layout. They support non-contiguous global storage through explicit gather/scatter mappings, joint coordinate and DOF attributes, body shape attributes, joint-type filters, and exact per-world label-prefix normalization.

Cross-world construction validates ordered labels, dimensions, shape ownership, and joint parent/child topology. It rejects ambiguous global/per-world mixtures and mismatched mechanisms rather than silently pairing unrelated entities. Existing `ArticulationView` behavior is unchanged.

Addresses #3174.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k TestEntityViews
uv run --extra dev -m newton.tests -k test_selection
python docs/generate_api.py
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version X.Y.Z --date 2026-08-15
```

The tests cover CPU and CUDA gather/scatter, non-contiguous world layouts, read-modify-write through gathered arrays, closed mechanisms with no articulation, duplicate leaf names, full-label patterns, fixed and multi-DOF joints, tree parity, shape ownership, and invalid cross-world topology.

## New feature / API change

```python
from newton.selection import BodyView, JointView

joint_view = JointView(
    model,
    "env_*/robot/*",
    label_prefixes=["env_0", "env_1"],
)
body_view = BodyView(
    model,
    "env_*/robot/*",
    label_prefixes=["env_0", "env_1"],
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `JointView` and `BodyView` for topology-independent joint and body selection.
  * Supports labeled closed-loop mechanisms, irregular layouts, masks, filtering, and non-contiguous entities.
  * Added accessors for joint positions, velocities, forces, and body transforms and velocities.
  * Exported the new views through the public selection API.

* **Documentation**
  * Added guidance for structured selection views and improved API module documentation.

* **Tests**
  * Expanded coverage for CPU, CUDA, validation, masking, and irregular layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->