### PR TITLE
fix(solvers): defer annotation evaluation so ModelBuilder() works on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
       - name: Test CI tooling
         run: uv run --no-project -m unittest discover -s scripts/ci/tests
       - name: Test minimal import (Python 3.10)
-        run: uv run --python 3.10 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+        run: uv run --python 3.10 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
       - name: Test minimal import (Python 3.11)
-        run: uv run --python 3.11 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+        run: uv run --python 3.11 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
       - name: Test minimal import (Python 3.12)
-        run: uv run --python 3.12 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+        run: uv run --python 3.12 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
       - name: Test minimal import (Python 3.13)
-        run: uv run --python 3.13 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+        run: uv run --python 3.13 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
       - name: Test minimal import (Python 3.14)
-        run: uv run --python 3.14 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+        run: uv run --python 3.14 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
 
   dependency-install-test:
     needs: minimal-import-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - release-*
 
 jobs:
-  minimal-import-test:
+  python-compatibility-test:
     if: github.event_name != 'push' || github.repository == 'newton-physics/newton'
     runs-on: ubuntu-latest
     steps:
@@ -41,19 +41,19 @@ jobs:
           version: "0.11.26"
       - name: Test CI tooling
         run: uv run --no-project -m unittest discover -s scripts/ci/tests
-      - name: Test minimal import (Python 3.10)
-        run: uv run --python 3.10 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
-      - name: Test minimal import (Python 3.11)
-        run: uv run --python 3.11 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
-      - name: Test minimal import (Python 3.12)
-        run: uv run --python 3.12 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
-      - name: Test minimal import (Python 3.13)
-        run: uv run --python 3.13 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
-      - name: Test minimal import (Python 3.14)
-        run: uv run --python 3.14 python -c "import newton; newton.ModelBuilder(); print(f'Newton {newton.__version__} imported successfully')"
+      - name: Python compatibility (Python 3.10)
+        run: uv run --python 3.10 python -m unittest newton.tests.test_python_compatibility
+      - name: Python compatibility (Python 3.11)
+        run: uv run --python 3.11 python -m unittest newton.tests.test_python_compatibility
+      - name: Python compatibility (Python 3.12)
+        run: uv run --python 3.12 python -m unittest newton.tests.test_python_compatibility
+      - name: Python compatibility (Python 3.13)
+        run: uv run --python 3.13 python -m unittest newton.tests.test_python_compatibility
+      - name: Python compatibility (Python 3.14)
+        run: uv run --python 3.14 python -m unittest newton.tests.test_python_compatibility
 
   dependency-install-test:
-    needs: minimal-import-test
+    needs: python-compatibility-test
     strategy:
       fail-fast: false
       matrix:

--- a/changelog/3941.fixed.md
+++ b/changelog/3941.fixed.md
@@ -1,0 +1,1 @@
+Fix `ModelBuilder()` raising `TypeError` on Python 3.10, caused by eager evaluation of a PEP 604 annotation over a subscripted Warp type in `SolverBase`.

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any
 
 import warp as wp

--- a/newton/tests/test_python_compatibility.py
+++ b/newton/tests/test_python_compatibility.py
@@ -12,12 +12,12 @@ postponed -- which is how a Python 3.10 ``TypeError`` reached users through
 
 import unittest
 
+import newton
+
 
 class TestPythonCompatibility(unittest.TestCase):
     def test_stable_solver_exports_resolve(self):
         """Resolve every stable public solver export."""
-        import newton
-
         for name in newton.solvers.__all__:
             if name == "experimental":
                 continue

--- a/newton/tests/test_python_compatibility.py
+++ b/newton/tests/test_python_compatibility.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility checks that must hold on every supported Python version.
+
+``pyproject.toml`` declares support down to Python 3.10, so the stable public
+API has to resolve there. Resolving a solver export imports the module that
+defines it, and annotations in that module are evaluated at import time unless
+postponed -- which is how a Python 3.10 ``TypeError`` reached users through
+``ModelBuilder()`` in #3941.
+"""
+
+import unittest
+
+
+class TestPythonCompatibility(unittest.TestCase):
+    def test_stable_solver_exports_resolve(self):
+        """Resolve every stable public solver export."""
+        import newton
+
+        for name in newton.solvers.__all__:
+            if name == "experimental":
+                continue
+            with self.subTest(name=name):
+                _ = getattr(newton.solvers, name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Fixes `newton.ModelBuilder()` raising `TypeError` on Python 3.10, and closes the CI gap that let it through.

`SolverBase` annotates `wp.array[wp.bool] | None`. That is evaluated at class-definition time, and `wp.array[wp.bool]` is not a `type` — so `typing._type_check` rejects it. Python 3.11 relaxed that check, which is why this reproduces only on 3.10, a version `pyproject.toml` declares as supported.

Three commits:

1. **`from __future__ import annotations` in `newton/_src/solvers/solver.py`.** One line, placed to match `solvers/coupled/solver_coupled.py` in the same subtree, which already defers.
2. **A regression test, `newton/tests/test_python_compatibility.py`**, run by CI on 3.10–3.14. See below.
3. Changelog fragment.

Closes #3941

### Where the regression guard lives

*(Revised after review — the first version of this PR appended `newton.ModelBuilder()`
to the five "minimal import" steps instead. @jcarius-nv pointed out that this catches
the defect only because constructing a builder happens to traverse the solver import
chain, which is incidental rather than a stated contract, and that CONTRIBUTING.md asks
bug fixes to carry a regression test. That is right, and this is his suggested test.)*

The guard has two halves, because either alone would miss this:

- **A named test.** `newton/tests/test_python_compatibility.py` resolves every stable
  export of `newton.solvers`. Resolving one imports the module that defines it, so the
  test fails on any module whose import-time annotations do not evaluate on a supported
  interpreter — the class of defect this is, stated as a contract rather than reached
  by accident.
- **Run on every supported version.** The full suite runs under the pinned
  `.python-version` (3.12), where the annotation evaluates fine, so a test alone would
  stay green. CI now invokes this one test on 3.10–3.14, replacing the smoke steps.

Verified on Python 3.10.20 / warp-lang 1.16.0 / newton 1.5.0, which carries the defect
verbatim (no postponed annotations; `wp.array[wp.bool] | None` at `solver.py:221`
and `:345`), by running the test with and without the one-line fix in fresh
interpreters:

```
defect present   FAIL — 9 errors, every one
                 TypeError: Union[arg, ...]: each arg must be a type. Got wp.array[wp.bool].
patched          PASS
```

Nine of the ten stable exports fail, not one: most solvers subclass `SolverBase`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added

## Test plan

Verified on newton 1.5.0 + warp-lang 1.16.0 + Python 3.10.20:

```
# without the fix
$ python -c "import newton; newton.ModelBuilder()"
TypeError: Union[arg, ...]: each arg must be a type. Got wp.array[wp.bool].

# with the fix
$ python -c "import newton; newton.ModelBuilder(); print('ok')"
ok
```

Beyond construction, `add_mjcf` then imports a 271-geom MuJoCo model successfully
(`body=37 shape=302 joint=37 dof=43`, matching the source model's `nv=43`).

Checked that deferring evaluation is behaviour-preserving for this module:

- `solver.py` contains no `typing.get_type_hints`, `__annotations__`, `pydantic` or `@dataclass` usage, so nothing reads these annotations at runtime;
- `newton/tests/test_api.py` does call `get_type_hints`, but only on importer functions and `ModelBuilder` methods, not on `SolverBase`; its `SolverSemiImplicit` assertions use `inspect.signature(...).kind`, which PEP 563 does not affect.

## Bug fix

**Steps to reproduce:**

1. Install `newton==1.5.0` under Python 3.10 (warp-lang 1.16.0 comes with it).
2. Construct a `ModelBuilder`.
3. `TypeError` is raised from `solver.py:221` during the solver import chain, before any user code runs.

**Minimal reproduction:**

```python
import newton

newton.ModelBuilder()
# TypeError: Union[arg, ...]: each arg must be a type. Got wp.array[wp.bool].
```

The `typing` behaviour difference, isolated from Newton and Warp:

```python
import typing
class Fake: pass          # not callable, like warp's _ArrayAnnotation
typing.Union[Fake(), None]
# 3.10 -> TypeError: Union[arg, ...]: each arg must be a type
# 3.11 -> typing.Optional[<__main__.Fake object ...>]
```

### Alternatives

If you would rather keep eager evaluation in this file, **quoting** the two annotations
works. I went with the future import because it fixes the file as a whole and matches a
sibling module.

~~or using `Optional[...]`~~ — **correction, thanks @jcarius-nv:** `Optional[...]` does
not work. It fails the same `_type_check`, just with a different message. Checked on
both warp-lang 1.16.0 and 1.14.0 under Python 3.10:

```python
wp.array[wp.bool] | None      # TypeError: Union[arg, ...]: each arg must be a type.
Optional[wp.array[wp.bool]]   # TypeError: typing.Optional requires a single type.
'wp.array[wp.bool] | None'    # ok
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that caused `ModelBuilder()` to fail during initialization on Python 3.10.
  * Improved compatibility with supported Python versions by safely handling type annotations.
* **Tests**
  * Added compatibility checks for importing stable solver functionality across Python 3.10–3.14.
* **Documentation**
  * Added a changelog entry describing the Python 3.10 compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
