### PR TITLE
xpbd: clamp rigid restitution + add body-vs-body no-bounce test (#1137)

### DIFF
--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2711,8 +2711,10 @@ def apply_rigid_restitution(
     if rel_vel_old >= 0.0:
         return
 
-    # Eq. 34
-    dv = (-rel_vel_new - restitution * rel_vel_old) / inv_mass
+    # Eq. 34 — clamp the restitution target to be non-negative so we never *inject*
+    # normal velocity (matches apply_particle_shape_restitution above). Without the
+    # wp.max(), body-vs-body contacts can rebound at restitution=0 (issue #1137).
+    dv = (-rel_vel_new + wp.max(-restitution * rel_vel_old, 0.0)) / inv_mass
 
     # Eq. 33 — push A in -n direction, B in +n direction
     if body_a >= 0:

--- a/newton/tests/test_shapes_no_bounce.py
+++ b/newton/tests/test_shapes_no_bounce.py
@@ -229,6 +229,64 @@ def test_shapes_never_exceed_initial_z(test, device):
         )
 
 
+def test_stacked_dynamic_boxes_no_bounce(test, device):
+    """
+    Reproduces issue #1137: two *dynamic* boxes in contact must not bounce at
+    restitution=0.
+
+    The existing test above only drops shapes onto a *static* ground (body=-1), so it
+    never exercises body-vs-body restitution — which is where apply_rigid_restitution
+    injects energy (see #1289). Here a dynamic box is dropped onto another dynamic box.
+    """
+    builder = newton.ModelBuilder(up_axis="Z")
+    builder.add_ground_plane()
+
+    cfg = newton.ModelBuilder.ShapeConfig(density=1000.0, restitution=0.0)
+
+    # Lower box resting on the ground (center 0.05, half-height 0.05 -> top at 0.10).
+    lower = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.05), q=wp.quat_identity()))
+    builder.add_shape_box(lower, hx=0.1, hy=0.1, hz=0.05, cfg=cfg)
+
+    # Upper box dropped from 0.25 onto the lower box (analytic rest center ~0.15).
+    upper = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.25), q=wp.quat_identity()))
+    builder.add_shape_box(upper, hx=0.05, hy=0.05, hz=0.05, cfg=cfg)
+
+    model = builder.finalize(device=device)
+
+    solver = newton.solvers.SolverXPBD(
+        model, iterations=2, rigid_contact_relaxation=0.8, angular_damping=0.0
+    )
+    state_0 = model.state()
+    state_1 = model.state()
+    control = model.control()
+
+    fps = 100
+    sim_substeps = 10
+    sim_dt = 1.0 / fps / sim_substeps
+
+    rest_z = 0.15  # analytic resting center of the upper box
+    slack = 0.03  # numeric tolerance
+    settled = False
+
+    for step in range(200):
+        for _ in range(sim_substeps):
+            contacts = model.collide(state=state_0, rigid_contact_margin=0.01)
+            state_0.clear_forces()
+            solver.step(state_0, state_1, control, contacts, sim_dt)
+            state_0, state_1 = state_1, state_0
+
+        upper_z = float(state_0.body_q.numpy()[upper][2])
+        # Only start asserting once the upper box has actually come down to (near) rest.
+        if not settled and upper_z <= rest_z + slack:
+            settled = True
+        if settled:
+            test.assertLessEqual(
+                upper_z,
+                rest_z + slack,
+                f"Step {step + 1}: upper box rebounded to z={upper_z:.4f} at restitution=0 (issue #1137)",
+            )
+
+
 class TestShapesNoBounce(unittest.TestCase):
     pass
 
@@ -237,6 +295,13 @@ add_function_test(
     TestShapesNoBounce,
     "test_shapes_never_exceed_initial_z",
     test_shapes_never_exceed_initial_z,
+    devices=get_selected_cuda_test_devices(),
+)
+
+add_function_test(
+    TestShapesNoBounce,
+    "test_stacked_dynamic_boxes_no_bounce",
+    test_stacked_dynamic_boxes_no_bounce,
     devices=get_selected_cuda_test_devices(),
 )
 


### PR DESCRIPTION
> **Draft** — I don't have a CUDA GPU to fully verify end-to-end, so I'm opening this to collaborate on the fix. The regression test and the analysis stand on their own; a maintainer run would confirm the kernel change.

## What

Fixes #1137 (rigid bodies bouncing at `restitution=0`), and adds the missing test coverage.

## Root cause

`apply_rigid_restitution` (`newton/_src/solvers/xpbd/kernels.py`) computes the restitution impulse **without the non-negative clamp** that the working particle version uses:

```python
# apply_particle_shape_restitution (correct)
dv = n * (-rel_vel_new + wp.max(-restitution * rel_vel_old, 0.0))

# apply_rigid_restitution (before this PR)
dv = (-rel_vel_new - restitution * rel_vel_old) / inv_mass   # no wp.max()
```

This PR aligns the two.

## Why the existing test didn't catch it

`test_shapes_never_exceed_initial_z` only drops shapes onto a **static ground** (`body=-1`), so it never exercises **body-vs-body** restitution — which is exactly where the energy is injected (and what @-the-#1289-reporter diagnosed regarding the `body_a` normal sign). This PR adds `test_stacked_dynamic_boxes_no_bounce`: a dynamic box dropped onto another dynamic box at `restitution=0`, asserting no rebound above the resting height.

## Honest status / open question

I lack CUDA hardware to run the sim, so I can't confirm the clamp alone fully resolves #1137. Per #1289, the `body_a` sign handling in the same kernel may also need correcting (the current `dv_a = -dv` vs. negating `n`). Happy to iterate — would a maintainer be able to run the new test against this change? If the clamp is insufficient, I'll follow up with the sign fix.

Related: #1289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented zero-restitution contacts from generating unintended upward bounce.
  - Improved stability when dynamic objects settle after collisions.

- **Tests**
  - Added coverage for stacked dynamic boxes to verify they remain settled without rebounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->