### PR TITLE
Update Kamino UT script to discover both internal and newton tests

### DIFF
--- a/newton/_src/solvers/kamino/tests/__main__.py
+++ b/newton/_src/solvers/kamino/tests/__main__.py
@@ -5,6 +5,7 @@ import argparse
 import unittest
 from pathlib import Path
 
+import newton
 from newton._src.solvers.kamino.tests import setup_tests as setup_tests_internal
 from newton.tests.kamino import setup_tests as setup_tests_newton
 
@@ -73,9 +74,9 @@ if __name__ == "__main__":
     # Kamino tests live in two locations: internal (private helpers) and under newton/tests/kamino
     # (public-facing / integration).
     this_file = Path(__file__).resolve()
-    repo_root = this_file.parents[5]  # <root>/newton/_src/solvers/kamino/tests/__main__.py
+    repo_root = Path(newton.__file__).resolve().parent
     test_folder_internal = this_file.parent
-    test_folder_newton = repo_root / "newton" / "tests" / "kamino"
+    test_folder_newton = repo_root / "tests" / "kamino"
 
     # Discover unit tests from both folders
     # Note: use repo root as top_level_dir as discovery doesn't allow moving up in the folder hierarchy

--- a/newton/_src/solvers/kamino/tests/__main__.py
+++ b/newton/_src/solvers/kamino/tests/__main__.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import os
 import unittest
+from pathlib import Path
 
-from newton._src.solvers.kamino.tests import setup_tests
+from newton._src.solvers.kamino.tests import setup_tests as setup_tests_internal
+from newton.tests.kamino import setup_tests as setup_tests_newton
 
 ###
 # Utilities
@@ -65,12 +66,30 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Perform global setup
-    setup_tests(verbose=args.verbose, device=args.device, clear_cache=args.clear_cache)
+    # Perform global setup (internal + public unit tests)
+    setup_tests_internal(verbose=args.verbose, device=args.device, clear_cache=args.clear_cache)
+    setup_tests_newton(verbose=args.verbose, device=args.device, clear_cache=args.clear_cache)
 
-    # Detect all unit tests
-    test_folder = os.path.dirname(os.path.abspath(__file__))
-    tests = unittest.defaultTestLoader.discover(test_folder, pattern="test_*.py")
+    # Kamino tests live in two locations: internal (private helpers) and under newton/tests/kamino
+    # (public-facing / integration).
+    this_file = Path(__file__).resolve()
+    repo_root = this_file.parents[5]  # <root>/newton/_src/solvers/kamino/tests/__main__.py
+    test_folder_internal = this_file.parent
+    test_folder_newton = repo_root / "newton" / "tests" / "kamino"
+
+    # Discover unit tests from both folders
+    # Note: use repo root as top_level_dir as discovery doesn't allow moving up in the folder hierarchy
+    tests_internal = unittest.TestLoader().discover(
+        start_dir=str(test_folder_internal),
+        pattern="test_*.py",
+        top_level_dir=str(repo_root),
+    )
+    tests_newton = unittest.TestLoader().discover(
+        start_dir=str(test_folder_newton),
+        pattern="test_*.py",
+        top_level_dir=str(repo_root),
+    )
 
     # Run tests
-    ModuleHeaderTestRunner(verbosity=2).run(tests)
+    suite = unittest.TestSuite([tests_internal, tests_newton])
+    ModuleHeaderTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
## Description

This updates the `__main__.py` script in Kamino's internal unit tests folder, to discover both internal and publically exposed Kamino unit tests. This allows to quickly run all relevant unit tests locally when making changes to Kamino (just like before we moved most of Kamino's internal unit tests to main newton tests).

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

Run 
```
uv run --extra dev -m newton._src.solvers.kamino.tests
```
and check that both sets of unit tests appear in the output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Kamino test execution to include both internal and public test suites.
  * Combined test discovery and execution provides broader validation of Kamino functionality.
  * Improved test environment setup and filesystem handling for more consistent test runs.
  * Test runs now provide more comprehensive coverage across supported Kamino components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->