### PR TITLE
Add MuJoCo model authoring helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,9 @@
 - Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems. (#3996)
 - Keep ViewerGL depth, shading, and shadows stable for very large meshes when the camera moves. ([#3977](https://github.com/newton-physics/newton/issues/3977))
 - Resolve deep heightfield contacts against the cell's physical surface instead of the volume the cell is extruded into, which reported about a metre of penetration with a normal pointing into the terrain once a collider's center passed below the surface.
+### Added
+
+- Import MuJoCo DC-motor actuators from MJCF and compiled `MjcActuator` USD for `SolverMuJoCo`. (#3950)
 
 ## [1.5.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,9 +169,6 @@
 - Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems. (#3996)
 - Keep ViewerGL depth, shading, and shadows stable for very large meshes when the camera moves. ([#3977](https://github.com/newton-physics/newton/issues/3977))
 - Resolve deep heightfield contacts against the cell's physical surface instead of the volume the cell is extruded into, which reported about a metre of penetration with a normal pointing into the terrain once a collider's center passed below the surface.
-### Added
-
-- Import MuJoCo DC-motor actuators from MJCF and compiled `MjcActuator` USD for `SolverMuJoCo`. (#3950)
 
 ## [1.5.0] - 2026-08-11
 

--- a/changelog/+mujoco-authoring-helpers-a4c7e2d9.added.md
+++ b/changelog/+mujoco-authoring-helpers-a4c7e2d9.added.md
@@ -1,0 +1,1 @@
+Add `newton.solvers.mujoco` helpers for programmatically authoring MuJoCo actuators, contact pairs, tendons, and equality constraints.

--- a/changelog/+mujoco-dcmotor-input-3b15f6a2.fixed.md
+++ b/changelog/+mujoco-dcmotor-input-3b15f6a2.fixed.md
@@ -1,0 +1,1 @@
+Preserve DC-motor voltage, position, and velocity input modes when creating actuators with MuJoCo 3.12.

--- a/changelog/3950.added.md
+++ b/changelog/3950.added.md
@@ -1,0 +1,1 @@
+Import MuJoCo DC-motor actuators from MJCF and compiled `MjcActuator` USD for `SolverMuJoCo`.

--- a/changelog/3950.fixed.md
+++ b/changelog/3950.fixed.md
@@ -1,0 +1,1 @@
+Align MuJoCo actuator dynamics, gain, and bias enum values with MuJoCo 3.12, including the DC-motor, SO3, and PID slots, so user-defined actuators are not misclassified.

--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -21,11 +21,13 @@ https://newton-physics.github.io/newton/stable/solvers/index.html.
    :hidden:
 
    newton_solvers_experimental
+   newton_solvers_mujoco
    newton_solvers_style3d
 
 .. rubric:: Submodules
 
 - :doc:`newton.solvers.experimental <newton_solvers_experimental>`
+- :doc:`newton.solvers.mujoco <newton_solvers_mujoco>`
 - :doc:`newton.solvers.style3d <newton_solvers_style3d>`
 
 .. rubric:: Classes

--- a/docs/api/newton_solvers_mujoco.rst
+++ b/docs/api/newton_solvers_mujoco.rst
@@ -1,0 +1,66 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+.. SPDX-License-Identifier: CC-BY-4.0
+
+newton.solvers.mujoco
+=====================
+
+MuJoCo solver and programmatic model-authoring helpers.
+
+Use :class:`~newton.solvers.SolverMuJoCo` as the solver class. The module-level
+helpers create MuJoCo-specific actuators, tendons, contact pairs, and equality
+constraints on a :class:`~newton.ModelBuilder` without exposing custom-frequency
+storage details.
+
+Example::
+
+    from newton.solvers import mujoco
+
+    actuator = mujoco.add_actuator_dcmotor(
+        builder,
+        target=mujoco.ActuatorTarget.joint(joint),
+        motorconst=(0.05, 0.05),
+        resistance=2.0,
+    )
+
+.. note::
+
+   This page documents helper functions exposed through the ``newton.solvers.mujoco`` attribute.
+   Because ``newton.solvers`` is a module rather than a package, use
+   ``from newton.solvers import mujoco`` instead of ``import newton.solvers.mujoco``.
+
+.. currentmodule:: newton._src.solvers.mujoco
+
+.. rubric:: Classes
+
+.. autoclass:: ActuatorTarget
+
+.. autoclass:: TendonWrapGeom
+
+.. autoclass:: TendonWrapPulley
+
+.. autoclass:: TendonWrapSite
+
+
+.. rubric:: Functions
+
+.. autofunction:: add_actuator_dcmotor
+
+.. autofunction:: add_actuator_general
+
+.. autofunction:: add_actuator_motor
+
+.. autofunction:: add_actuator_position
+
+.. autofunction:: add_actuator_velocity
+
+.. autofunction:: add_contact_pair
+
+.. autofunction:: add_equality_connect
+
+.. autofunction:: add_equality_joint
+
+.. autofunction:: add_equality_weld
+
+.. autofunction:: add_tendon_fixed
+
+.. autofunction:: add_tendon_spatial

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1225,6 +1225,15 @@ class ModelBuilder:
         urdf_value_transformer: Callable[[str, dict[str, Any] | None], Any] | None = None
         """Transformer function that converts a URDF attribute value string to a valid Warp dtype. If undefined, the generic converter from :func:`newton.utils.parse_warp_value_from_string` is used. Receives an optional context dict with parsing-time information."""
 
+        reference_value_transformer: Callable[[Any, dict[str, Any]], Any] | None = None
+        """Transformer for entity references copied by :meth:`ModelBuilder.add_builder`.
+
+        Use this instead of :attr:`references` when the referenced entity type depends on
+        other values in the same row. The callback receives the value and a context with
+        ``builder`` (the source builder), ``destination_builder``, ``entity_offsets``,
+        ``custom_frequency_offsets``, ``row_index``, ``world``, and ``label_prefix``.
+        """
+
         def __post_init__(self):
             """Initialize default values and validate dtype compatibility."""
             # Allow str dtype for string attributes (stored as Python lists, not warp arrays)
@@ -2126,6 +2135,7 @@ class ModelBuilder:
             and existing.assignment == incoming.assignment
             and existing.namespace == incoming.namespace
             and existing.references == incoming.references
+            and existing.reference_value_transformer is incoming.reference_value_transformer
         )
 
     @staticmethod
@@ -4753,8 +4763,13 @@ class ModelBuilder:
             value_offset = 0 if use_current_world else get_offset(attr.references)
             is_equality_target_attr = full_key == "mujoco:equality_constraint_target"
             is_collision_mask_domain_attr = full_key == collision_mask_domain_key and bool(collision_mask_domain_remap)
+            has_reference_value_transformer = attr.reference_value_transformer is not None
             needs_remap = (
-                value_offset != 0 or use_current_world or is_equality_target_attr or is_collision_mask_domain_attr
+                value_offset != 0
+                or use_current_world
+                or is_equality_target_attr
+                or is_collision_mask_domain_attr
+                or has_reference_value_transformer
             )
 
             if needs_remap:
@@ -4812,7 +4827,22 @@ class ModelBuilder:
                     value: Any,
                     is_equality_target: bool = is_equality_target_attr,
                     is_collision_mask_domain: bool = is_collision_mask_domain_attr,
+                    reference_value_transformer: Callable[[Any, dict[str, Any]], Any]
+                    | None = attr.reference_value_transformer,
                 ) -> Any:
+                    if reference_value_transformer is not None:
+                        return reference_value_transformer(
+                            value,
+                            {
+                                "builder": builder,
+                                "destination_builder": self,
+                                "entity_offsets": entity_offsets,
+                                "custom_frequency_offsets": custom_frequency_offsets,
+                                "row_index": entity_idx,
+                                "world": world,
+                                "label_prefix": label_prefix,
+                            },
+                        )
                     if is_equality_target:
                         return transform_equality_target_value(entity_idx, value)
                     if is_collision_mask_domain:

--- a/newton/_src/solvers/__init__.py
+++ b/newton/_src/solvers/__init__.py
@@ -5,7 +5,7 @@ import importlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from . import style3d
+    from . import mujoco, style3d
     from .featherstone import SolverFeatherstone
     from .implicit_mpm import SolverImplicitMPM
     from .kamino import SolverKamino
@@ -26,6 +26,7 @@ __all__ = [
     "SolverStyle3D",
     "SolverVBD",
     "SolverXPBD",
+    "mujoco",
     "style3d",
 ]
 
@@ -43,6 +44,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "SolverStyle3D": (".style3d.solver_style3d", "SolverStyle3D"),
     "SolverVBD": (".vbd", "SolverVBD"),
     "SolverXPBD": (".xpbd", "SolverXPBD"),
+    "mujoco": (".mujoco", None),
     "style3d": (".style3d", None),
 }
 

--- a/newton/_src/solvers/mujoco/__init__.py
+++ b/newton/_src/solvers/mujoco/__init__.py
@@ -1,8 +1,59 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+"""MuJoCo solver and programmatic model-authoring helpers.
+
+Use :class:`~newton.solvers.SolverMuJoCo` as the solver class. The module-level
+helpers create MuJoCo-specific actuators, tendons, contact pairs, and equality
+constraints on a :class:`~newton.ModelBuilder` without exposing custom-frequency
+storage details.
+
+Example::
+
+    from newton.solvers import mujoco
+
+    actuator = mujoco.add_actuator_dcmotor(
+        builder,
+        target=mujoco.ActuatorTarget.joint(joint),
+        motorconst=(0.05, 0.05),
+        resistance=2.0,
+    )
+"""
+
+from .actuators import (
+    ActuatorTarget,
+    add_actuator_dcmotor,
+    add_actuator_general,
+    add_actuator_motor,
+    add_actuator_position,
+    add_actuator_velocity,
+)
+from .contacts import add_contact_pair
+from .equality import add_equality_connect, add_equality_joint, add_equality_weld
 from .solver_mujoco import SolverMuJoCo
+from .tendons import (
+    TendonWrapGeom,
+    TendonWrapPulley,
+    TendonWrapSite,
+    add_tendon_fixed,
+    add_tendon_spatial,
+)
 
 __all__ = [
+    "ActuatorTarget",
     "SolverMuJoCo",
+    "TendonWrapGeom",
+    "TendonWrapPulley",
+    "TendonWrapSite",
+    "add_actuator_dcmotor",
+    "add_actuator_general",
+    "add_actuator_motor",
+    "add_actuator_position",
+    "add_actuator_velocity",
+    "add_contact_pair",
+    "add_equality_connect",
+    "add_equality_joint",
+    "add_equality_weld",
+    "add_tendon_fixed",
+    "add_tendon_spatial",
 ]

--- a/newton/_src/solvers/mujoco/_authoring.py
+++ b/newton/_src/solvers/mujoco/_authoring.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared implementation helpers for MuJoCo model authoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...sim import ModelBuilder
+
+
+def _ensure_mujoco_attributes(builder: ModelBuilder, sentinel: str) -> None:
+    """Register the MuJoCo schema when the requested domain is unavailable."""
+    if builder.has_custom_attribute(sentinel):
+        return
+
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    SolverMuJoCo.register_custom_attributes(builder)
+
+
+def _prepare_custom_frequency_row(
+    builder: ModelBuilder,
+    frequency: str,
+    values: dict[str, Any],
+    custom_attributes: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate and combine one solver-owned custom-frequency row."""
+    extras = custom_attributes or {}
+    overlap = values.keys() & extras.keys()
+    if overlap:
+        names = ", ".join(sorted(overlap))
+        raise ValueError(f"custom_attributes cannot override MuJoCo-managed values: {names}")
+
+    row = {**values, **extras}
+    for key in row:
+        attribute = builder.custom_attributes.get(key)
+        if attribute is None:
+            raise AttributeError(
+                f"Custom attribute '{key}' is not registered. Register it before adding a {frequency} row."
+            )
+        if attribute.frequency != frequency:
+            raise ValueError(
+                f"Custom attribute '{key}' uses frequency {attribute.frequency!r}, expected {frequency!r}."
+            )
+    return row
+
+
+def _add_custom_frequency_row(
+    builder: ModelBuilder,
+    frequency: str,
+    values: dict[str, Any],
+    *,
+    index_key: str,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Append one validated custom-frequency row and return its index."""
+    row = _prepare_custom_frequency_row(builder, frequency, values, custom_attributes)
+    return builder.add_custom_values(**row)[index_key]
+
+
+__all__ = []

--- a/newton/_src/solvers/mujoco/actuators.py
+++ b/newton/_src/solvers/mujoco/actuators.py
@@ -1,0 +1,734 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Programmatic authoring helpers for MuJoCo actuators."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import warp as wp
+
+from ...geometry import ShapeFlags
+from ...sim import ModelBuilder
+from ._authoring import _add_custom_frequency_row, _ensure_mujoco_attributes
+from .enums import _ActuatorBiasType, _ActuatorDynamicsType, _ActuatorGainType
+
+
+@dataclass(frozen=True)
+class ActuatorTarget:
+    """A typed MuJoCo actuator transmission target.
+
+    Construct targets with :meth:`joint`, :meth:`joint_dof`, :meth:`tendon`,
+    :meth:`site`, :meth:`body`, or :meth:`slider_crank`. The authoring helper
+    resolves the target to MuJoCo's heterogeneous ``trnid`` representation.
+    """
+
+    kind: str
+    """Transmission target kind."""
+
+    index: int
+    """Primary Newton entity index."""
+
+    secondary_index: int = -1
+    """Optional secondary Newton entity index."""
+
+    dof: int | None = None
+    """Local joint DOF, when :attr:`kind` is ``"joint"``."""
+
+    @classmethod
+    def joint(cls, joint: int, dof: int | None = None) -> ActuatorTarget:
+        """Target a Newton joint, optionally selecting one local DOF.
+
+        Args:
+            joint: Newton joint index.
+            dof: Local DOF within the joint. Required for multi-DOF joints.
+
+        Returns:
+            A typed joint target.
+        """
+        return cls("joint", int(joint), dof=None if dof is None else int(dof))
+
+    @classmethod
+    def joint_dof(cls, dof: int) -> ActuatorTarget:
+        """Target an absolute Newton joint-DOF index.
+
+        Args:
+            dof: Absolute Newton joint-DOF index.
+
+        Returns:
+            A typed joint-DOF target.
+        """
+        return cls("joint_dof", int(dof))
+
+    @classmethod
+    def tendon(cls, tendon: int) -> ActuatorTarget:
+        """Target a ``mujoco:tendon`` row.
+
+        Args:
+            tendon: Row index returned by :func:`add_tendon_fixed` or
+                :func:`add_tendon_spatial`.
+
+        Returns:
+            A typed tendon target.
+        """
+        return cls("tendon", int(tendon))
+
+    @classmethod
+    def site(cls, site: int, refsite: int | None = None) -> ActuatorTarget:
+        """Target a Newton site shape, optionally relative to another site.
+
+        Args:
+            site: Newton site-shape index.
+            refsite: Optional reference site-shape index.
+
+        Returns:
+            A typed site target.
+        """
+        return cls("site", int(site), -1 if refsite is None else int(refsite))
+
+    @classmethod
+    def body(cls, body: int) -> ActuatorTarget:
+        """Target a Newton body.
+
+        Args:
+            body: Newton body index.
+
+        Returns:
+            A typed body target.
+        """
+        return cls("body", int(body))
+
+    @classmethod
+    def slider_crank(cls, cranksite: int, slidersite: int) -> ActuatorTarget:
+        """Target the crank and slider sites of a slider-crank transmission.
+
+        Args:
+            cranksite: Newton crank site-shape index.
+            slidersite: Newton slider site-shape index.
+
+        Returns:
+            A typed slider-crank target.
+        """
+        return cls("slider_crank", int(cranksite), int(slidersite))
+
+
+def _validate_index(name: str, index: int, count: int) -> None:
+    if index < 0 or index >= count:
+        raise IndexError(f"{name} index {index} is outside [0, {count}).")
+
+
+def _validate_site(builder: ModelBuilder, site: int, name: str) -> None:
+    _validate_index(name, site, len(builder.shape_flags))
+    if not (int(builder.shape_flags[site]) & int(ShapeFlags.SITE)):
+        raise ValueError(f"{name} index {site} does not identify a Newton site.")
+
+
+def _resolve_target(builder: ModelBuilder, target: ActuatorTarget) -> tuple[int, wp.vec2i]:
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    if not isinstance(target, ActuatorTarget):
+        raise TypeError("target must be an ActuatorTarget.")
+
+    if target.kind == "joint":
+        _validate_index("joint", target.index, len(builder.joint_type))
+        linear_dofs, angular_dofs = builder.joint_dof_dim[target.index]
+        dof_count = linear_dofs + angular_dofs
+        if target.dof is None:
+            if dof_count != 1:
+                raise ValueError(
+                    f"Joint {target.index} has {dof_count} DOFs; specify the local dof in ActuatorTarget.joint()."
+                )
+            local_dof = 0
+        else:
+            local_dof = target.dof
+        _validate_index("joint dof", local_dof, dof_count)
+        dof = int(builder.joint_qd_start[target.index]) + local_dof
+        return int(SolverMuJoCo.TrnType.JOINT), wp.vec2i(dof, -1)
+
+    if target.kind == "joint_dof":
+        _validate_index("joint dof", target.index, len(builder.joint_qd))
+        return int(SolverMuJoCo.TrnType.JOINT), wp.vec2i(target.index, -1)
+
+    if target.kind == "tendon":
+        tendon_count = builder._custom_frequency_counts.get("mujoco:tendon", 0)
+        _validate_index("tendon", target.index, tendon_count)
+        return int(SolverMuJoCo.TrnType.TENDON), wp.vec2i(target.index, -1)
+
+    if target.kind == "site":
+        _validate_site(builder, target.index, "site")
+        if target.secondary_index >= 0:
+            _validate_site(builder, target.secondary_index, "refsite")
+        return int(SolverMuJoCo.TrnType.SITE), wp.vec2i(target.index, target.secondary_index)
+
+    if target.kind == "body":
+        _validate_index("body", target.index, len(builder.body_mass))
+        return int(SolverMuJoCo.TrnType.BODY), wp.vec2i(target.index, -1)
+
+    if target.kind == "slider_crank":
+        _validate_site(builder, target.index, "cranksite")
+        _validate_site(builder, target.secondary_index, "slidersite")
+        return int(SolverMuJoCo.TrnType.SLIDERCRANK), wp.vec2i(target.index, target.secondary_index)
+
+    raise ValueError(f"Unsupported actuator target kind {target.kind!r}.")
+
+
+def _vector(
+    builder: ModelBuilder,
+    key: str,
+    values: Sequence[float],
+    length: int,
+    *,
+    exact: bool = False,
+) -> Any:
+    components = [float(value) for value in values]
+    if (exact and len(components) != length) or len(components) > length:
+        requirement = "exactly" if exact else "at most"
+        raise ValueError(f"{key} requires {requirement} {length} values, got {len(components)}.")
+    components.extend([0.0] * (length - len(components)))
+    return builder.custom_attributes[key].dtype(*components)
+
+
+def _tristate(value: bool | int | str) -> int:
+    if isinstance(value, str):
+        try:
+            return {"false": 0, "true": 1, "auto": 2}[value.lower().strip()]
+        except KeyError as error:
+            raise ValueError(f"Expected false, true, or auto, got {value!r}.") from error
+    result = int(value)
+    if result not in (0, 1, 2):
+        raise ValueError(f"Expected a MuJoCo tri-state value in {{0, 1, 2}}, got {value!r}.")
+    return result
+
+
+def _enum_value(value: int | str, mapping: dict[str, int], name: str) -> int:
+    if isinstance(value, str):
+        try:
+            return mapping[value.lower().replace("_", "").strip()]
+        except KeyError as error:
+            choices = ", ".join(sorted(mapping))
+            raise ValueError(f"Unknown {name} {value!r}; expected one of {choices}.") from error
+    return int(value)
+
+
+def _dynamics_type(value: int | str) -> int:
+    return _enum_value(
+        value,
+        {
+            "none": int(_ActuatorDynamicsType.NONE),
+            "integrator": int(_ActuatorDynamicsType.INTEGRATOR),
+            "filter": int(_ActuatorDynamicsType.FILTER),
+            "filterexact": int(_ActuatorDynamicsType.FILTER_EXACT),
+            "muscle": int(_ActuatorDynamicsType.MUSCLE),
+            "dcmotor": int(_ActuatorDynamicsType.DCMOTOR),
+            "user": int(_ActuatorDynamicsType.USER),
+        },
+        "dyntype",
+    )
+
+
+def _gain_type(value: int | str) -> int:
+    return _enum_value(
+        value,
+        {
+            "fixed": int(_ActuatorGainType.FIXED),
+            "affine": int(_ActuatorGainType.AFFINE),
+            "muscle": int(_ActuatorGainType.MUSCLE),
+            "dcmotor": int(_ActuatorGainType.DCMOTOR),
+            "so3": int(_ActuatorGainType.SO3),
+            "user": int(_ActuatorGainType.USER),
+        },
+        "gaintype",
+    )
+
+
+def _bias_type(value: int | str) -> int:
+    return _enum_value(
+        value,
+        {
+            "none": int(_ActuatorBiasType.NONE),
+            "affine": int(_ActuatorBiasType.AFFINE),
+            "muscle": int(_ActuatorBiasType.MUSCLE),
+            "dcmotor": int(_ActuatorBiasType.DCMOTOR),
+            "so3": int(_ActuatorBiasType.SO3),
+            "user": int(_ActuatorBiasType.USER),
+        },
+        "biastype",
+    )
+
+
+def _input_mode(value: int | str) -> int:
+    return _enum_value(value, {"voltage": 0, "position": 1, "velocity": 2}, "DC-motor input mode")
+
+
+def _add_actuator(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    ctrl_type: int,
+    dyntype: int | str = "none",
+    gaintype: int | str = "fixed",
+    biastype: int | str = "none",
+    dynprm: Sequence[float] = (1.0,),
+    gainprm: Sequence[float] = (1.0,),
+    biasprm: Sequence[float] = (0.0,),
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    actrange: Sequence[float] | None = None,
+    actlimited: bool | int | str = "auto",
+    actdim: int | None = None,
+    actearly: bool = False,
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    specific_values: dict[str, Any] | None = None,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    _ensure_mujoco_attributes(builder, "mujoco:actuator_trnid")
+    trntype, trnid = _resolve_target(builder, target)
+    if trntype == int(SolverMuJoCo.TrnType.SLIDERCRANK):
+        if cranklength is None or cranklength <= 0.0:
+            raise ValueError("A slider-crank actuator requires a positive cranklength [m].")
+
+    values: dict[str, Any] = {
+        "mujoco:actuator_trnid": trnid,
+        "mujoco:actuator_target_label": "",
+        "mujoco:actuator_trntype": trntype,
+        "mujoco:actuator_dyntype": _dynamics_type(dyntype),
+        "mujoco:actuator_gaintype": _gain_type(gaintype),
+        "mujoco:actuator_biastype": _bias_type(biastype),
+        "mujoco:actuator_world": builder.current_world,
+        "mujoco:actuator_ctrllimited": _tristate(ctrllimited),
+        "mujoco:actuator_forcelimited": _tristate(forcelimited),
+        "mujoco:actuator_ctrlrange": _vector(
+            builder,
+            "mujoco:actuator_ctrlrange",
+            ctrlrange if ctrlrange is not None else (),
+            2,
+        ),
+        "mujoco:actuator_has_ctrlrange": int(ctrlrange is not None),
+        "mujoco:actuator_forcerange": _vector(
+            builder,
+            "mujoco:actuator_forcerange",
+            forcerange if forcerange is not None else (),
+            2,
+        ),
+        "mujoco:actuator_has_forcerange": int(forcerange is not None),
+        "mujoco:actuator_gear": _vector(builder, "mujoco:actuator_gear", gear, 6),
+        "mujoco:actuator_damping": float(damping),
+        "mujoco:actuator_armature": float(armature),
+        "mujoco:actuator_cranklength": 0.0 if cranklength is None else float(cranklength),
+        "mujoco:actuator_dynprm": _vector(builder, "mujoco:actuator_dynprm", dynprm, 10),
+        "mujoco:actuator_gainprm": _vector(builder, "mujoco:actuator_gainprm", gainprm, 10),
+        "mujoco:actuator_biasprm": _vector(builder, "mujoco:actuator_biasprm", biasprm, 10),
+        "mujoco:actuator_actlimited": _tristate(actlimited),
+        "mujoco:actuator_actrange": _vector(
+            builder,
+            "mujoco:actuator_actrange",
+            actrange if actrange is not None else (),
+            2,
+        ),
+        "mujoco:actuator_has_actrange": int(actrange is not None),
+        "mujoco:actuator_actdim": -1 if actdim is None else int(actdim),
+        "mujoco:actuator_actearly": bool(actearly),
+        "mujoco:ctrl": float(ctrl),
+        "mujoco:ctrl_source": int(SolverMuJoCo.CtrlSource.CTRL_DIRECT),
+        "mujoco:ctrl_type": int(ctrl_type),
+    }
+    if specific_values:
+        values.update(specific_values)
+
+    return _add_custom_frequency_row(
+        builder,
+        "mujoco:actuator",
+        values,
+        index_key="mujoco:actuator_trnid",
+        custom_attributes=custom_attributes,
+    )
+
+
+def add_actuator_general(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    dyntype: int | str = "none",
+    gaintype: int | str = "fixed",
+    biastype: int | str = "none",
+    dynprm: Sequence[float] = (1.0,),
+    gainprm: Sequence[float] = (1.0,),
+    biasprm: Sequence[float] = (0.0,),
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    actrange: Sequence[float] | None = None,
+    actlimited: bool | int | str = "auto",
+    actdim: int | None = None,
+    actearly: bool = False,
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo-native general actuator controlled through ``control.mujoco.ctrl``.
+
+    Args:
+        builder: Model builder receiving the actuator.
+        target: Typed actuator transmission target.
+        dyntype: MuJoCo activation dynamics type.
+        gaintype: MuJoCo gain type.
+        biastype: MuJoCo bias type.
+        dynprm: Activation dynamics parameters, padded to ten values.
+        gainprm: Gain parameters, padded to ten values.
+        biasprm: Bias parameters, padded to ten values.
+        gear: Transmission gear, padded to six values.
+        ctrlrange: Optional control range.
+        ctrllimited: Control-limit tri-state (false, true, or auto).
+        forcerange: Optional actuator force range [N or N·m].
+        forcelimited: Force-limit tri-state (false, true, or auto).
+        actrange: Optional activation-state range.
+        actlimited: Activation-limit tri-state (false, true, or auto).
+        actdim: Activation-state dimension, or ``None`` for automatic selection.
+        actearly: Whether force uses the next activation state.
+        cranklength: Slider-crank length [m]. Required for slider-crank targets.
+        damping: Actuator damping [N·s/m or N·m·s/rad].
+        armature: Actuator armature [kg or kg·m²].
+        ctrl: Initial MuJoCo control value.
+        custom_attributes: Additional registered ``mujoco:actuator`` attributes.
+
+    Returns:
+        The ``mujoco:actuator`` row index.
+    """
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    return _add_actuator(
+        builder,
+        target,
+        ctrl_type=int(SolverMuJoCo.CtrlType.GENERAL),
+        dyntype=dyntype,
+        gaintype=gaintype,
+        biastype=biastype,
+        dynprm=dynprm,
+        gainprm=gainprm,
+        biasprm=biasprm,
+        gear=gear,
+        ctrlrange=ctrlrange,
+        ctrllimited=ctrllimited,
+        forcerange=forcerange,
+        forcelimited=forcelimited,
+        actrange=actrange,
+        actlimited=actlimited,
+        actdim=actdim,
+        actearly=actearly,
+        cranklength=cranklength,
+        damping=damping,
+        armature=armature,
+        ctrl=ctrl,
+        custom_attributes=custom_attributes,
+    )
+
+
+def add_actuator_motor(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo motor shortcut controlled through ``control.mujoco.ctrl``.
+
+    Args:
+        builder: Model builder receiving the actuator.
+        target: Typed actuator transmission target.
+        gear: Transmission gear, padded to six values.
+        ctrlrange: Optional control range.
+        ctrllimited: Control-limit tri-state (false, true, or auto).
+        forcerange: Optional actuator force range [N or N·m].
+        forcelimited: Force-limit tri-state (false, true, or auto).
+        cranklength: Slider-crank length [m]. Required for slider-crank targets.
+        damping: Actuator damping [N·s/m or N·m·s/rad].
+        armature: Actuator armature [kg or kg·m²].
+        ctrl: Initial MuJoCo control value.
+        custom_attributes: Additional registered ``mujoco:actuator`` attributes.
+
+    Returns:
+        The ``mujoco:actuator`` row index.
+    """
+    return add_actuator_general(
+        builder,
+        target,
+        gainprm=(1.0,),
+        biasprm=(0.0,),
+        gear=gear,
+        ctrlrange=ctrlrange,
+        ctrllimited=ctrllimited,
+        forcerange=forcerange,
+        forcelimited=forcelimited,
+        cranklength=cranklength,
+        damping=damping,
+        armature=armature,
+        ctrl=ctrl,
+        custom_attributes=custom_attributes,
+    )
+
+
+def add_actuator_position(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    kp: float = 1.0,
+    kv: float = 0.0,
+    dampratio: float = 0.0,
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo position shortcut controlled through ``control.mujoco.ctrl``.
+
+    Args:
+        builder: Model builder receiving the actuator.
+        target: Typed actuator transmission target.
+        kp: Position feedback gain.
+        kv: Velocity feedback gain.
+        dampratio: Damping ratio used when ``kv`` is zero.
+        gear: Transmission gear, padded to six values.
+        ctrlrange: Optional control range.
+        ctrllimited: Control-limit tri-state (false, true, or auto).
+        forcerange: Optional actuator force range [N or N·m].
+        forcelimited: Force-limit tri-state (false, true, or auto).
+        cranklength: Slider-crank length [m]. Required for slider-crank targets.
+        damping: Actuator damping [N·s/m or N·m·s/rad].
+        armature: Actuator armature [kg or kg·m²].
+        ctrl: Initial MuJoCo control value.
+        custom_attributes: Additional registered ``mujoco:actuator`` attributes.
+
+    Returns:
+        The ``mujoco:actuator`` row index.
+    """
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    if kp <= 0.0:
+        raise ValueError("kp must be positive.")
+    if kv != 0.0 and dampratio != 0.0:
+        raise ValueError("Specify either kv or dampratio, not both.")
+    bias_damping = -float(kv) if kv != 0.0 else float(dampratio)
+    return _add_actuator(
+        builder,
+        target,
+        ctrl_type=int(SolverMuJoCo.CtrlType.POSITION),
+        gaintype="fixed",
+        biastype="affine",
+        gainprm=(kp,),
+        biasprm=(0.0, -kp, bias_damping),
+        gear=gear,
+        ctrlrange=ctrlrange,
+        ctrllimited=ctrllimited,
+        forcerange=forcerange,
+        forcelimited=forcelimited,
+        cranklength=cranklength,
+        damping=damping,
+        armature=armature,
+        ctrl=ctrl,
+        custom_attributes=custom_attributes,
+    )
+
+
+def add_actuator_velocity(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    kv: float = 1.0,
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo velocity shortcut controlled through ``control.mujoco.ctrl``.
+
+    Args:
+        builder: Model builder receiving the actuator.
+        target: Typed actuator transmission target.
+        kv: Velocity feedback gain.
+        gear: Transmission gear, padded to six values.
+        ctrlrange: Optional control range.
+        ctrllimited: Control-limit tri-state (false, true, or auto).
+        forcerange: Optional actuator force range [N or N·m].
+        forcelimited: Force-limit tri-state (false, true, or auto).
+        cranklength: Slider-crank length [m]. Required for slider-crank targets.
+        damping: Actuator damping [N·s/m or N·m·s/rad].
+        armature: Actuator armature [kg or kg·m²].
+        ctrl: Initial MuJoCo control value.
+        custom_attributes: Additional registered ``mujoco:actuator`` attributes.
+
+    Returns:
+        The ``mujoco:actuator`` row index.
+    """
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    if kv <= 0.0:
+        raise ValueError("kv must be positive.")
+    return _add_actuator(
+        builder,
+        target,
+        ctrl_type=int(SolverMuJoCo.CtrlType.VELOCITY),
+        gaintype="fixed",
+        biastype="affine",
+        gainprm=(kv,),
+        biasprm=(0.0, 0.0, -kv),
+        gear=gear,
+        ctrlrange=ctrlrange,
+        ctrllimited=ctrllimited,
+        forcerange=forcerange,
+        forcelimited=forcelimited,
+        cranklength=cranklength,
+        damping=damping,
+        armature=armature,
+        ctrl=ctrl,
+        custom_attributes=custom_attributes,
+    )
+
+
+def add_actuator_dcmotor(
+    builder: ModelBuilder,
+    target: ActuatorTarget,
+    *,
+    motorconst: Sequence[float] = (0.0, 0.0),
+    resistance: float = 0.0,
+    nominal: Sequence[float] = (0.0, 0.0, 0.0),
+    saturation: Sequence[float] = (0.0, 0.0, 0.0),
+    inductance: Sequence[float] = (0.0, 0.0),
+    cogging: Sequence[float] = (0.0, 0.0, 0.0),
+    controller: Sequence[float] = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    thermal: Sequence[float] = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    lugre: Sequence[float] = (0.0, 0.0, 0.0, 0.0, 0.0),
+    input_mode: int | str = "voltage",
+    gear: Sequence[float] = (1.0,),
+    ctrlrange: Sequence[float] | None = None,
+    ctrllimited: bool | int | str = "auto",
+    forcerange: Sequence[float] | None = None,
+    forcelimited: bool | int | str = "auto",
+    actrange: Sequence[float] | None = None,
+    actlimited: bool | int | str = "auto",
+    cranklength: float | None = None,
+    damping: float = 0.0,
+    armature: float = 0.0,
+    ctrl: float = 0.0,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo DC-motor shortcut controlled through ``control.mujoco.ctrl``.
+
+    The high-level values are preserved until :class:`SolverMuJoCo` builds its
+    native MuJoCo model, where ``MjsActuator.set_to_dcmotor()`` compiles them.
+
+    Args:
+        builder: Model builder receiving the actuator.
+        target: Typed actuator transmission target.
+        motorconst: Motor torque and back-EMF constants.
+        resistance: Terminal resistance [ohm].
+        nominal: Nominal voltage, current, and speed.
+        saturation: Current, voltage, and controller saturation values.
+        inductance: Inductance and current-loop bandwidth.
+        cogging: Cogging-friction parameters.
+        controller: Controller parameters.
+        thermal: Thermal-model parameters.
+        lugre: LuGre-friction parameters.
+        input_mode: ``"voltage"``, ``"position"``, ``"velocity"``, or its integer code.
+        gear: Transmission gear, padded to six values.
+        ctrlrange: Optional control range.
+        ctrllimited: Control-limit tri-state (false, true, or auto).
+        forcerange: Optional actuator force range [N or N·m].
+        forcelimited: Force-limit tri-state (false, true, or auto).
+        actrange: Optional activation-state range.
+        actlimited: Activation-limit tri-state (false, true, or auto).
+        cranklength: Slider-crank length [m]. Required for slider-crank targets.
+        damping: Actuator damping [N·s/m or N·m·s/rad].
+        armature: Actuator armature [kg or kg·m²].
+        ctrl: Initial MuJoCo control value.
+        custom_attributes: Additional registered ``mujoco:actuator`` attributes.
+
+    Returns:
+        The ``mujoco:actuator`` row index.
+    """
+    from .solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    _ensure_mujoco_attributes(builder, "mujoco:actuator_trnid")
+    SolverMuJoCo._register_dcmotor_custom_attributes(builder)
+    specific_values = {
+        "mujoco:actuator_dcmotor_motorconst": _vector(
+            builder, "mujoco:actuator_dcmotor_motorconst", motorconst, 2, exact=True
+        ),
+        "mujoco:actuator_dcmotor_resistance": float(resistance),
+        "mujoco:actuator_dcmotor_nominal": _vector(builder, "mujoco:actuator_dcmotor_nominal", nominal, 3, exact=True),
+        "mujoco:actuator_dcmotor_saturation": _vector(
+            builder, "mujoco:actuator_dcmotor_saturation", saturation, 3, exact=True
+        ),
+        "mujoco:actuator_dcmotor_inductance": _vector(
+            builder, "mujoco:actuator_dcmotor_inductance", inductance, 2, exact=True
+        ),
+        "mujoco:actuator_dcmotor_cogging": _vector(builder, "mujoco:actuator_dcmotor_cogging", cogging, 3, exact=True),
+        "mujoco:actuator_dcmotor_controller": _vector(
+            builder, "mujoco:actuator_dcmotor_controller", controller, 6, exact=True
+        ),
+        "mujoco:actuator_dcmotor_thermal": _vector(builder, "mujoco:actuator_dcmotor_thermal", thermal, 6, exact=True),
+        "mujoco:actuator_dcmotor_lugre": _vector(builder, "mujoco:actuator_dcmotor_lugre", lugre, 5, exact=True),
+        "mujoco:actuator_dcmotor_input": _input_mode(input_mode),
+    }
+    return _add_actuator(
+        builder,
+        target,
+        ctrl_type=int(SolverMuJoCo.CtrlType.DCMOTOR),
+        gear=gear,
+        ctrlrange=ctrlrange,
+        ctrllimited=ctrllimited,
+        forcerange=forcerange,
+        forcelimited=forcelimited,
+        actrange=actrange,
+        actlimited=actlimited,
+        cranklength=cranklength,
+        damping=damping,
+        armature=armature,
+        ctrl=ctrl,
+        specific_values=specific_values,
+        custom_attributes=custom_attributes,
+    )
+
+
+__all__ = [
+    "ActuatorTarget",
+    "add_actuator_dcmotor",
+    "add_actuator_general",
+    "add_actuator_motor",
+    "add_actuator_position",
+    "add_actuator_velocity",
+]

--- a/newton/_src/solvers/mujoco/contacts.py
+++ b/newton/_src/solvers/mujoco/contacts.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Programmatic authoring helpers for MuJoCo contact metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ...sim import ModelBuilder
+from ._authoring import _add_custom_frequency_row, _ensure_mujoco_attributes
+
+
+def _vector(builder: ModelBuilder, key: str, values: Sequence[float], length: int) -> Any:
+    components = [float(value) for value in values]
+    if len(components) != length:
+        raise ValueError(f"{key} requires exactly {length} values, got {len(components)}.")
+    return builder.custom_attributes[key].dtype(*components)
+
+
+def add_contact_pair(
+    builder: ModelBuilder,
+    shape0: int,
+    shape1: int,
+    *,
+    condim: int = 3,
+    solref: Sequence[float] = (0.02, 1.0),
+    solreffriction: Sequence[float] = (0.02, 1.0),
+    solimp: Sequence[float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+    margin: float = 0.0,
+    gap: float = 0.0,
+    friction: Sequence[float] = (1.0, 1.0, 0.005, 0.0001, 0.0001),
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add an explicit MuJoCo contact pair.
+
+    Args:
+        builder: Model builder receiving the pair.
+        shape0: First Newton shape index.
+        shape1: Second Newton shape index.
+        condim: MuJoCo contact dimensionality.
+        solref: Normal constraint reference parameters.
+        solreffriction: Friction constraint reference parameters.
+        solimp: Constraint impedance parameters.
+        margin: Contact inclusion margin [m].
+        gap: Inactive contact gap [m].
+        friction: Sliding, torsional, and rolling friction coefficients.
+        custom_attributes: Additional registered ``mujoco:pair`` attributes.
+
+    Returns:
+        The ``mujoco:pair`` row index.
+    """
+    _ensure_mujoco_attributes(builder, "mujoco:pair_geom1")
+    shape_count = len(builder.shape_body)
+    for name, shape in (("shape0", shape0), ("shape1", shape1)):
+        if shape < 0 or shape >= shape_count:
+            raise IndexError(f"{name} index {shape} is outside [0, {shape_count}).")
+    if shape0 == shape1:
+        raise ValueError("A MuJoCo contact pair requires two distinct shapes.")
+    if condim not in (1, 3, 4, 6):
+        raise ValueError("condim must be one of 1, 3, 4, or 6.")
+
+    values = {
+        "mujoco:pair_world": builder.current_world,
+        "mujoco:pair_geom1": int(shape0),
+        "mujoco:pair_geom2": int(shape1),
+        "mujoco:pair_condim": int(condim),
+        "mujoco:pair_solref": _vector(builder, "mujoco:pair_solref", solref, 2),
+        "mujoco:pair_solreffriction": _vector(builder, "mujoco:pair_solreffriction", solreffriction, 2),
+        "mujoco:pair_solimp": _vector(builder, "mujoco:pair_solimp", solimp, 5),
+        "mujoco:pair_margin": float(margin),
+        "mujoco:pair_gap": float(gap),
+        "mujoco:pair_friction": _vector(builder, "mujoco:pair_friction", friction, 5),
+    }
+    return _add_custom_frequency_row(
+        builder,
+        "mujoco:pair",
+        values,
+        index_key="mujoco:pair_geom1",
+        custom_attributes=custom_attributes,
+    )
+
+
+__all__ = ["add_contact_pair"]

--- a/newton/_src/solvers/mujoco/equality.py
+++ b/newton/_src/solvers/mujoco/equality.py
@@ -6,14 +6,14 @@
 attributes.
 
 Equality constraints are MuJoCo-specific concepts that live on the model under
-the ``mujoco`` namespace. The public lower-level path for users is
-:meth:`ModelBuilder.add_custom_values` with ``mujoco:equality_constraint_*``
-keys; this module provides convenience used internally by the MJCF/USD
-importers and by tests.
+the ``mujoco`` namespace. Public typed helpers append complete constraint rows;
+the lower-level :meth:`ModelBuilder.add_custom_values` path remains available
+for custom schemas.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
@@ -324,3 +324,191 @@ def _add_equality_constraint(
         )
 
     return constraint_idx
+
+
+def _validate_body(builder: ModelBuilder, body: int, name: str) -> None:
+    if body < -1 or body >= len(builder.body_mass):
+        raise IndexError(f"{name} index {body} is outside [-1, {len(builder.body_mass)}).")
+
+
+def _validate_joint(builder: ModelBuilder, joint: int, name: str) -> None:
+    if joint < 0 or joint >= len(builder.joint_type):
+        raise IndexError(f"{name} index {joint} is outside [0, {len(builder.joint_type)}).")
+    linear_dofs, angular_dofs = builder.joint_dof_dim[joint]
+    if linear_dofs + angular_dofs != 1:
+        raise ValueError(f"{name} index {joint} must identify a scalar joint.")
+
+
+def _ensure_equality_attributes(builder: ModelBuilder) -> None:
+    if not builder.has_custom_attribute("mujoco:equality_constraint_type"):
+        _register_equality_constraint_attributes(builder)
+
+
+def _equality_custom_attributes(
+    custom_attributes: dict[str, Any] | None,
+    solref: Sequence[float] | None,
+    solimp: Sequence[float] | None,
+) -> dict[str, Any] | None:
+    attributes = dict(custom_attributes or {})
+    if solref is not None:
+        if "mujoco:eq_solref" in attributes:
+            raise ValueError("solref and custom_attributes['mujoco:eq_solref'] cannot both be specified.")
+        values = [float(value) for value in solref]
+        if len(values) != 2:
+            raise ValueError(f"solref requires exactly 2 values, got {len(values)}.")
+        attributes["mujoco:eq_solref"] = wp.vec2(*values)
+    if solimp is not None:
+        if "mujoco:eq_solimp" in attributes:
+            raise ValueError("solimp and custom_attributes['mujoco:eq_solimp'] cannot both be specified.")
+        values = [float(value) for value in solimp]
+        if len(values) != 5:
+            raise ValueError(f"solimp requires exactly 5 values, got {len(values)}.")
+        attributes["mujoco:eq_solimp"] = vec5(*values)
+    return attributes or None
+
+
+def add_equality_connect(
+    builder: ModelBuilder,
+    body1: int,
+    body2: int = -1,
+    *,
+    anchor: Vec3 | None = None,
+    label: str | None = None,
+    enabled: bool = True,
+    solref: Sequence[float] | None = None,
+    solimp: Sequence[float] | None = None,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo connect equality between two bodies.
+
+    Args:
+        builder: Model builder receiving the constraint.
+        body1: First body index, or ``-1`` for the world.
+        body2: Second body index, or ``-1`` for the world.
+        anchor: Anchor point in the first body's frame [m].
+        label: Optional constraint label.
+        enabled: Whether the constraint is active.
+        solref: Optional MuJoCo constraint reference parameters.
+        solimp: Optional MuJoCo constraint impedance parameters.
+        custom_attributes: Additional registered equality-frequency attributes.
+
+    Returns:
+        The ``mujoco:equality_constraint`` row index.
+    """
+    _ensure_equality_attributes(builder)
+    _validate_body(builder, body1, "body1")
+    _validate_body(builder, body2, "body2")
+    if body1 < 0 and body2 < 0:
+        raise ValueError("A connect equality must reference at least one body.")
+    return _add_equality_constraint(
+        builder,
+        EqType.CONNECT,
+        body1=body1,
+        body2=body2,
+        anchor=anchor,
+        label=label,
+        enabled=enabled,
+        custom_attributes=_equality_custom_attributes(custom_attributes, solref, solimp),
+    )
+
+
+def add_equality_weld(
+    builder: ModelBuilder,
+    body1: int,
+    body2: int = -1,
+    *,
+    relpose: Transform | None = None,
+    torquescale: float = 1.0,
+    label: str | None = None,
+    enabled: bool = True,
+    solref: Sequence[float] | None = None,
+    solimp: Sequence[float] | None = None,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo weld equality between two bodies.
+
+    Args:
+        builder: Model builder receiving the constraint.
+        body1: First body index, or ``-1`` for the world.
+        body2: Second body index, or ``-1`` for the world.
+        relpose: Relative pose of the second body in the first body's frame.
+        torquescale: Angular residual length scale [m].
+        label: Optional constraint label.
+        enabled: Whether the constraint is active.
+        solref: Optional MuJoCo constraint reference parameters.
+        solimp: Optional MuJoCo constraint impedance parameters.
+        custom_attributes: Additional registered equality-frequency attributes.
+
+    Returns:
+        The ``mujoco:equality_constraint`` row index.
+    """
+    _ensure_equality_attributes(builder)
+    _validate_body(builder, body1, "body1")
+    _validate_body(builder, body2, "body2")
+    if body1 < 0 and body2 < 0:
+        raise ValueError("A weld equality must reference at least one body.")
+    return _add_equality_constraint(
+        builder,
+        EqType.WELD,
+        body1=body1,
+        body2=body2,
+        relpose=relpose,
+        torquescale=torquescale,
+        label=label,
+        enabled=enabled,
+        custom_attributes=_equality_custom_attributes(custom_attributes, solref, solimp),
+    )
+
+
+def add_equality_joint(
+    builder: ModelBuilder,
+    joint1: int,
+    joint2: int,
+    *,
+    polycoef: Sequence[float] = (0.0, 1.0),
+    label: str | None = None,
+    enabled: bool = True,
+    solref: Sequence[float] | None = None,
+    solimp: Sequence[float] | None = None,
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a MuJoCo polynomial equality between two scalar joints.
+
+    Args:
+        builder: Model builder receiving the constraint.
+        joint1: Dependent Newton joint index.
+        joint2: Reference Newton joint index.
+        polycoef: Up to five polynomial coefficients.
+        label: Optional constraint label.
+        enabled: Whether the constraint is active.
+        solref: Optional MuJoCo constraint reference parameters.
+        solimp: Optional MuJoCo constraint impedance parameters.
+        custom_attributes: Additional registered equality-frequency attributes.
+
+    Returns:
+        The ``mujoco:equality_constraint`` row index.
+    """
+    _ensure_equality_attributes(builder)
+    _validate_joint(builder, joint1, "joint1")
+    _validate_joint(builder, joint2, "joint2")
+    coefficients = [float(value) for value in polycoef]
+    if len(coefficients) > 5:
+        raise ValueError(f"polycoef accepts at most 5 values, got {len(coefficients)}.")
+    coefficients.extend([0.0] * (5 - len(coefficients)))
+    return _add_equality_constraint(
+        builder,
+        EqType.JOINT,
+        joint1=joint1,
+        joint2=joint2,
+        polycoef=coefficients,
+        label=label,
+        enabled=enabled,
+        custom_attributes=_equality_custom_attributes(custom_attributes, solref, solimp),
+    )
+
+
+__all__ = [
+    "add_equality_connect",
+    "add_equality_joint",
+    "add_equality_weld",
+]

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -1530,6 +1530,7 @@ def create_convert_mjw_contacts_to_newton_kernel():
 
 CTRL_SOURCE_JOINT_TARGET = wp.constant(0)
 CTRL_SOURCE_CTRL_DIRECT = wp.constant(1)
+CTRL_TYPE_DCMOTOR = wp.constant(3)
 
 
 @wp.func
@@ -2109,6 +2110,7 @@ def update_axis_properties_kernel(
 def update_actuator_properties_kernel(
     mjc_actuator_ctrl_source: wp.array[wp.int32],
     mjc_actuator_to_newton_actuator_idx: wp.array[wp.int32],
+    newton_actuator_ctrl_type: wp.array[wp.int32],
     newton_actuator_gainprm: wp.array[vec10],
     newton_actuator_biasprm: wp.array[vec10],
     newton_actuator_dynprm: wp.array[vec10],
@@ -2136,6 +2138,7 @@ def update_actuator_properties_kernel(
     Args:
         mjc_actuator_ctrl_source: 0=JOINT_TARGET, 1=CTRL_DIRECT
         mjc_actuator_to_newton_actuator_idx: Index into Newton's mujoco:actuator arrays
+        newton_actuator_ctrl_type: Intrinsic actuator shortcut type
         newton_actuator_gainprm: Newton's model.mujoco.actuator_gainprm
         newton_actuator_biasprm: Newton's model.mujoco.actuator_biasprm
         newton_actuator_dynprm: Newton's model.mujoco.actuator_dynprm
@@ -2157,6 +2160,11 @@ def update_actuator_properties_kernel(
     actuator_ctrlrange[world, actuator] = newton_actuator_ctrlrange[world_newton_idx]
 
     if source != CTRL_SOURCE_CTRL_DIRECT:
+        return
+
+    # High-level MJCF DC-motor rows keep placeholder general-actuator arrays;
+    # preserve the parameters compiled by MjsActuator.set_to_dcmotor().
+    if newton_actuator_ctrl_type[world_newton_idx] == CTRL_TYPE_DCMOTOR:
         return
 
     actuator_gain[world, actuator] = newton_actuator_gainprm[world_newton_idx]

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -131,6 +131,46 @@ AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
 
 
+def _remap_actuator_trnid(value: Any, context: dict[str, Any]) -> Any:
+    """Remap a heterogeneous MuJoCo actuator target during builder composition."""
+    if value is None:
+        return None
+
+    source_builder = context["builder"]
+    row_index = context["row_index"]
+    trntype_attr = source_builder.custom_attributes.get("mujoco:actuator_trntype")
+    if trntype_attr is None:
+        return value
+    trntype = trntype_attr.default
+    if trntype_attr.values and row_index < len(trntype_attr.values):
+        authored = trntype_attr.values[row_index]
+        if authored is not None:
+            trntype = authored
+
+    primary = int(value[0])
+    secondary = int(value[1])
+    entity_offsets = context["entity_offsets"]
+    custom_frequency_offsets = context["custom_frequency_offsets"]
+
+    def offset(index: int, amount: int) -> int:
+        return index + amount if index >= 0 else index
+
+    if int(trntype) in (int(SolverMuJoCo.TrnType.JOINT), int(SolverMuJoCo.TrnType.JOINT_IN_PARENT)):
+        primary = offset(primary, entity_offsets["joint_dof"])
+    elif int(trntype) == int(SolverMuJoCo.TrnType.TENDON):
+        primary = offset(primary, custom_frequency_offsets.get("mujoco:tendon", 0))
+    elif int(trntype) == int(SolverMuJoCo.TrnType.SITE):
+        primary = offset(primary, entity_offsets["shape"])
+        secondary = offset(secondary, entity_offsets["shape"])
+    elif int(trntype) == int(SolverMuJoCo.TrnType.BODY):
+        primary = offset(primary, entity_offsets["body"])
+    elif int(trntype) == int(SolverMuJoCo.TrnType.SLIDERCRANK):
+        primary = offset(primary, entity_offsets["shape"])
+        secondary = offset(secondary, entity_offsets["shape"])
+
+    return wp.vec2i(primary, secondary)
+
+
 def _required_specifier(package: str, requirements: Iterable[str]) -> str | None:
     pattern = re.compile(rf"^{re.escape(package)}(?=[<>=!~])([^;]+)")
     for requirement in requirements:
@@ -466,11 +506,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
           :attr:`~newton.JointTargetMode.POSITION_VELOCITY` mode, kd is handled by the separate velocity actuator.
         - :attr:`VELOCITY`: Maps from :attr:`~newton.Control.joint_target_qd`, syncs gains from :attr:`~newton.Model.joint_target_kd`
         - :attr:`GENERAL`: Used with :attr:`~newton.solvers.SolverMuJoCo.CtrlSource.CTRL_DIRECT` mode for motor/general actuators
+        - :attr:`DCMOTOR`: Recreates the MuJoCo ``dcmotor`` shortcut from its high-level MJCF parameters
         """
 
         POSITION = 0
         VELOCITY = 1
         GENERAL = 2
+        DCMOTOR = 3
 
     class TrnType(IntEnum):
         """Transmission type values for MuJoCo actuators."""
@@ -950,6 +992,115 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     owner = slider_owners.pop() if len(slider_owners) == 1 else -1
             owners.append(owner)
         return owners
+
+    @classmethod
+    def _register_dcmotor_custom_attributes(cls, builder: ModelBuilder) -> None:
+        """Declare high-level MJCF DC-motor parameters when a source uses them."""
+
+        def parse_dcmotor_input(value: Any, _context: dict[str, Any] | None = None) -> int:
+            return int(
+                cls._parse_named_int(
+                    value,
+                    {"voltage": 0, "position": 1, "pos": 1, "velocity": 2, "vel": 2},
+                )
+            )
+
+        dcmotor_vec6 = wp.types.vector(length=6, dtype=wp.float32)
+        attributes = (
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_motorconst",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec2,
+                default=wp.vec2(0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="motorconst",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_resistance",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.float32,
+                default=0.0,
+                namespace="mujoco",
+                mjcf_attribute_name="resistance",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_nominal",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec3,
+                default=wp.vec3(0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="nominal",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_saturation",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec3,
+                default=wp.vec3(0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="saturation",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_inductance",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec2,
+                default=wp.vec2(0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="inductance",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_cogging",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec3,
+                default=wp.vec3(0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="cogging",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_controller",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=dcmotor_vec6,
+                default=dcmotor_vec6(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="controller",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_thermal",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=dcmotor_vec6,
+                default=dcmotor_vec6(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="thermal",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_lugre",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=vec5,
+                default=vec5(0.0, 0.0, 0.0, 0.0, 0.0),
+                namespace="mujoco",
+                mjcf_attribute_name="lugre",
+            ),
+            ModelBuilder.CustomAttribute(
+                name="actuator_dcmotor_input",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.int32,
+                default=0,
+                namespace="mujoco",
+                mjcf_attribute_name="input",
+                mjcf_value_transformer=parse_dcmotor_input,
+            ),
+        )
+        for attribute in attributes:
+            builder.add_custom_attribute(attribute)
 
     @override
     @classmethod
@@ -1757,18 +1908,21 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             "filter": _ActuatorDynamicsType.FILTER,
             "filterexact": _ActuatorDynamicsType.FILTER_EXACT,
             "muscle": _ActuatorDynamicsType.MUSCLE,
+            "dcmotor": _ActuatorDynamicsType.DCMOTOR,
             "user": _ActuatorDynamicsType.USER,
         }
         actuator_gain_types = {
             "fixed": _ActuatorGainType.FIXED,
             "affine": _ActuatorGainType.AFFINE,
             "muscle": _ActuatorGainType.MUSCLE,
+            "dcmotor": _ActuatorGainType.DCMOTOR,
             "user": _ActuatorGainType.USER,
         }
         actuator_bias_types = {
             "none": _ActuatorBiasType.NONE,
             "affine": _ActuatorBiasType.AFFINE,
             "muscle": _ActuatorBiasType.MUSCLE,
+            "dcmotor": _ActuatorBiasType.DCMOTOR,
             "user": _ActuatorBiasType.USER,
         }
 
@@ -2091,6 +2245,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 dtype=wp.vec2i,
                 default=wp.vec2i(-1, -1),
                 namespace="mujoco",
+                reference_value_transformer=_remap_actuator_trnid,
             )
         )
 
@@ -2322,6 +2477,31 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 usd_attribute_name="mjc:gear",
             )
         )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="actuator_damping",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.float32,
+                default=0.0,
+                namespace="mujoco",
+                mjcf_attribute_name="damping",
+                usd_attribute_name="mjc:damping",
+            )
+        )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="actuator_armature",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.float32,
+                default=0.0,
+                namespace="mujoco",
+                mjcf_attribute_name="armature",
+                usd_attribute_name="mjc:armature",
+            )
+        )
+
         builder.add_custom_attribute(
             ModelBuilder.CustomAttribute(
                 name="actuator_cranklength",
@@ -3429,6 +3609,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         actuator_trnid = mujoco_attrs.actuator_trnid.numpy()
         trntype_arr = mujoco_attrs.actuator_trntype.numpy() if hasattr(mujoco_attrs, "actuator_trntype") else None
         ctrl_source_arr = mujoco_attrs.ctrl_source.numpy() if hasattr(mujoco_attrs, "ctrl_source") else None
+        ctrl_type_arr = mujoco_attrs.ctrl_type.numpy() if hasattr(mujoco_attrs, "ctrl_type") else None
         actuator_world_arr = mujoco_attrs.actuator_world.numpy() if hasattr(mujoco_attrs, "actuator_world") else None
         actuator_target_label_arr = getattr(mujoco_attrs, "actuator_target_label", None)
         joint_dof_label_arr = getattr(mujoco_attrs, "joint_dof_label", None)
@@ -3482,6 +3663,30 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         actrange_arr = mujoco_attrs.actuator_actrange.numpy() if hasattr(mujoco_attrs, "actuator_actrange") else None
         actlimited_arr = (
             mujoco_attrs.actuator_actlimited.numpy() if hasattr(mujoco_attrs, "actuator_actlimited") else None
+        )
+        damping_arr = mujoco_attrs.actuator_damping.numpy() if hasattr(mujoco_attrs, "actuator_damping") else None
+        armature_arr = mujoco_attrs.actuator_armature.numpy() if hasattr(mujoco_attrs, "actuator_armature") else None
+        dcmotor_parameter_names = (
+            "actuator_dcmotor_motorconst",
+            "actuator_dcmotor_resistance",
+            "actuator_dcmotor_nominal",
+            "actuator_dcmotor_saturation",
+            "actuator_dcmotor_inductance",
+            "actuator_dcmotor_cogging",
+            "actuator_dcmotor_controller",
+            "actuator_dcmotor_thermal",
+            "actuator_dcmotor_lugre",
+            "actuator_dcmotor_input",
+        )
+        has_dcmotor_shortcut = ctrl_type_arr is not None and np.any(ctrl_type_arr == int(SolverMuJoCo.CtrlType.DCMOTOR))
+        dcmotor_parameter_arrays = (
+            {
+                name: getattr(mujoco_attrs, name).numpy()
+                for name in dcmotor_parameter_names
+                if hasattr(mujoco_attrs, name)
+            }
+            if has_dcmotor_shortcut
+            else {}
         )
         for mujoco_act_idx in range(mujoco_actuator_count):
             # Skip JOINT_TARGET actuators - they're already added via joint_target_mode path
@@ -3630,6 +3835,10 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             if hasattr(mujoco_attrs, "actuator_cranklength"):
                 cranklength = float(mujoco_attrs.actuator_cranklength.numpy()[mujoco_act_idx])
                 general_args["cranklength"] = cranklength
+            if damping_arr is not None:
+                general_args["damping"] = float(damping_arr[mujoco_act_idx])
+            if armature_arr is not None:
+                general_args["armature"] = float(armature_arr[mujoco_act_idx])
             # Only pass range to MuJoCo when explicitly set in MJCF (has_*range flags),
             # so MuJoCo can correctly resolve auto-limited flags via spec.compiler.autolimits.
             if has_ctrlrange_arr is not None and has_ctrlrange_arr[mujoco_act_idx]:
@@ -3660,12 +3869,37 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             if hasattr(mujoco_attrs, "actuator_biastype"):
                 biastype = int(mujoco_attrs.actuator_biastype.numpy()[mujoco_act_idx])
                 general_args["biastype"] = biastype
-            # Detect position/velocity actuator shortcuts. Use set_to_position/
-            # set_to_velocity after add_actuator so MuJoCo's compiler computes kd
-            # from dampratio via mj_setConst (kd = dampratio * 2 * sqrt(kp * acc0)).
-            shortcut = None  # "position" or "velocity" if detected
-            shortcut_args: dict[str, float] = {}
-            if general_args.get("biastype") == mujoco.mjtBias.mjBIAS_AFFINE and general_args.get("gainprm", [0])[0] > 0:
+            if general_args.get("gaintype") == int(mujoco.mjtGain.mjGAIN_DCMOTOR):
+                # Compiled MuJoCo 3.11 USD stores the input mode in gainprm[8].
+                input_mode = int(general_args.get("gainprm", [0] * 10)[8])
+                general_args["ctrlspec"] = int(mujoco.mjtCtrlInput.mjINPUT_VOLTAGE) if input_mode == 0 else input_mode
+            # Apply shortcut helpers after add_actuator so MuJoCo derives all
+            # compiled parameters exactly as it does for native MJCF.
+            shortcut = None
+            shortcut_args: dict[str, Any] = {}
+            ctrl_type = int(ctrl_type_arr[mujoco_act_idx]) if ctrl_type_arr is not None else -1
+            if ctrl_type == int(SolverMuJoCo.CtrlType.DCMOTOR):
+                shortcut = "dcmotor"
+                input_mode = int(dcmotor_parameter_arrays["actuator_dcmotor_input"][mujoco_act_idx])
+                # MuJoCo 3.12 uses input bits; Newton's voltage mode retains its zero code.
+                ctrlspec = int(mujoco.mjtCtrlInput.mjINPUT_VOLTAGE) if input_mode == 0 else input_mode
+                shortcut_args = {
+                    "motorconst": list(dcmotor_parameter_arrays["actuator_dcmotor_motorconst"][mujoco_act_idx]),
+                    "resistance": float(dcmotor_parameter_arrays["actuator_dcmotor_resistance"][mujoco_act_idx]),
+                    "nominal": list(dcmotor_parameter_arrays["actuator_dcmotor_nominal"][mujoco_act_idx]),
+                    "saturation": list(dcmotor_parameter_arrays["actuator_dcmotor_saturation"][mujoco_act_idx]),
+                    "inductance": list(dcmotor_parameter_arrays["actuator_dcmotor_inductance"][mujoco_act_idx]),
+                    "cogging": list(dcmotor_parameter_arrays["actuator_dcmotor_cogging"][mujoco_act_idx]),
+                    "controller": list(dcmotor_parameter_arrays["actuator_dcmotor_controller"][mujoco_act_idx]),
+                    "thermal": list(dcmotor_parameter_arrays["actuator_dcmotor_thermal"][mujoco_act_idx]),
+                    "lugre": list(dcmotor_parameter_arrays["actuator_dcmotor_lugre"][mujoco_act_idx]),
+                    "ctrlspec": ctrlspec,
+                }
+                for key in ("dynprm", "gainprm", "biasprm", "dyntype", "gaintype", "biastype", "actdim"):
+                    general_args.pop(key, None)
+            elif (
+                general_args.get("biastype") == mujoco.mjtBias.mjBIAS_AFFINE and general_args.get("gainprm", [0])[0] > 0
+            ):
                 kp = general_args["gainprm"][0]
                 bp = general_args.get("biasprm", [0, 0, 0])
                 # Position shortcut: biasprm = [0, -kp, -kv]
@@ -3705,6 +3939,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 act.set_to_position(**shortcut_args)
             elif shortcut == "velocity":
                 act.set_to_velocity(**shortcut_args)
+            elif shortcut == "dcmotor":
+                act.set_to_dcmotor(**shortcut_args)
             # CTRL_DIRECT actuators - store MJCF-order index into control.mujoco.ctrl
             # mujoco_act_idx is the index in Newton's mujoco:actuator frequency (MJCF order)
             mjc_actuator_ctrl_source_list.append(1)  # CTRL_DIRECT
@@ -9522,6 +9758,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         actuator_gainprm = getattr(mujoco_attrs, "actuator_gainprm", None)
         actuator_biasprm = getattr(mujoco_attrs, "actuator_biasprm", None)
         actuator_dynprm = getattr(mujoco_attrs, "actuator_dynprm", None)
+        actuator_ctrl_type = getattr(mujoco_attrs, "ctrl_type", None)
         actuator_ctrlrange = getattr(mujoco_attrs, "actuator_ctrlrange", None)
         actuator_forcerange = getattr(mujoco_attrs, "actuator_forcerange", None)
         actuator_actrange = getattr(mujoco_attrs, "actuator_actrange", None)
@@ -9531,6 +9768,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             actuator_gainprm is None
             or actuator_biasprm is None
             or actuator_dynprm is None
+            or actuator_ctrl_type is None
             or actuator_ctrlrange is None
             or actuator_forcerange is None
             or actuator_actrange is None
@@ -9548,6 +9786,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             inputs=[
                 self.mjc_actuator_ctrl_source,
                 self.mjc_actuator_to_newton_actuator_idx,
+                actuator_ctrl_type,
                 actuator_gainprm,
                 actuator_biasprm,
                 actuator_dynprm,

--- a/newton/_src/solvers/mujoco/tendons.py
+++ b/newton/_src/solvers/mujoco/tendons.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Programmatic authoring helpers for MuJoCo tendons."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ...geometry import ShapeFlags
+from ...sim import ModelBuilder
+from ._authoring import _ensure_mujoco_attributes, _prepare_custom_frequency_row
+
+
+@dataclass(frozen=True)
+class TendonWrapSite:
+    """A site entry in a spatial tendon path."""
+
+    site: int
+    """Newton site-shape index."""
+
+
+@dataclass(frozen=True)
+class TendonWrapGeom:
+    """A geometry wrapping entry in a spatial tendon path."""
+
+    geom: int
+    """Newton non-site shape index."""
+
+    sidesite: int | None = None
+    """Optional Newton site-shape index selecting the wrapping side."""
+
+
+@dataclass(frozen=True)
+class TendonWrapPulley:
+    """A pulley entry in a spatial tendon path."""
+
+    divisor: float
+    """Positive pulley divisor."""
+
+
+def _vector(builder: ModelBuilder, key: str, values: Sequence[float], length: int) -> Any:
+    components = [float(value) for value in values]
+    if len(components) != length:
+        raise ValueError(f"{key} requires exactly {length} values, got {len(components)}.")
+    return builder.custom_attributes[key].dtype(*components)
+
+
+def _tristate(value: bool | int | str) -> int:
+    if isinstance(value, str):
+        try:
+            return {"false": 0, "true": 1, "auto": 2}[value.lower().strip()]
+        except KeyError as error:
+            raise ValueError(f"Expected false, true, or auto, got {value!r}.") from error
+    result = int(value)
+    if result not in (0, 1, 2):
+        raise ValueError(f"Expected a MuJoCo tri-state value in {{0, 1, 2}}, got {value!r}.")
+    return result
+
+
+def _validate_shape(builder: ModelBuilder, shape: int, *, site: bool, name: str) -> None:
+    shape_count = len(builder.shape_flags)
+    if shape < 0 or shape >= shape_count:
+        raise IndexError(f"{name} index {shape} is outside [0, {shape_count}).")
+    is_site = bool(int(builder.shape_flags[shape]) & int(ShapeFlags.SITE))
+    if is_site != site:
+        expected = "site" if site else "non-site shape"
+        raise ValueError(f"{name} index {shape} does not identify a Newton {expected}.")
+
+
+def _tendon_values(
+    builder: ModelBuilder,
+    *,
+    tendon_type: int,
+    joint_adr: int,
+    joint_num: int,
+    wrap_adr: int,
+    wrap_num: int,
+    label: str | None,
+    stiffness: float,
+    damping: float,
+    frictionloss: float,
+    limited: bool | int | str,
+    limit_range: Sequence[float],
+    margin: float,
+    solref_limit: Sequence[float],
+    solimp_limit: Sequence[float],
+    solref_friction: Sequence[float],
+    solimp_friction: Sequence[float],
+    armature: float,
+    springlength: Sequence[float],
+) -> dict[str, Any]:
+    return {
+        "mujoco:tendon_world": builder.current_world,
+        "mujoco:tendon_stiffness": float(stiffness),
+        "mujoco:tendon_damping": float(damping),
+        "mujoco:tendon_frictionloss": float(frictionloss),
+        "mujoco:tendon_limited": _tristate(limited),
+        "mujoco:tendon_range": _vector(builder, "mujoco:tendon_range", limit_range, 2),
+        "mujoco:tendon_margin": float(margin),
+        "mujoco:tendon_solref_limit": _vector(builder, "mujoco:tendon_solref_limit", solref_limit, 2),
+        "mujoco:tendon_solimp_limit": _vector(builder, "mujoco:tendon_solimp_limit", solimp_limit, 5),
+        "mujoco:tendon_solref_friction": _vector(builder, "mujoco:tendon_solref_friction", solref_friction, 2),
+        "mujoco:tendon_solimp_friction": _vector(builder, "mujoco:tendon_solimp_friction", solimp_friction, 5),
+        "mujoco:tendon_armature": float(armature),
+        "mujoco:tendon_springlength": _vector(builder, "mujoco:tendon_springlength", springlength, 2),
+        "mujoco:tendon_joint_adr": int(joint_adr),
+        "mujoco:tendon_joint_num": int(joint_num),
+        "mujoco:tendon_label": label or "",
+        "mujoco:tendon_type": int(tendon_type),
+        "mujoco:tendon_wrap_adr": int(wrap_adr),
+        "mujoco:tendon_wrap_num": int(wrap_num),
+    }
+
+
+def add_tendon_fixed(
+    builder: ModelBuilder,
+    joints: Sequence[tuple[int, float]],
+    *,
+    label: str | None = None,
+    stiffness: float = 0.0,
+    damping: float = 0.0,
+    frictionloss: float = 0.0,
+    limited: bool | int | str = "auto",
+    limit_range: Sequence[float] = (0.0, 0.0),
+    margin: float = 0.0,
+    solref_limit: Sequence[float] = (0.02, 1.0),
+    solimp_limit: Sequence[float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+    solref_friction: Sequence[float] = (0.02, 1.0),
+    solimp_friction: Sequence[float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+    armature: float = 0.0,
+    springlength: Sequence[float] = (-1.0, -1.0),
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a fixed tendon as a linear combination of Newton joints.
+
+    Args:
+        builder: Model builder receiving the tendon.
+        joints: Ordered ``(joint_index, coefficient)`` entries.
+        label: Optional tendon label.
+        stiffness: Tendon stiffness [N/m].
+        damping: Tendon damping [N·s/m].
+        frictionloss: Tendon friction loss [N].
+        limited: Tendon-limit tri-state (false, true, or auto).
+        limit_range: Tendon length range [m].
+        margin: Tendon limit margin [m].
+        solref_limit: Limit constraint reference parameters.
+        solimp_limit: Limit constraint impedance parameters.
+        solref_friction: Friction constraint reference parameters.
+        solimp_friction: Friction constraint impedance parameters.
+        armature: Tendon armature [kg].
+        springlength: Tendon spring length range [m].
+        custom_attributes: Additional registered ``mujoco:tendon`` attributes.
+
+    Returns:
+        The ``mujoco:tendon`` row index.
+    """
+    _ensure_mujoco_attributes(builder, "mujoco:tendon_world")
+    entries = [(int(joint), float(coef)) for joint, coef in joints]
+    if not entries:
+        raise ValueError("A fixed tendon requires at least one joint entry.")
+    joint_count = len(builder.joint_type)
+    for joint, _ in entries:
+        if joint < 0 or joint >= joint_count:
+            raise IndexError(f"joint index {joint} is outside [0, {joint_count}).")
+
+    joint_start = builder._custom_frequency_counts.get("mujoco:tendon_joint", 0)
+    values = _tendon_values(
+        builder,
+        tendon_type=0,
+        joint_adr=joint_start,
+        joint_num=len(entries),
+        wrap_adr=0,
+        wrap_num=0,
+        label=label,
+        stiffness=stiffness,
+        damping=damping,
+        frictionloss=frictionloss,
+        limited=limited,
+        limit_range=limit_range,
+        margin=margin,
+        solref_limit=solref_limit,
+        solimp_limit=solimp_limit,
+        solref_friction=solref_friction,
+        solimp_friction=solimp_friction,
+        armature=armature,
+        springlength=springlength,
+    )
+    row = _prepare_custom_frequency_row(builder, "mujoco:tendon", values, custom_attributes)
+
+    for joint, coef in entries:
+        builder.add_custom_values(**{"mujoco:tendon_joint": joint, "mujoco:tendon_coef": coef})
+    return builder.add_custom_values(**row)["mujoco:tendon_world"]
+
+
+def add_tendon_spatial(
+    builder: ModelBuilder,
+    path: Sequence[TendonWrapSite | TendonWrapGeom | TendonWrapPulley],
+    *,
+    label: str | None = None,
+    stiffness: float = 0.0,
+    damping: float = 0.0,
+    frictionloss: float = 0.0,
+    limited: bool | int | str = "auto",
+    limit_range: Sequence[float] = (0.0, 0.0),
+    margin: float = 0.0,
+    solref_limit: Sequence[float] = (0.02, 1.0),
+    solimp_limit: Sequence[float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+    solref_friction: Sequence[float] = (0.02, 1.0),
+    solimp_friction: Sequence[float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+    armature: float = 0.0,
+    springlength: Sequence[float] = (-1.0, -1.0),
+    custom_attributes: dict[str, Any] | None = None,
+) -> int:
+    """Add a spatial tendon from typed site, geometry, and pulley entries.
+
+    Args:
+        builder: Model builder receiving the tendon.
+        path: Ordered spatial tendon path entries.
+        label: Optional tendon label.
+        stiffness: Tendon stiffness [N/m].
+        damping: Tendon damping [N·s/m].
+        frictionloss: Tendon friction loss [N].
+        limited: Tendon-limit tri-state (false, true, or auto).
+        limit_range: Tendon length range [m].
+        margin: Tendon limit margin [m].
+        solref_limit: Limit constraint reference parameters.
+        solimp_limit: Limit constraint impedance parameters.
+        solref_friction: Friction constraint reference parameters.
+        solimp_friction: Friction constraint impedance parameters.
+        armature: Tendon armature [kg].
+        springlength: Tendon spring length range [m].
+        custom_attributes: Additional registered ``mujoco:tendon`` attributes.
+
+    Returns:
+        The ``mujoco:tendon`` row index.
+    """
+    _ensure_mujoco_attributes(builder, "mujoco:tendon_world")
+    entries: list[tuple[int, int, int, float]] = []
+    for entry in path:
+        if isinstance(entry, TendonWrapSite):
+            _validate_shape(builder, entry.site, site=True, name="site")
+            entries.append((0, int(entry.site), -1, 0.0))
+        elif isinstance(entry, TendonWrapGeom):
+            _validate_shape(builder, entry.geom, site=False, name="geom")
+            sidesite = -1 if entry.sidesite is None else int(entry.sidesite)
+            if sidesite >= 0:
+                _validate_shape(builder, sidesite, site=True, name="sidesite")
+            entries.append((1, int(entry.geom), sidesite, 0.0))
+        elif isinstance(entry, TendonWrapPulley):
+            if entry.divisor <= 0.0:
+                raise ValueError("A tendon pulley divisor must be positive.")
+            entries.append((2, -1, -1, float(entry.divisor)))
+        else:
+            raise TypeError(f"Unsupported spatial tendon path entry {type(entry).__name__}.")
+    if not entries:
+        raise ValueError("A spatial tendon requires at least one path entry.")
+
+    wrap_start = builder._custom_frequency_counts.get("mujoco:tendon_wrap", 0)
+    values = _tendon_values(
+        builder,
+        tendon_type=1,
+        joint_adr=0,
+        joint_num=0,
+        wrap_adr=wrap_start,
+        wrap_num=len(entries),
+        label=label,
+        stiffness=stiffness,
+        damping=damping,
+        frictionloss=frictionloss,
+        limited=limited,
+        limit_range=limit_range,
+        margin=margin,
+        solref_limit=solref_limit,
+        solimp_limit=solimp_limit,
+        solref_friction=solref_friction,
+        solimp_friction=solimp_friction,
+        armature=armature,
+        springlength=springlength,
+    )
+    row = _prepare_custom_frequency_row(builder, "mujoco:tendon", values, custom_attributes)
+
+    for wrap_type, shape, sidesite, parameter in entries:
+        builder.add_custom_values(
+            **{
+                "mujoco:tendon_wrap_type": wrap_type,
+                "mujoco:tendon_wrap_shape": shape,
+                "mujoco:tendon_wrap_sidesite": sidesite,
+                "mujoco:tendon_wrap_prm": parameter,
+            }
+        )
+    return builder.add_custom_values(**row)["mujoco:tendon_world"]
+
+
+__all__ = [
+    "TendonWrapGeom",
+    "TendonWrapPulley",
+    "TendonWrapSite",
+    "add_tendon_fixed",
+    "add_tendon_spatial",
+]

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -386,6 +386,10 @@ def parse_mjcf(
     # Register the MuJoCo custom attributes needed to preserve imported model
     # properties. The operation is idempotent.
     SolverMuJoCo.register_custom_attributes(builder)
+    # Avoid replicating and allocating high-level DC-motor arrays for the
+    # overwhelmingly common case where the MJCF contains no DC motors.
+    if any(True for _ in root.iter("dcmotor")):
+        SolverMuJoCo._register_dcmotor_custom_attributes(builder)
     # Bit 1 in one MJCF file may describe different shapes than bit 1 in
     # another. Give every add_mjcf() call a domain so those equal numbers are
     # not mistaken for one shared collision rule. The domain is only a source

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -3373,6 +3373,13 @@ def parse_mjcf(
                 biasprm = vec10(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                 ctrl_source_val = SolverMuJoCo.CtrlSource.CTRL_DIRECT
 
+            elif actuator_type == "dcmotor":
+                # SolverMuJoCo applies MuJoCo's native DC-motor shortcut from
+                # the high-level parameters preserved by custom attributes.
+                gainprm = vec10(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                biasprm = vec10(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                ctrl_source_val = SolverMuJoCo.CtrlSource.CTRL_DIRECT
+
             elif actuator_type == "general":
                 gainprm_str = merged_attrib.get("gainprm", "1 0 0 0 0 0 0 0 0 0")
                 biasprm_str = merged_attrib.get("biasprm", "0 0 0 0 0 0 0 0 0 0")
@@ -3418,6 +3425,8 @@ def parse_mjcf(
                 ctrl_type_val = int(SolverMuJoCo.CtrlType.POSITION)
             elif actuator_type == "velocity":
                 ctrl_type_val = int(SolverMuJoCo.CtrlType.VELOCITY)
+            elif actuator_type == "dcmotor":
+                ctrl_type_val = int(SolverMuJoCo.CtrlType.DCMOTOR)
             else:
                 ctrl_type_val = int(SolverMuJoCo.CtrlType.GENERAL)
 

--- a/newton/tests/test_mujoco_authoring.py
+++ b/newton/tests/test_mujoco_authoring.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for programmatic MuJoCo-specific model authoring helpers."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.solvers import mujoco
+
+
+def _add_revolute(builder: newton.ModelBuilder, label: str) -> tuple[int, int]:
+    """Add a single-body revolute articulation and return its body and joint."""
+    body = builder.add_link(
+        mass=1.0,
+        inertia=wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        label=f"{label}_body",
+    )
+    joint = builder.add_joint_revolute(parent=-1, child=body, axis=wp.vec3(0.0, 0.0, 1.0), label=label)
+    builder.add_articulation([joint], label=f"{label}_articulation")
+    return body, joint
+
+
+class TestMuJoCoActuatorAuthoring(unittest.TestCase):
+    """Tests for public MuJoCo actuator authoring helpers."""
+
+    def test_add_actuator_dcmotor(self):
+        """Create a DC-motor row from high-level parameters."""
+        builder = newton.ModelBuilder()
+        _, joint = _add_revolute(builder, "hinge")
+
+        actuator = mujoco.add_actuator_dcmotor(
+            builder,
+            target=mujoco.ActuatorTarget.joint(joint),
+            motorconst=(0.05, 0.06),
+            resistance=2.0,
+            nominal=(24.0, 0.2, 100.0),
+            saturation=(2.0, 4.0, 7.0),
+            inductance=(0.01, 20.0),
+            cogging=(0.1, 6.0, 0.2),
+            controller=(5.0, 1.0, 0.2, 10.0, 2.0, 3.0),
+            thermal=(0.004, 10.0, 30.0, 0.001, 0.4, 90.0),
+            lugre=(0.3, 0.4, 0.5, 12.0, 0.02),
+            input_mode="position",
+            gear=(3.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            damping=0.7,
+            armature=0.02,
+        )
+        model = builder.finalize()
+
+        self.assertEqual(actuator, 0)
+        self.assertEqual(model.custom_frequency_counts["mujoco:actuator"], 1)
+        np.testing.assert_array_equal(model.mujoco.actuator_trnid.numpy(), [[0, -1]])
+        np.testing.assert_array_equal(
+            model.mujoco.actuator_trntype.numpy(),
+            [int(newton.solvers.SolverMuJoCo.TrnType.JOINT)],
+        )
+        np.testing.assert_array_equal(
+            model.mujoco.ctrl_type.numpy(),
+            [int(newton.solvers.SolverMuJoCo.CtrlType.DCMOTOR)],
+        )
+        np.testing.assert_allclose(model.mujoco.actuator_dcmotor_motorconst.numpy(), [[0.05, 0.06]])
+        np.testing.assert_allclose(model.mujoco.actuator_dcmotor_lugre.numpy(), [[0.3, 0.4, 0.5, 12.0, 0.02]])
+        np.testing.assert_array_equal(model.mujoco.actuator_dcmotor_input.numpy(), [1])
+
+        solver = newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=True, disable_contacts=True)
+        self.assertEqual(solver.mj_model.nu, 1)
+        native_mujoco = newton.solvers.SolverMuJoCo.import_mujoco()[0]
+        np.testing.assert_array_equal(
+            solver.mj_model.actuator_dyntype,
+            [native_mujoco.mjtDyn.mjDYN_DCMOTOR],
+        )
+
+    def test_add_actuator_shortcuts_and_ranges(self):
+        """Normalize shortcut parameters and authored range metadata."""
+        builder = newton.ModelBuilder()
+        _, joint = _add_revolute(builder, "hinge")
+        target = mujoco.ActuatorTarget.joint(joint)
+
+        mujoco.add_actuator_motor(builder, target=target, ctrlrange=(-2.0, 2.0), ctrllimited=True)
+        mujoco.add_actuator_position(builder, target=target, kp=10.0, kv=2.0)
+        mujoco.add_actuator_velocity(builder, target=target, kv=3.0)
+        mujoco.add_actuator_general(
+            builder,
+            target=target,
+            dyntype="filterexact",
+            dynprm=(0.05,),
+            gainprm=(4.0,),
+            biasprm=(0.0, -4.0, -0.5),
+        )
+        model = builder.finalize()
+
+        self.assertEqual(model.custom_frequency_counts["mujoco:actuator"], 4)
+        np.testing.assert_array_equal(model.mujoco.actuator_has_ctrlrange.numpy(), [1, 0, 0, 0])
+        np.testing.assert_array_equal(model.mujoco.actuator_ctrllimited.numpy(), [1, 2, 2, 2])
+        np.testing.assert_allclose(model.mujoco.actuator_gainprm.numpy()[:, 0], [1.0, 10.0, 3.0, 4.0])
+        np.testing.assert_allclose(model.mujoco.actuator_biasprm.numpy()[1, :3], [0.0, -10.0, -2.0])
+        np.testing.assert_allclose(model.mujoco.actuator_biasprm.numpy()[2, :3], [0.0, 0.0, -3.0])
+
+    def test_dcmotor_input_modes_match_mujoco(self):
+        """Preserve named and numeric input modes with MuJoCo's input bitmask."""
+        native_mujoco = newton.solvers.SolverMuJoCo.import_mujoco()[0]
+        for name, code, ctrlspec, controller in (
+            ("voltage", 0, native_mujoco.mjtCtrlInput.mjINPUT_VOLTAGE, (0.0,) * 6),
+            ("position", 1, native_mujoco.mjtCtrlInput.mjINPUT_POS, (5.0, 1.0, 0.2, 10.0, 2.0, 3.0)),
+            ("velocity", 2, native_mujoco.mjtCtrlInput.mjINPUT_VEL, (0.0, 0.0, 0.2, 10.0, 2.0, 3.0)),
+        ):
+            for input_mode in (name, code):
+                with self.subTest(input_mode=input_mode):
+                    builder = newton.ModelBuilder()
+                    _, joint = _add_revolute(builder, "hinge")
+                    mujoco.add_actuator_dcmotor(
+                        builder,
+                        target=mujoco.ActuatorTarget.joint(joint),
+                        motorconst=(0.05, 0.06),
+                        resistance=2.0,
+                        controller=controller,
+                        input_mode=input_mode,
+                    )
+                    solver = newton.solvers.SolverMuJoCo(builder.finalize(), use_mujoco_cpu=True, disable_contacts=True)
+                    np.testing.assert_array_equal(solver.mj_model.actuator_ctrlspec, [ctrlspec])
+
+    def test_reject_multidof_joint_without_dof(self):
+        """Require an explicit local DOF for multi-DOF joint targets."""
+        builder = newton.ModelBuilder()
+        body = builder.add_link(mass=1.0)
+        joint = builder.add_joint_ball(parent=-1, child=body)
+        builder.add_articulation([joint])
+
+        with self.assertRaisesRegex(ValueError, "dof"):
+            mujoco.add_actuator_motor(builder, target=mujoco.ActuatorTarget.joint(joint))
+
+    def test_remap_actuator_target_when_merging_builders(self):
+        """Offset heterogeneous actuator targets during builder composition."""
+        blueprint = newton.ModelBuilder()
+        blueprint_body, blueprint_joint = _add_revolute(blueprint, "blueprint_hinge")
+        blueprint_site0 = blueprint.add_site(blueprint_body, label="blueprint_site0")
+        blueprint_site1 = blueprint.add_site(blueprint_body, label="blueprint_site1")
+        blueprint_tendon = mujoco.add_tendon_fixed(blueprint, joints=[(blueprint_joint, 1.0)])
+        mujoco.add_actuator_motor(blueprint, target=mujoco.ActuatorTarget.joint(blueprint_joint))
+        mujoco.add_actuator_motor(blueprint, target=mujoco.ActuatorTarget.tendon(blueprint_tendon))
+        mujoco.add_actuator_motor(blueprint, target=mujoco.ActuatorTarget.site(blueprint_site0, blueprint_site1))
+        mujoco.add_actuator_motor(blueprint, target=mujoco.ActuatorTarget.body(blueprint_body))
+        mujoco.add_actuator_motor(
+            blueprint,
+            target=mujoco.ActuatorTarget.slider_crank(blueprint_site0, blueprint_site1),
+            cranklength=0.1,
+        )
+
+        scene = newton.ModelBuilder()
+        scene_body, scene_joint = _add_revolute(scene, "scene_hinge")
+        scene.add_site(scene_body, label="scene_site")
+        mujoco.add_tendon_fixed(scene, joints=[(scene_joint, 1.0)])
+        scene.add_builder(blueprint)
+        model = scene.finalize()
+
+        np.testing.assert_array_equal(
+            model.mujoco.actuator_trnid.numpy(),
+            [[1, -1], [1, -1], [1, 2], [1, -1], [1, 2]],
+        )
+
+
+class TestMuJoCoEntityAuthoring(unittest.TestCase):
+    """Tests for non-actuator MuJoCo authoring helpers."""
+
+    def test_add_contact_pair(self):
+        """Create an explicit MuJoCo contact-pair row."""
+        builder = newton.ModelBuilder()
+        shape0 = builder.add_shape_box(body=-1, hx=0.1, hy=0.1, hz=0.1)
+        shape1 = builder.add_shape_sphere(body=-1, radius=0.1)
+
+        pair = mujoco.add_contact_pair(
+            builder,
+            shape0,
+            shape1,
+            condim=4,
+            friction=(0.8, 0.7, 0.01, 0.02, 0.03),
+            margin=0.01,
+        )
+        model = builder.finalize()
+
+        self.assertEqual(pair, 0)
+        np.testing.assert_array_equal(model.mujoco.pair_geom1.numpy(), [shape0])
+        np.testing.assert_array_equal(model.mujoco.pair_geom2.numpy(), [shape1])
+        np.testing.assert_array_equal(model.mujoco.pair_condim.numpy(), [4])
+        np.testing.assert_allclose(model.mujoco.pair_friction.numpy(), [[0.8, 0.7, 0.01, 0.02, 0.03]])
+
+    def test_add_fixed_tendon_and_tendon_actuator(self):
+        """Create a fixed tendon and target it with an actuator."""
+        builder = newton.ModelBuilder()
+        _, joint0 = _add_revolute(builder, "hinge0")
+        _, joint1 = _add_revolute(builder, "hinge1")
+
+        tendon = mujoco.add_tendon_fixed(
+            builder,
+            joints=[(joint0, 1.0), (joint1, -0.5)],
+            label="coupling",
+            stiffness=20.0,
+        )
+        mujoco.add_actuator_motor(builder, target=mujoco.ActuatorTarget.tendon(tendon), gear=(2.0,))
+        model = builder.finalize()
+
+        self.assertEqual(tendon, 0)
+        np.testing.assert_array_equal(model.mujoco.tendon_joint_adr.numpy(), [0])
+        np.testing.assert_array_equal(model.mujoco.tendon_joint_num.numpy(), [2])
+        np.testing.assert_array_equal(model.mujoco.tendon_joint.numpy(), [joint0, joint1])
+        np.testing.assert_allclose(model.mujoco.tendon_coef.numpy(), [1.0, -0.5])
+        np.testing.assert_array_equal(
+            model.mujoco.actuator_trntype.numpy(),
+            [int(newton.solvers.SolverMuJoCo.TrnType.TENDON)],
+        )
+        np.testing.assert_array_equal(model.mujoco.actuator_trnid.numpy(), [[tendon, -1]])
+
+    def test_add_spatial_tendon(self):
+        """Create a spatial tendon while hiding its child-row addresses."""
+        builder = newton.ModelBuilder()
+        body, _ = _add_revolute(builder, "hinge")
+        site0 = builder.add_site(body, label="site0")
+        geom = builder.add_shape_sphere(body, radius=0.1, label="geom")
+        site1 = builder.add_site(body, label="site1")
+
+        tendon = mujoco.add_tendon_spatial(
+            builder,
+            path=[
+                mujoco.TendonWrapSite(site0),
+                mujoco.TendonWrapGeom(geom, sidesite=site1),
+                mujoco.TendonWrapPulley(2.0),
+            ],
+            label="spatial",
+        )
+        model = builder.finalize()
+
+        self.assertEqual(tendon, 0)
+        np.testing.assert_array_equal(model.mujoco.tendon_wrap_adr.numpy(), [0])
+        np.testing.assert_array_equal(model.mujoco.tendon_wrap_num.numpy(), [3])
+        np.testing.assert_array_equal(model.mujoco.tendon_wrap_type.numpy(), [0, 1, 2])
+        np.testing.assert_array_equal(model.mujoco.tendon_wrap_shape.numpy(), [site0, geom, -1])
+        np.testing.assert_array_equal(model.mujoco.tendon_wrap_sidesite.numpy(), [-1, site1, -1])
+        np.testing.assert_allclose(model.mujoco.tendon_wrap_prm.numpy(), [0.0, 0.0, 2.0])
+
+    def test_add_equality_helpers(self):
+        """Create typed MuJoCo equality-constraint rows."""
+        builder = newton.ModelBuilder()
+        body0, joint0 = _add_revolute(builder, "hinge0")
+        body1, joint1 = _add_revolute(builder, "hinge1")
+
+        connect = mujoco.add_equality_connect(builder, body0, body1, anchor=(0.1, 0.2, 0.3))
+        weld = mujoco.add_equality_weld(builder, body0, body1, torquescale=2.0)
+        joint = mujoco.add_equality_joint(builder, joint0, joint1, polycoef=(1.0, 2.0))
+        model = builder.finalize()
+
+        self.assertEqual((connect, weld, joint), (0, 1, 2))
+        np.testing.assert_array_equal(
+            model.mujoco.equality_constraint_type.numpy(),
+            [
+                int(newton.solvers.SolverMuJoCo.EqType.CONNECT),
+                int(newton.solvers.SolverMuJoCo.EqType.WELD),
+                int(newton.solvers.SolverMuJoCo.EqType.JOINT),
+            ],
+        )
+        np.testing.assert_allclose(model.mujoco.equality_constraint_anchor.numpy()[0], [0.1, 0.2, 0.3])
+        np.testing.assert_allclose(model.mujoco.equality_constraint_polycoef.numpy()[2], [1.0, 2.0, 0.0, 0.0, 0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -65,6 +65,26 @@ MJCF_ACTUATORS = """<?xml version="1.0" encoding="utf-8"?>
 </mujoco>
 """
 
+MJCF_DCMOTOR_ACTUATOR = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test_dcmotor_actuator">
+    <option gravity="0 0 0"/>
+    <worldbody>
+        <body name="link">
+            <joint name="hinge" axis="0 0 1" type="hinge"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+        </body>
+    </worldbody>
+    <actuator>
+        <dcmotor name="dc" joint="hinge" gear="3"
+                 resistance="2" motorconst="0.05 0.06" nominal="24 0.2 100"
+                 inductance="0.01 20" thermal="0.004 10 30 0.001 0.4 90"
+                 saturation="2 4 7" cogging="0.1 6 0.2"
+                 lugre="0.3 0.4 0.5 12 0.02" input="pos"
+                 controller="5 1 0.2 10 2 3" damping="0.7" armature="0.02"/>
+    </actuator>
+</mujoco>
+"""
+
 USD_MJC_ACTUATOR_TEMPLATE = """#usda 1.0
 (
     defaultPrim = "Root"
@@ -150,6 +170,26 @@ USD_MJC_DIRECT_ACTUATOR = """        def MjcActuator "HingeMotor"
         {
             uniform double[] mjc:gainPrm = [7, 0, 0, 0, 0, 0, 0, 0, 0, 0]
             uniform double[] mjc:biasPrm = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            rel mjc:target = </Root/Hinge>
+        }
+"""
+
+USD_MJC_DCMOTOR_ACTUATOR = """        def MjcActuator "HingeDCMotor"
+        {
+            uniform token mjc:dynType = "dcmotor"
+            uniform token mjc:gainType = "dcmotor"
+            uniform token mjc:biasType = "dcmotor"
+            uniform int mjc:actDim = 5
+            uniform bool mjc:actEarly = true
+            uniform double[] mjc:dynPrm = [0.005, 7, 0.004, 10, 90, 0.3, 0.4, 10, 2, 0]
+            uniform double[] mjc:gainPrm = [2, 0.0547722558, 0.001, 0.4, 5, 1, 0.2, 3, 1, 0]
+            uniform double[] mjc:biasPrm = [0.1, 6, 0.2, 0.5, 12, 0.02, 0, 0, 0, 0]
+            uniform double[] mjc:gear = [3, 0, 0, 0, 0, 0]
+            uniform double mjc:forceRange:min = -2
+            uniform double mjc:forceRange:max = 2
+            uniform token mjc:forceLimited = "true"
+            uniform double mjc:damping = 0.7
+            uniform double mjc:armature = 0.02
             rel mjc:target = </Root/Hinge>
         }
 """
@@ -285,6 +325,111 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertEqual(solver.mj_model.nu, 1)
         np.testing.assert_array_equal(solver.mjc_actuator_ctrl_source.numpy(), [SolverMuJoCo.CtrlSource.CTRL_DIRECT])
         np.testing.assert_array_equal(solver.mjc_actuator_to_newton_idx.numpy(), [0])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_usd_mjc_dcmotor_actuator_preserves_compiled_parameters(self):
+        """Preserve a compiled USD DC-motor actuator through SolverMuJoCo."""
+        mujoco = SolverMuJoCo.import_mujoco()[0]
+        builder = load_usd_mjc_actuator_builder(USD_MJC_DCMOTOR_ACTUATOR)
+        model = builder.finalize()
+
+        np.testing.assert_array_equal(model.mujoco.ctrl_source.numpy(), [SolverMuJoCo.CtrlSource.CTRL_DIRECT])
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mj_model = solver.mj_model
+        self.assertEqual(mj_model.nu, 1)
+        self.assertEqual(mj_model.na, 5)
+        self.assertEqual(mj_model.actuator_dyntype[0], mujoco.mjtDyn.mjDYN_DCMOTOR)
+        self.assertEqual(mj_model.actuator_gaintype[0], mujoco.mjtGain.mjGAIN_DCMOTOR)
+        self.assertEqual(mj_model.actuator_biastype[0], mujoco.mjtBias.mjBIAS_DCMOTOR)
+        self.assertEqual(mj_model.actuator_ctrlspec[0], mujoco.mjtCtrlInput.mjINPUT_POS)
+        np.testing.assert_allclose(mj_model.actuator_dynprm[0], [0.005, 7, 0.004, 10, 90, 0.3, 0.4, 10, 2, 0])
+        np.testing.assert_allclose(
+            mj_model.actuator_gainprm[0],
+            [2, 0.0547722558, 0.001, 0.4, 5, 1, 0.2, 3, 1, 0],
+        )
+        np.testing.assert_allclose(mj_model.actuator_biasprm[0], [0.1, 6, 0.2, 0.5, 12, 0.02, 0, 0, 0, 0])
+        np.testing.assert_allclose(mj_model.actuator_forcerange[0], [-2, 2])
+        np.testing.assert_allclose(mj_model.actuator_gear[0], [3, 0, 0, 0, 0, 0])
+        np.testing.assert_allclose(mj_model.actuator_damping[0], 0.7)
+        np.testing.assert_allclose(mj_model.actuator_armature[0], 0.02)
+        for attribute in (
+            "actuator_dynprm",
+            "actuator_gainprm",
+            "actuator_biasprm",
+            "actuator_forcerange",
+            "actuator_gear",
+        ):
+            np.testing.assert_allclose(
+                getattr(solver.mjw_model, attribute).numpy()[0],
+                getattr(mj_model, attribute),
+            )
+
+    def test_mjcf_dcmotor_actuator_matches_native_mujoco(self):
+        """Recreate a stateful MJCF DC-motor actuator with native parameters."""
+        mujoco = SolverMuJoCo.import_mujoco()[0]
+        native_model = mujoco.MjModel.from_xml_string(MJCF_DCMOTOR_ACTUATOR)
+
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_DCMOTOR_ACTUATOR)
+        model = builder.finalize()
+
+        self.assertEqual(model.custom_frequency_counts.get("mujoco:actuator", 0), 1)
+        np.testing.assert_array_equal(model.mujoco.ctrl_source.numpy(), [SolverMuJoCo.CtrlSource.CTRL_DIRECT])
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        generated_model = solver.mj_model
+        self.assertEqual(generated_model.nu, native_model.nu)
+        self.assertEqual(generated_model.na, native_model.na)
+        for attribute in (
+            "actuator_dyntype",
+            "actuator_ctrlspec",
+            "actuator_gaintype",
+            "actuator_biastype",
+            "actuator_actearly",
+            "actuator_actnum",
+            "actuator_dynprm",
+            "actuator_gainprm",
+            "actuator_biasprm",
+            "actuator_forcerange",
+            "actuator_gear",
+            "actuator_damping",
+            "actuator_armature",
+        ):
+            np.testing.assert_allclose(getattr(generated_model, attribute), getattr(native_model, attribute))
+
+        self.assertEqual(solver.mjw_model.actuator_dyntype.numpy()[0], mujoco.mjtDyn.mjDYN_DCMOTOR)
+        self.assertEqual(solver.mjw_model.actuator_gaintype.numpy()[0], mujoco.mjtGain.mjGAIN_DCMOTOR)
+        self.assertEqual(solver.mjw_model.actuator_biastype.numpy()[0], mujoco.mjtBias.mjBIAS_DCMOTOR)
+        for attribute in (
+            "actuator_dynprm",
+            "actuator_gainprm",
+            "actuator_biasprm",
+            "actuator_forcerange",
+            "actuator_gear",
+        ):
+            np.testing.assert_allclose(
+                getattr(solver.mjw_model, attribute).numpy()[0],
+                getattr(native_model, attribute),
+            )
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        control.mujoco.ctrl.assign([0.25])
+        solver.step(state_0, state_1, control, None, dt=0.001)
+        activation = solver.mjw_data.act.numpy()
+        self.assertTrue(np.all(np.isfinite(activation)))
+        self.assertGreater(float(np.max(np.abs(activation))), 0.0)
+
+    def test_mjcf_without_dcmotor_omits_high_level_parameters(self):
+        """Avoid allocating high-level DC-motor parameters for ordinary actuators."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_ACTUATORS)
+
+        self.assertNotIn("mujoco:actuator_dcmotor_motorconst", builder.custom_attributes)
+        model = builder.finalize()
+        self.assertFalse(hasattr(model.mujoco, "actuator_dcmotor_motorconst"))
 
     def test_parsing_ctrl_direct_false(self):
         """Test parsing with ctrl_direct=False."""

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -13386,7 +13386,7 @@ class TestActuatorTypes(unittest.TestCase):
 
     def test_unsupported_type_warns(self):
         """Warn on an unsupported gaintype, naming the attribute, the value and the MJCF actuator."""
-        for gaintype in ("dcmotor", "so3", "pid", "bogus"):
+        for gaintype in ("so3", "pid", "bogus"):
             with self.subTest(gaintype=gaintype):
                 builder = newton.ModelBuilder()
                 with self.assertWarnsRegex(RuntimeWarning, rf"gaintype '{gaintype}' on actuator 'a'"):


### PR DESCRIPTION
## Description

Add a public `newton.solvers.mujoco` authoring namespace for constructing MuJoCo-specific custom attributes without manually coordinating attribute names and row layouts. The helpers cover general, motor, position, velocity, and DC-motor actuators; explicit contact pairs; fixed and spatial tendons; and connect, weld, and joint equality constraints.

The change also adds a generic custom-attribute reference transformer so heterogeneous actuator targets remain valid when builders are composed.

This draft is stacked on [#3952](https://github.com/newton-physics/newton/pull/3952). Until that PR merges, GitHub will show its DC-motor commit in this PR's comparison against `main`; the additional review scope here is the `Add MuJoCo model authoring helpers` commit.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k test_mujoco_authoring
uv run --extra dev -m newton.tests -k test_mujoco_general_actuators
uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-17
uvx pre-commit run -a
```

The public API generator and a warnings-as-errors Sphinx build were also run successfully.

## New feature / API change

```python
import newton
from newton.solvers import mujoco

builder = newton.ModelBuilder()
joint = ...  # Joint index returned by a ModelBuilder joint helper.

mujoco.add_actuator_dcmotor(
    builder,
    target=mujoco.ActuatorTarget.joint(joint),
    motorconst=(0.05, 0.06),
    resistance=2.0,
    nominal=(24.0, 0.2, 100.0),
    inductance=(0.01, 20.0),
    thermal=(0.004, 10.0, 30.0, 0.001, 0.4, 90.0),
    lugre=(0.3, 0.4, 0.5, 12.0, 0.02),
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MuJoCo authoring support for actuators, contact pairs, fixed and spatial tendons, and connect, weld, and joint equality constraints.
  - Added general, motor, position, velocity, and DC-motor actuator helpers with support for multiple transmission targets and input modes.
  - Added MuJoCo solver exports and improved builder composition for remapping referenced targets.
  - Added MJCF support for importing DC-motor actuators.

- **Documentation**
  - Added API documentation and usage examples for MuJoCo solver authoring helpers.

- **Bug Fixes**
  - Improved preservation of compiled DC-motor parameters and actuator settings during simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->