### PR TITLE
Optimize linear texture conversion

### DIFF
--- a/changelog/+texture-conversion-8d3f6a2c.changed.md
+++ b/changelog/+texture-conversion-8d3f6a2c.changed.md
@@ -1,0 +1,1 @@
+Speed up linear `uint8` texture conversion and avoid redundant visual-material resolution during USD import. Pass `load_visual_materials=False` to `newton.usd.get_mesh()` when only geometry, normals, and UVs are needed.

--- a/changelog/+texture-conversion-8d3f6a2c.deprecated.md
+++ b/changelog/+texture-conversion-8d3f6a2c.deprecated.md
@@ -1,0 +1,1 @@
+Deprecate passing `newton.usd.get_mesh()` parameters positionally after the stable positional input `source`; migrate calls such as `get_mesh(prim, True)` to `get_mesh(prim, load_normals=True)`.

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1110,6 +1110,7 @@ def _get_mesh_from_source(
     preserve_facevarying_uvs: bool,
     compute_inertia: bool,
     apply_stage_units: bool,
+    load_visual_materials: bool,
 ) -> Mesh:
     """Load and merge mesh prims from a USD stage, path, URL, or prim subtree."""
     if Usd is None or UsdGeom is None:
@@ -1162,6 +1163,7 @@ def _get_mesh_from_source(
             vertex_splitting_angle_threshold_deg=vertex_splitting_angle_threshold_deg,
             preserve_facevarying_uvs=preserve_facevarying_uvs,
             compute_inertia=False,
+            load_visual_materials=load_visual_materials,
         )
         source_meshes.append(source_mesh)
         matrix = _relative_transform_matrix(prim, root, xform_cache)
@@ -1333,6 +1335,8 @@ def get_mesh(
     root_path: str | None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
+    *,
+    load_visual_materials: bool = True,
 ) -> Mesh: ...
 
 
@@ -1351,6 +1355,8 @@ def get_mesh(
     root_path: None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
+    *,
+    load_visual_materials: bool = True,
 ) -> tuple[Mesh, np.ndarray | None]: ...
 
 
@@ -1371,6 +1377,7 @@ def get_mesh(
     apply_stage_units: bool = True,
     *,
     prim: Usd.Prim,
+    load_visual_materials: bool = True,
 ) -> Mesh: ...
 
 
@@ -1391,6 +1398,7 @@ def get_mesh(
     apply_stage_units: bool = True,
     *,
     prim: Usd.Prim,
+    load_visual_materials: bool = True,
 ) -> tuple[Mesh, np.ndarray | None]: ...
 
 
@@ -1410,6 +1418,7 @@ def get_mesh(
     apply_stage_units: bool = True,
     *,
     prim: Usd.Prim | None = None,
+    load_visual_materials: bool = True,
 ) -> Mesh | tuple[Mesh, np.ndarray | None]:
     """
     Load a triangle mesh from a USD mesh prim, stage, file path, or URL.
@@ -1484,6 +1493,11 @@ def get_mesh(
             non-mesh prim sources from authored USD distance units to meters.
             Single mesh prim sources keep their authored coordinates for
             backward compatibility unless ``root_path`` is provided.
+        load_visual_materials: If True, resolve and attach the bound visual
+            material's color, texture, metallic, and roughness. Set to False
+            when only mesh geometry is needed. If ``load_uvs`` is True, the
+            material's shader network may still be inspected to select the UV
+            primvar used by the texture.
 
     Returns:
         newton.Mesh: The loaded mesh, or ``(mesh, uv_indices)`` if
@@ -1520,6 +1534,7 @@ def get_mesh(
             preserve_facevarying_uvs=preserve_facevarying_uvs,
             compute_inertia=compute_inertia,
             apply_stage_units=apply_stage_units,
+            load_visual_materials=load_visual_materials,
         )
 
     if Usd is not None and isinstance(source, Usd.Prim):
@@ -1719,7 +1734,7 @@ def get_mesh(
     if return_uv_indices and uvs is not None and uv_indices is None:
         uv_indices = faces.reshape(-1)
 
-    material_props = resolve_material_properties_for_prim(prim)
+    material_props = resolve_material_properties_for_prim(prim) if load_visual_materials else {}
 
     mesh_out = Mesh(
         points,

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -17,6 +17,7 @@ from ..core.types import Axis, AxisType
 from ..geometry import Gaussian, Mesh
 from ..sim.model import Model
 from ..utils.color import color_linear_to_srgb
+from ..utils.deprecation import deprecate_nonkeyword_arguments
 from ..utils.import_usd_deformable_utils import _validate_mass_array, _warn_geometry_authored_material_attrs
 from ..utils.texture import linear_texture_to_srgb, load_texture
 
@@ -1323,6 +1324,7 @@ def _find_uv_primvar(prim: Usd.Prim):
 @overload
 def get_mesh(
     source: Usd.Prim | Usd.Stage | str | os.PathLike[str],
+    *,
     load_normals: bool = False,
     load_uvs: bool = False,
     maxhullvert: int | None = None,
@@ -1335,7 +1337,6 @@ def get_mesh(
     root_path: str | None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
-    *,
     load_visual_materials: bool = True,
 ) -> Mesh: ...
 
@@ -1343,6 +1344,7 @@ def get_mesh(
 @overload
 def get_mesh(
     source: Usd.Prim,
+    *,
     load_normals: bool = False,
     load_uvs: bool = False,
     maxhullvert: int | None = None,
@@ -1355,7 +1357,6 @@ def get_mesh(
     root_path: None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
-    *,
     load_visual_materials: bool = True,
 ) -> tuple[Mesh, np.ndarray | None]: ...
 
@@ -1363,6 +1364,7 @@ def get_mesh(
 @overload
 def get_mesh(
     source: None = None,
+    *,
     load_normals: bool = False,
     load_uvs: bool = False,
     maxhullvert: int | None = None,
@@ -1375,7 +1377,6 @@ def get_mesh(
     root_path: str | None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
-    *,
     prim: Usd.Prim,
     load_visual_materials: bool = True,
 ) -> Mesh: ...
@@ -1384,6 +1385,7 @@ def get_mesh(
 @overload
 def get_mesh(
     source: None = None,
+    *,
     load_normals: bool = False,
     load_uvs: bool = False,
     maxhullvert: int | None = None,
@@ -1396,14 +1398,15 @@ def get_mesh(
     root_path: None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
-    *,
     prim: Usd.Prim,
     load_visual_materials: bool = True,
 ) -> tuple[Mesh, np.ndarray | None]: ...
 
 
+@deprecate_nonkeyword_arguments
 def get_mesh(
     source: Usd.Prim | Usd.Stage | str | os.PathLike[str] | None = None,
+    *,
     load_normals: bool = False,
     load_uvs: bool = False,
     maxhullvert: int | None = None,
@@ -1416,7 +1419,6 @@ def get_mesh(
     root_path: str | None = None,
     compute_inertia: bool = True,
     apply_stage_units: bool = True,
-    *,
     prim: Usd.Prim | None = None,
     load_visual_materials: bool = True,
 ) -> Mesh | tuple[Mesh, np.ndarray | None]:

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1493,11 +1493,16 @@ def get_mesh(
             non-mesh prim sources from authored USD distance units to meters.
             Single mesh prim sources keep their authored coordinates for
             backward compatibility unless ``root_path`` is provided.
-        load_visual_materials: If True, resolve and attach the bound visual
-            material's color, texture, metallic, and roughness. Set to False
-            when only mesh geometry is needed. If ``load_uvs`` is True, the
-            material's shader network may still be inspected to select the UV
-            primvar used by the texture.
+        load_visual_materials: If True, resolve the mesh's visual material and
+            populate :attr:`newton.Mesh.color`, :attr:`newton.Mesh.texture`,
+            :attr:`newton.Mesh.metallic`, and :attr:`newton.Mesh.roughness`.
+            Resolution also covers materials bound through an instance
+            prototype or a ``UsdGeom.Subset`` child, and the ``displayColor``
+            primvar fallback. If False, those attributes keep their
+            :class:`newton.Mesh` defaults; set it to False when only mesh
+            geometry is needed. If ``load_uvs`` is True, the material's shader
+            network may still be inspected to select the UV primvar used by
+            the texture.
 
     Returns:
         newton.Mesh: The loaded mesh, or ``(mesh, uv_indices)`` if

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -773,7 +773,12 @@ def parse_usd(
             if cached_key != key and cached_key in mesh_cache:
                 return mesh_cache[cached_key]
 
-        mesh = usd.get_mesh(prim, load_uvs=load_uvs, load_normals=load_normals)
+        mesh = usd.get_mesh(
+            prim,
+            load_uvs=load_uvs,
+            load_normals=load_normals,
+            load_visual_materials=False,
+        )
         mesh_cache[key] = mesh
         return mesh
 
@@ -4013,7 +4018,16 @@ def parse_usd(
                         # as visual-only mesh imports.
                         mesh = _get_mesh_with_visual_material(prim, path_name=path)
                     else:
+                        # Not viewport-drawn, but the viewer still draws these under show_collision /
+                        # show_static. Mutating the shared cache entry is safe: both caches key on the
+                        # prim path, so every consumer resolves the same values.
                         mesh = _get_mesh_cached(prim)
+                        if material_props.get("texture") is not None:
+                            mesh.texture = material_props["texture"]
+                        if material_props.get("roughness") is not None:
+                            mesh.roughness = material_props["roughness"]
+                        if material_props.get("metallic") is not None:
+                            mesh.metallic = material_props["metallic"]
                     mesh.maxhullvert = R.get_value(
                         prim,
                         prim_type=PrimType.SHAPE,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4024,6 +4024,9 @@ def parse_usd(
                         mesh = _get_mesh_cached(prim)
                         if material_props.get("texture") is not None:
                             mesh.texture = material_props["texture"]
+                            # A textured material resolves no scalar color, so add_shape()
+                            # would otherwise fall back to its palette and tint the texture.
+                            mesh.color = (1.0, 1.0, 1.0)
                         if material_props.get("roughness") is not None:
                             mesh.roughness = material_props["roughness"]
                         if material_props.get("metallic") is not None:

--- a/newton/_src/utils/texture.py
+++ b/newton/_src/utils/texture.py
@@ -14,6 +14,21 @@ import numpy as np
 _texture_url_cache: dict[str, bytes] = {}
 
 
+def _linear_to_srgb(linear: np.ndarray) -> np.ndarray:
+    return np.where(linear <= 0.0031308, linear * 12.92, 1.055 * np.power(linear, 1.0 / 2.4) - 0.055)
+
+
+def _make_linear_to_srgb_uint8_lut() -> np.ndarray:
+    linear = np.arange(256, dtype=np.float32) / 255.0
+    srgb = _linear_to_srgb(linear)
+    lut = np.clip(np.round(srgb * 255.0), 0.0, 255.0).astype(np.uint8)
+    lut.setflags(write=False)
+    return lut
+
+
+_LINEAR_TO_SRGB_UINT8_LUT = _make_linear_to_srgb_uint8_lut()
+
+
 def _is_http_url(path: str) -> bool:
     parsed = urlparse(path)
     return parsed.scheme in ("http", "https")
@@ -146,16 +161,22 @@ def linear_texture_to_srgb(texture_image: np.ndarray | None) -> np.ndarray | Non
         return np.ascontiguousarray(image)
 
     out = image.copy()
+    if out.dtype == np.uint8:
+        # One channel at a time: a 3-channel fancy index triples the gathered temporary.
+        for channel in range(3):
+            out[..., channel] = _LINEAR_TO_SRGB_UINT8_LUT[out[..., channel]]
+        return np.ascontiguousarray(out)
+
     if np.issubdtype(out.dtype, np.integer):
         scale = float(np.iinfo(out.dtype).max)
         rgb = np.clip(out[..., :3].astype(np.float32) / scale, 0.0, 1.0)
-        srgb = np.where(rgb <= 0.0031308, rgb * 12.92, 1.055 * np.power(rgb, 1.0 / 2.4) - 0.055)
+        srgb = _linear_to_srgb(rgb)
         out[..., :3] = np.clip(np.round(srgb * scale), 0.0, scale).astype(out.dtype)
         return np.ascontiguousarray(out)
 
     out = out.astype(np.float32, copy=False)
     rgb = np.clip(out[..., :3], 0.0, 1.0)
-    out[..., :3] = np.where(rgb <= 0.0031308, rgb * 12.92, 1.055 * np.power(rgb, 1.0 / 2.4) - 0.055)
+    out[..., :3] = _linear_to_srgb(rgb)
     return np.ascontiguousarray(out.astype(image.dtype, copy=False))
 
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -12474,8 +12474,8 @@ def Xform "Body" (
         render_mesh = newton.Mesh(base_vertices * 4.0, indices)
         render_mesh._uvs = np.zeros((render_mesh.vertices.shape[0], 2), dtype=np.float32)
 
-        def _mock_get_mesh(_prim, *, load_uvs=False, load_normals=False):
-            del load_normals
+        def _mock_get_mesh(_prim, *, load_uvs=False, load_normals=False, load_visual_materials=True):
+            del load_normals, load_visual_materials
             return render_mesh if load_uvs else physics_mesh
 
         with (
@@ -13881,6 +13881,7 @@ def Mesh "cube"
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_get_mesh_converts_linear_texture_to_display_space(self):
+        """Decode a ``raw``-color-space texture and convert its RGB to sRGB, leaving alpha unchanged."""
         from PIL import Image
 
         source_rgba = np.array([[[64, 128, 255, 200]]], dtype=np.uint8)
@@ -13905,6 +13906,7 @@ def Mesh "cube"
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_get_mesh_leaves_display_texture_paths_lazy(self):
+        """Keep an ``sRGB``-color-space texture as an unresolved path instead of decoding it."""
         _stage, prim = self._create_stage_with_texture("display.png", source_color_space="sRGB")
 
         mesh = usd.get_mesh(prim)

--- a/newton/tests/test_texture.py
+++ b/newton/tests/test_texture.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for texture loading, including assets packaged inside USD (.usdz) archives."""
+"""Tests for texture loading, assets packaged inside USD (.usdz) archives, and linear-to-sRGB conversion."""
 
 import importlib.util
 import tempfile
@@ -10,10 +10,38 @@ from pathlib import Path
 
 import numpy as np
 
-from newton._src.utils.texture import load_texture
+from newton._src.utils.texture import linear_texture_to_srgb, load_texture
 from newton.tests.unittest_utils import USD_AVAILABLE
 
 _PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None
+
+
+class TestLinearTextureToSrgb(unittest.TestCase):
+    def test_uint8_lut_matches_reference_bit_exactly(self):
+        """Match the reference conversion bit-for-bit for every uint8 value."""
+        values = np.arange(256, dtype=np.uint8)
+        image = np.empty((1, 256, 4), dtype=np.uint8)
+        # Offset each channel so a wrong-channel LUT index is detectable; each still spans all 256 values.
+        for channel in range(3):
+            image[0, :, channel] = np.roll(values, channel * 64)
+        image[..., 3] = values[::-1]
+        original = image.copy()
+
+        converted = linear_texture_to_srgb(image)
+
+        expected = original.copy()
+        linear_rgb = np.clip(original[..., :3].astype(np.float32) / 255.0, 0.0, 1.0)
+        expected_rgb = np.where(
+            linear_rgb <= 0.0031308,
+            linear_rgb * 12.92,
+            1.055 * np.power(linear_rgb, 1.0 / 2.4) - 0.055,
+        )
+        expected[..., :3] = np.clip(np.round(expected_rgb * 255.0), 0.0, 255.0).astype(np.uint8)
+        np.testing.assert_array_equal(converted, expected)
+        np.testing.assert_array_equal(image, original)
+        self.assertTrue(converted.flags.c_contiguous)
+        # The shared LUT is read-only; the returned image must not inherit that flag.
+        self.assertTrue(converted.flags.writable)
 
 
 def _write_png(path: Path, color: tuple[int, int, int]) -> None:

--- a/newton/tests/test_texture.py
+++ b/newton/tests/test_texture.py
@@ -40,8 +40,8 @@ class TestLinearTextureToSrgb(unittest.TestCase):
         np.testing.assert_array_equal(converted, expected)
         np.testing.assert_array_equal(image, original)
         self.assertTrue(converted.flags.c_contiguous)
-        # The shared LUT is read-only; the returned image must not inherit that flag.
-        self.assertTrue(converted.flags.writable)
+        # The shared LUT is read-only; the result must not inherit that. "W" is NumPy's short key for the write flag.
+        self.assertTrue(converted.flags["W"])
 
 
 def _write_png(path: Path, color: tuple[int, int, int]) -> None:


### PR DESCRIPTION
## Description

Speeds up USD texture import in two independent ways.

**Linear→sRGB conversion for `uint8` textures.** `linear_texture_to_srgb()` evaluated
`np.power()` over every pixel. Since `uint8` has only 256 distinct inputs, the transfer
function is now precomputed into a 256-entry lookup table and applied per channel. The
LUT is built with the same float32 arithmetic the general integer path uses, so results
are bit-identical to before — verified exhaustively over all 256 values.

`uint8` RGBA is the only form that reaches this function in practice: it is called from
`_resolve_color_texture_asset()`, whose input always comes from `load_texture()` →
PIL `.convert("RGBA")`. The general integer and float paths are unchanged.

**Redundant visual-material resolution during import.** `get_mesh()` unconditionally
called `resolve_material_properties_for_prim()`, which for a linear-space texture
eagerly decodes the image and converts it. `parse_usd()` already resolves and memoizes
the same material itself via `_get_material_props_cached()`, so this work was performed
twice per mesh prim — once uncached. A new `load_visual_materials` keyword lets callers
skip it, and `parse_usd()` now passes `False`.

Colliders that are not viewport-drawn still reach the viewer through its
`show_collision` / `show_static` overlays, so `parse_usd()` re-attaches `texture`,
`roughness`, and `metallic` on that path. Display color was already passed separately
via `shape_params["color"]` and is unaffected.


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->
```
uv run --extra dev -m newton.tests -k test_texture
uv run --extra dev -m newton.tests -k test_import_usd
uv run --extra dev -m newton.tests -k test_usd_mesh_loading
```

Results on the startup time for the Anymal D example:

- Takes `add_usd` from 138.3 ms to to 119.7 ms (-13.5%)
- Takes the time to first physics step from 1238.9 ms to 1219.1 ms (-1.6%)

## New feature / API change

```python
import newton

# Skip resolving and decoding the bound visual material when only geometry is needed.
mesh = newton.usd.get_mesh(prim, load_uvs=True, load_visual_materials=False)

assert mesh.texture is None and mesh.color is None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - USD mesh loading can skip visual-material processing when only geometry data is needed, improving import efficiency.
  - Displayed collision meshes retain available texture and physically based material properties.
  - Faster, consistent linear-to-sRGB conversion for 8-bit textures.

- **Bug Fixes**
  - Preserved texture channels, alpha data, and writable output during conversion.

- **Documentation**
  - Added guidance to use keyword arguments for USD mesh-loading options.

- **Tests**
  - Added coverage for exact 8-bit texture conversion and USD material-loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->