### PR TITLE
[Kamino] Expose speculative contacts culling flag in config

### DIFF
--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -385,6 +385,13 @@ class ConstrainedDynamicsConfig(ConfigBase):
     Defaults to an empty dictionary.
     """
 
+    cull_speculative_contacts: bool = True
+    """
+    Whether to cull speculative (= separated) contacts in the dynamics solve.
+    These contacts have occasionally led to numerical instabilities, and
+    can yield inaccurate restitutive impacts.
+    """
+
     @override
     @staticmethod
     def register_custom_attributes(builder: ModelBuilder) -> None:

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -1014,6 +1014,7 @@ class SolverKamino(SolverBase, CouplingInterface):
                     convert_forces=False,
                     friction_mix_mode=self._config.materials.friction_mix_mode,
                     restitution_mix_mode=self._config.materials.restitution_mix_mode,
+                    cull_speculative_contacts=self._config.dynamics.cull_speculative_contacts,
                 )
         else:
             self._detector = None


### PR DESCRIPTION
## Description

A flag was recently added to `convert_contacts_newton_to_kamino()` to enable/disable the culling of speculative contacts; but it is left at its default value in `SolverKamino`. This PR surfaces this flag in the config so we can disable this culling in specific examples, until we can find a better solution to handle speculative contacts. Indeed culling these contacts helps in some cases, but has been seen to lead to contact force flickering in some cases.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to remove separated speculative contacts during constrained dynamics solves.
  * This behavior is enabled by default and can be configured through the dynamics settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->