### PR TITLE
Reject cross-articulation joints

### DIFF
--- a/changelog/3968.fixed.md
+++ b/changelog/3968.fixed.md
@@ -1,0 +1,1 @@
+Reject joints that connect separate articulations during model finalization, preventing incorrect kinematics and dynamics results.

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -864,12 +864,12 @@ with a desired acceleration:
 Orphan joints
 -------------
 
-Each articulation must form a kinematic tree rooted at the world. In particular,
-the parent body of every articulated joint must either be the world or be the child
-of another joint in the same articulation. Connecting two articulations with a
-joint is unsupported and :meth:`~newton.ModelBuilder.finalize` rejects that
-topology. To compose imported robots, pass ``parent_body`` and ``base_joint`` to
-the importer so the new joints are appended to the parent's articulation.
+A joint in one articulation cannot use a body from another articulation as its
+parent. This cross-articulation topology is unsupported, and
+:meth:`~newton.ModelBuilder.finalize` rejects it. To compose imported assets with
+:meth:`~newton.ModelBuilder.add_urdf`, :meth:`~newton.ModelBuilder.add_mjcf`, or
+:meth:`~newton.ModelBuilder.add_usd`, pass ``parent_body`` and ``base_joint`` so
+the new joints are appended to the parent's articulation.
 
 An **orphan joint** is a joint that is not part of any articulation **and** whose child body is not reachable through any articulated joint (i.e. the child has no articulated path back to the rest of the model). This situation can arise when:
 

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -882,7 +882,7 @@ USD import preserves joints outside authored articulations without emitting an a
 
 **Validation and finalization**
 
-By default, :meth:`~newton.ModelBuilder.finalize` raises a :class:`ValueError` for non-root orphan joints. Loop-closing joints and standalone world-root joints pass this check. To proceed with another orphan topology, skip this validation explicitly:
+By default, :meth:`~newton.ModelBuilder.finalize` raises a :class:`ValueError` for joints that connect separate articulations and for non-root orphan joints. Loop-closing joints and standalone world-root joints pass this check. To proceed with either unsupported topology, set ``skip_validation_joints=True`` explicitly:
 
 .. testsetup:: articulation-orphan-joints
 

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -864,6 +864,13 @@ with a desired acceleration:
 Orphan joints
 -------------
 
+Each articulation must form a kinematic tree rooted at the world. In particular,
+the parent body of every articulated joint must either be the world or be the child
+of another joint in the same articulation. Connecting two articulations with a
+joint is unsupported and :meth:`~newton.ModelBuilder.finalize` rejects that
+topology. To compose imported robots, pass ``parent_body`` and ``base_joint`` to
+the importer so the new joints are appended to the parent's articulation.
+
 An **orphan joint** is a joint that is not part of any articulation **and** whose child body is not reachable through any articulated joint (i.e. the child has no articulated path back to the rest of the model). This situation can arise when:
 
 * The USD asset does not define a ``PhysicsArticulationRootAPI`` on any prim, so no articulations are discovered during parsing.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -10419,11 +10419,10 @@ class ModelBuilder:
                 )
 
     def _validate_joints(self):
-        """Validate articulation rootedness and joint membership.
+        """Validate articulation topology and joint membership.
 
-        Every non-world parent of an articulated joint must be the child of another
-        joint in the same articulation. This keeps each articulation rooted at the
-        world and prevents joints from connecting separate articulations.
+        A joint in one articulation cannot have a parent body that belongs to a
+        different articulation. Connected joints must use the same articulation.
 
         Loop-closing joints are allowed when their child is already reachable through
         an articulation. Standalone world-root joints (``parent == -1``) are also
@@ -10435,9 +10434,12 @@ class ModelBuilder:
         """
         if self.joint_count > 0:
             articulation_children = {}
+            body_articulations = {}
             for joint_idx, articulation_idx in enumerate(self.joint_articulation):
                 if articulation_idx >= 0:
-                    articulation_children.setdefault(articulation_idx, set()).add(self.joint_child[joint_idx])
+                    child = self.joint_child[joint_idx]
+                    articulation_children.setdefault(articulation_idx, set()).add(child)
+                    body_articulations.setdefault(child, set()).add(articulation_idx)
 
             for joint_idx, articulation_idx in enumerate(self.joint_articulation):
                 if articulation_idx < 0:
@@ -10451,14 +10453,20 @@ class ModelBuilder:
                 if parent < -1 or parent >= self.body_count:
                     continue
 
+                parent_articulations = body_articulations.get(parent)
+                if not parent_articulations:
+                    continue
+
+                parent_articulation_idx = min(parent_articulations)
                 articulation_label = self.articulation_label[articulation_idx]
+                parent_articulation_label = self.articulation_label[parent_articulation_idx]
                 joint_label = self.joint_label[joint_idx]
                 parent_label = self.body_label[parent]
                 raise ValueError(
-                    f"Articulation {articulation_idx} ('{articulation_label}') is not rooted at the world: "
-                    f"joint {joint_idx} ('{joint_label}') has parent body {parent} ('{parent_label}') outside the "
-                    "same articulation. Articulations cannot be connected through joints. Add all connected joints "
-                    "to the same articulation."
+                    f"Joint {joint_idx} ('{joint_label}') in articulation {articulation_idx} "
+                    f"('{articulation_label}') has parent body {parent} ('{parent_label}') in articulation "
+                    f"{parent_articulation_idx} ('{parent_articulation_label}'). Articulations cannot be connected "
+                    "through joints. Add all connected joints to the same articulation."
                 )
 
             # Find all bodies reachable via articulated joints.
@@ -11151,7 +11159,7 @@ class ModelBuilder:
                 you are confident the model is valid. Default is False.
             skip_validation_worlds: If True, skips validation of world ordering and contiguity. Default is False.
             skip_validation_joints: If True, skips articulation-topology and membership validation. By default,
-                articulations must be rooted at the world, and non-root joints must belong to an articulation or
+                joints cannot connect separate articulations, and non-root joints must belong to an articulation or
                 close a loop; standalone world-root joints are allowed.
             skip_validation_shapes: If True, skips validation of shapes having valid contact margins. Default is False.
             skip_validation_structure: If True, skips validation of structural invariants (body/joint references,

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -10419,7 +10419,11 @@ class ModelBuilder:
                 )
 
     def _validate_joints(self):
-        """Validate that joints belong to an articulation, with two exceptions.
+        """Validate articulation rootedness and joint membership.
+
+        Every non-world parent of an articulated joint must be the child of another
+        joint in the same articulation. This keeps each articulation rooted at the
+        world and prevents joints from connecting separate articulations.
 
         Loop-closing joints are allowed when their child is already reachable through
         an articulation. Standalone world-root joints (``parent == -1``) are also
@@ -10430,7 +10434,34 @@ class ModelBuilder:
             ValueError: If any validation check fails.
         """
         if self.joint_count > 0:
-            # First, find all bodies reachable via articulated joints
+            articulation_children = {}
+            for joint_idx, articulation_idx in enumerate(self.joint_articulation):
+                if articulation_idx >= 0:
+                    articulation_children.setdefault(articulation_idx, set()).add(self.joint_child[joint_idx])
+
+            for joint_idx, articulation_idx in enumerate(self.joint_articulation):
+                if articulation_idx < 0:
+                    continue
+
+                parent = self.joint_parent[joint_idx]
+                if parent == -1 or parent in articulation_children[articulation_idx]:
+                    continue
+
+                # Let structural validation report malformed body references.
+                if parent < -1 or parent >= self.body_count:
+                    continue
+
+                articulation_label = self.articulation_label[articulation_idx]
+                joint_label = self.joint_label[joint_idx]
+                parent_label = self.body_label[parent]
+                raise ValueError(
+                    f"Articulation {articulation_idx} ('{articulation_label}') is not rooted at the world: "
+                    f"joint {joint_idx} ('{joint_label}') has parent body {parent} ('{parent_label}') outside the "
+                    "same articulation. Articulations cannot be connected through joints. Add all connected joints "
+                    "to the same articulation."
+                )
+
+            # Find all bodies reachable via articulated joints.
             articulated_bodies = set()
             articulated_bodies.add(-1)  # World is always reachable
             for i, art in enumerate(self.joint_articulation):
@@ -11119,8 +11150,9 @@ class ModelBuilder:
             skip_all_validations: If True, skips all validation checks. Use for maximum performance when
                 you are confident the model is valid. Default is False.
             skip_validation_worlds: If True, skips validation of world ordering and contiguity. Default is False.
-            skip_validation_joints: If True, skips articulation-membership validation. By default, non-root joints
-                must belong to an articulation or close a loop; standalone world-root joints are allowed.
+            skip_validation_joints: If True, skips articulation-topology and membership validation. By default,
+                articulations must be rooted at the world, and non-root joints must belong to an articulation or
+                close a loop; standalone world-root joints are allowed.
             skip_validation_shapes: If True, skips validation of shapes having valid contact margins. Default is False.
             skip_validation_structure: If True, skips validation of structural invariants (body/joint references,
                 particle topology, array lengths, monotonicity). Default is False.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -10433,27 +10433,33 @@ class ModelBuilder:
             ValueError: If any validation check fails.
         """
         if self.joint_count > 0:
-            articulation_children = {}
-            body_articulations = {}
+            articulation_to_child_bodies = {}
+            child_body_to_articulations = {}
             for joint_idx, articulation_idx in enumerate(self.joint_articulation):
-                if articulation_idx >= 0:
-                    child = self.joint_child[joint_idx]
-                    articulation_children.setdefault(articulation_idx, set()).add(child)
-                    body_articulations.setdefault(child, set()).add(articulation_idx)
+                if articulation_idx < 0:
+                    continue
+
+                child = self.joint_child[joint_idx]
+                if articulation_idx not in articulation_to_child_bodies:
+                    articulation_to_child_bodies[articulation_idx] = set()
+                articulation_to_child_bodies[articulation_idx].add(child)
+                if child not in child_body_to_articulations:
+                    child_body_to_articulations[child] = set()
+                child_body_to_articulations[child].add(articulation_idx)
 
             for joint_idx, articulation_idx in enumerate(self.joint_articulation):
                 if articulation_idx < 0:
                     continue
 
                 parent = self.joint_parent[joint_idx]
-                if parent == -1 or parent in articulation_children[articulation_idx]:
+                if parent == -1 or parent in articulation_to_child_bodies[articulation_idx]:
                     continue
 
                 # Let structural validation report malformed body references.
                 if parent < -1 or parent >= self.body_count:
                     continue
 
-                parent_articulations = body_articulations.get(parent)
+                parent_articulations = child_body_to_articulations.get(parent)
                 if not parent_articulations:
                     continue
 

--- a/newton/tests/kamino/test_kamino_core_model.py
+++ b/newton/tests/kamino/test_kamino_core_model.py
@@ -503,8 +503,8 @@ class TestModelConversions(unittest.TestCase):
         Test per-world base assignment when articulation roots are not unary free joints.
 
         A free-rooted articulation following a fixed-rooted one still provides the
-        world's floating base; a world whose articulations are fixed-rooted or
-        rooted by a free joint with a body parent gets no base.
+        world's floating base; a world whose only articulation is fixed-rooted,
+        including one with a body-parented free joint, gets no base.
         """
 
         def build_model(free_root: str | None) -> Model:
@@ -513,13 +513,18 @@ class TestModelConversions(unittest.TestCase):
             body_fixed = builder.add_link()
             builder.add_shape_box(body_fixed)
             joint_fixed = builder.add_joint_fixed(parent=-1, child=body_fixed)
-            builder.add_articulation([joint_fixed])
             if free_root is not None:
                 body_free = builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 2.0), wp.quat_identity()))
                 builder.add_shape_box(body_free)
                 parent = -1 if free_root == "world" else body_fixed
                 joint_free = builder.add_joint_free(child=body_free, parent=parent)
-                builder.add_articulation([joint_free])
+                if parent == -1:
+                    builder.add_articulation([joint_fixed])
+                    builder.add_articulation([joint_free])
+                else:
+                    builder.add_articulation([joint_fixed, joint_free])
+            else:
+                builder.add_articulation([joint_fixed])
             return builder.finalize(device=self.default_device)
 
         model_kamino = ModelKamino.from_newton(build_model(free_root="world"))

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -1240,7 +1240,7 @@ def _cable_ball_joint_attaches_rod_endpoint_impl(test: unittest.TestCase, device
 
     # Kinematic anchor body at the rod start point.
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     # Anchor marker sphere.
     anchor_radius = 0.1
     builder.add_shape_sphere(anchor, radius=anchor_radius)
@@ -1398,7 +1398,7 @@ def _cable_fixed_joint_attaches_rod_endpoint_impl(test: unittest.TestCase, devic
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
 
     # Kinematic anchor body with identity rotation (can't match rotation to two different cables).
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     anchor_radius = 0.1
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
@@ -1591,7 +1591,7 @@ def _cable_revolute_joint_attaches_rod_endpoint_impl(test: unittest.TestCase, de
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
 
     # Kinematic anchor body with identity rotation.
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     anchor_radius = 0.1
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
@@ -1800,7 +1800,7 @@ def _cable_revolute_drive_tracks_target_impl(test: unittest.TestCase, device):
     anchor_radius = 0.1
 
     # Kinematic anchor body.
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -1926,7 +1926,7 @@ def _cable_revolute_drive_limit_impl(test: unittest.TestCase, device):
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2063,7 +2063,7 @@ def _cable_prismatic_joint_attaches_rod_endpoint_impl(test: unittest.TestCase, d
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
 
     # Kinematic anchor body with identity rotation (matching ball/fixed/revolute).
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     anchor_radius = 0.1
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
@@ -2207,7 +2207,7 @@ def _cable_prismatic_drive_tracks_target_impl(test: unittest.TestCase, device):
     anchor_radius = 0.1
 
     # Kinematic anchor body.
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2333,7 +2333,7 @@ def _cable_prismatic_drive_limit_impl(test: unittest.TestCase, device):
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2475,7 +2475,7 @@ def _cable_d6_joint_attaches_rod_endpoint_impl(test: unittest.TestCase, device):
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2630,7 +2630,7 @@ def _cable_d6_joint_all_locked_impl(test: unittest.TestCase, device):
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2760,7 +2760,7 @@ def _cable_d6_joint_locked_x_impl(test: unittest.TestCase, device):
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -2924,7 +2924,7 @@ def _cable_d6_drive_tracks_target_impl(test: unittest.TestCase, device):
     anchor_radius = 0.1
 
     # Kinematic anchor body.
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -3066,7 +3066,7 @@ def _cable_d6_drive_limit_impl(test: unittest.TestCase, device, rigid_compliant_
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
     anchor_radius = 0.1
 
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0
@@ -4112,7 +4112,7 @@ def _joint_enabled_toggle_impl(test: unittest.TestCase, device, rigid_compliant_
 
     # Kinematic anchor sphere at height.
     anchor_pos = wp.vec3(0.0, 0.0, 3.0)
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     anchor_radius = 0.1
     builder.add_shape_sphere(anchor, radius=anchor_radius)
     builder.body_mass[anchor] = 0.0
@@ -4216,7 +4216,7 @@ def _cable_fixed_joint_tracks_moving_kinematic_impl(test: unittest.TestCase, dev
     builder = newton.ModelBuilder()
 
     anchor_pos = wp.vec3(0.0, 0.0, 1.0)
-    anchor = builder.add_body(xform=wp.transform(anchor_pos, wp.quat_identity()))
+    anchor = builder.add_link(xform=wp.transform(anchor_pos, wp.quat_identity()))
     builder.add_shape_sphere(anchor, radius=0.05)
     builder.body_mass[anchor] = 0.0
     builder.body_inv_mass[anchor] = 0.0

--- a/newton/tests/test_custom_attributes.py
+++ b/newton/tests/test_custom_attributes.py
@@ -32,7 +32,13 @@ class TestCustomAttributes(unittest.TestCase):
         self.device = wp.get_device()
 
     def _add_test_robot(self, builder: ModelBuilder, add_articulation: bool = True) -> dict[str, int]:
-        """Build a simple 2-bar linkage robot without custom attributes."""
+        """Build a simple 2-bar linkage robot without custom attributes.
+
+        Args:
+            builder: Model builder that receives the robot.
+            add_articulation: Whether to register the fixture joints in an articulation. If False, the joints remain
+                unregistered for later composition.
+        """
         base = builder.add_link(xform=wp.transform([0.0, 0.0, 0.0], wp.quat_identity()), mass=1.0)
         builder.add_shape_box(base, hx=0.1, hy=0.1, hz=0.1)
 

--- a/newton/tests/test_custom_attributes.py
+++ b/newton/tests/test_custom_attributes.py
@@ -31,7 +31,7 @@ class TestCustomAttributes(unittest.TestCase):
         """Set up test fixtures."""
         self.device = wp.get_device()
 
-    def _add_test_robot(self, builder: ModelBuilder) -> dict[str, int]:
+    def _add_test_robot(self, builder: ModelBuilder, add_articulation: bool = True) -> dict[str, int]:
         """Build a simple 2-bar linkage robot without custom attributes."""
         base = builder.add_link(xform=wp.transform([0.0, 0.0, 0.0], wp.quat_identity()), mass=1.0)
         builder.add_shape_box(base, hx=0.1, hy=0.1, hz=0.1)
@@ -58,8 +58,8 @@ class TestCustomAttributes(unittest.TestCase):
             axis=[0.0, 1.0, 0.0],
         )
 
-        # Add articulation for the joints
-        builder.add_articulation([joint1, joint2])
+        if add_articulation:
+            builder.add_articulation([joint1, joint2])
 
         return {"base": base, "link1": link1, "link2": link2, "joint1": joint1, "joint2": joint2}
 
@@ -339,7 +339,7 @@ class TestCustomAttributes(unittest.TestCase):
             )
         )
 
-        robot_entities = self._add_test_robot(builder)
+        robot_entities = self._add_test_robot(builder, add_articulation=False)
 
         body = builder.add_link(mass=1.0)
         joint3 = builder.add_joint_revolute(
@@ -353,7 +353,7 @@ class TestCustomAttributes(unittest.TestCase):
                 "custom_int_coord": [12],
             },
         )
-        builder.add_articulation([joint3])
+        builder.add_articulation([robot_entities["joint1"], robot_entities["joint2"], joint3])
 
         model = builder.finalize(device=self.device)
 
@@ -395,7 +395,7 @@ class TestCustomAttributes(unittest.TestCase):
             )
         )
 
-        robot_entities = self._add_test_robot(builder)
+        robot_entities = self._add_test_robot(builder, add_articulation=False)
 
         body = builder.add_link(mass=1.0)
         joint3 = builder.add_joint_revolute(
@@ -407,7 +407,7 @@ class TestCustomAttributes(unittest.TestCase):
                 "custom_int_cts": [1, 2, 3, 4, 5],
             },
         )
-        builder.add_articulation([joint3])
+        builder.add_articulation([robot_entities["joint1"], robot_entities["joint2"], joint3])
 
         model = builder.finalize(device=self.device)
 
@@ -442,7 +442,7 @@ class TestCustomAttributes(unittest.TestCase):
             )
         )
 
-        robot_entities = self._add_test_robot(builder)
+        robot_entities = self._add_test_robot(builder, add_articulation=False)
         cfg = ModelBuilder.JointDofConfig
 
         body = builder.add_link(mass=1.0)
@@ -456,7 +456,7 @@ class TestCustomAttributes(unittest.TestCase):
                 "custom_int_coord": [100, 200, 300],
             },
         )
-        builder.add_articulation([joint3])
+        builder.add_articulation([robot_entities["joint1"], robot_entities["joint2"], joint3])
 
         model = builder.finalize(device=self.device)
 
@@ -494,7 +494,7 @@ class TestCustomAttributes(unittest.TestCase):
             )
         )
 
-        robot_entities = self._add_test_robot(builder)
+        robot_entities = self._add_test_robot(builder, add_articulation=False)
         cfg = ModelBuilder.JointDofConfig
 
         body = builder.add_link(mass=1.0)
@@ -508,7 +508,7 @@ class TestCustomAttributes(unittest.TestCase):
                 "custom_int_cts": [1, 2, 3],
             },
         )
-        builder.add_articulation([joint3])
+        builder.add_articulation([robot_entities["joint1"], robot_entities["joint2"], joint3])
 
         model = builder.finalize(device=self.device)
 
@@ -550,7 +550,7 @@ class TestCustomAttributes(unittest.TestCase):
             )
         )
 
-        robot_entities = self._add_test_robot(builder)
+        robot_entities = self._add_test_robot(builder, add_articulation=False)
         cfg = ModelBuilder.JointDofConfig
 
         body = builder.add_link(mass=1.0)
@@ -565,7 +565,7 @@ class TestCustomAttributes(unittest.TestCase):
                 "custom_vec3_cts": [[0.01, 0.02, 0.03], [0.04, 0.05, 0.06], [0.07, 0.08, 0.09]],
             },
         )
-        builder.add_articulation([joint3])
+        builder.add_articulation([robot_entities["joint1"], robot_entities["joint2"], joint3])
 
         model = builder.finalize(device=self.device)
 

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -2154,14 +2154,13 @@ class TestModelJoints(unittest.TestCase):
         builder = ModelBuilder()
         parent = builder.add_link(xform=parent_body_xform)
         child = builder.add_link(xform=child_body_xform)
-        root_joint = builder.add_joint_fixed(parent=-1, child=parent, parent_xform=parent_body_xform)
         joint = builder.add_joint_free(
             parent=parent,
             child=child,
             parent_xform=parent_xform,
             child_xform=child_xform,
         )
-        builder.add_articulation([root_joint, joint])
+        builder.add_articulation([joint])
 
         parent_anchor_world = parent_body_xform * parent_xform
         expected_joint_q = wp.transform_inverse(parent_anchor_world) * child_body_xform * child_xform
@@ -3150,7 +3149,7 @@ class TestModelJoints(unittest.TestCase):
         self.assertIn("pendulum_articulation", error_msg)
         self.assertIn("mount_joint", error_msg)
         self.assertIn("base", error_msg)
-        self.assertIn("same articulation", error_msg)
+        self.assertIn("cannot be connected", error_msg)
 
     def test_joint_world_validation(self):
         """Test that joints validate parent/child bodies belong to current world"""
@@ -3528,10 +3527,9 @@ class TestModelWorld(unittest.TestCase):
             b1 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()), mass=10.0)
             b2 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5), wp.quat_identity()), mass=5.0)
             b3 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 1.0), wp.quat_identity()), mass=2.5)
-            j0 = world_builder.add_joint_fixed(parent=-1, child=b1)
             j1 = world_builder.add_joint_revolute(parent=b1, child=b2, axis=(0, 1, 0))
             j2 = world_builder.add_joint_revolute(parent=b2, child=b3, axis=(0, 1, 0))
-            world_builder.add_articulation([j0, j1, j2])
+            world_builder.add_articulation([j1, j2])
             world_builder.add_shape_sphere(
                 body=b1, xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()), radius=0.1
             )
@@ -3576,7 +3574,7 @@ class TestModelWorld(unittest.TestCase):
         self.assertEqual(model.particle_count, 9)  # 3 global + 2*3 = 9
         self.assertEqual(model.body_count, 12)  # 3 global + 3*3 = 12
         self.assertEqual(model.shape_count, 12)  # 3 global + 3*3 = 12
-        self.assertEqual(model.joint_count, 12)  # 3 global + 3*3 = 12
+        self.assertEqual(model.joint_count, 9)  # 3 global + 2*3 = 9
         self.assertEqual(model.articulation_count, 6)  # 3 global + 1*3 = 6
 
         # Verify group assignments
@@ -3619,11 +3617,14 @@ class TestModelWorld(unittest.TestCase):
 
         if len(joint_world) > 0:
             self.assertEqual(joint_world[0], -1)  # ground body's free joint
-            self.assertTrue(np.all(joint_world[1:4] == 0))
-            self.assertTrue(np.all(joint_world[4:7] == 1))
-            self.assertTrue(np.all(joint_world[7:10] == 2))
-            self.assertEqual(joint_world[10], -1)  # floor body's free joint
-            self.assertEqual(joint_world[11], -1)  # ball body's free joint
+            self.assertEqual(joint_world[1], 0)
+            self.assertEqual(joint_world[2], 0)
+            self.assertEqual(joint_world[3], 1)
+            self.assertEqual(joint_world[4], 1)
+            self.assertEqual(joint_world[5], 2)
+            self.assertEqual(joint_world[6], 2)
+            self.assertEqual(joint_world[7], -1)  # floor body's free joint
+            self.assertEqual(joint_world[8], -1)  # ball body's free joint
 
         if len(articulation_world) > 0:
             self.assertEqual(articulation_world[0], -1)  # ground body's articulation
@@ -3695,11 +3696,11 @@ class TestModelWorld(unittest.TestCase):
         self.assertTrue(np.array_equal(particle_world_start, np.array([1, 3, 5, 7, 9])))
         self.assertTrue(np.array_equal(body_world_start, np.array([1, 4, 7, 10, 12])))
         self.assertTrue(np.array_equal(shape_world_start, np.array([1, 4, 7, 10, 12])))
-        self.assertTrue(np.array_equal(joint_world_start, np.array([1, 4, 7, 10, 12])))
+        self.assertTrue(np.array_equal(joint_world_start, np.array([1, 3, 5, 7, 9])))
         self.assertTrue(np.array_equal(articulation_world_start, np.array([1, 2, 3, 4, 6])))
         self.assertTrue(np.array_equal(joint_dof_world_start, np.array([6, 8, 10, 12, 24])))
         self.assertTrue(np.array_equal(joint_coord_world_start, np.array([7, 9, 11, 13, 27])))
-        self.assertTrue(np.array_equal(joint_constraint_world_start, np.array([0, 16, 32, 48, 48])))
+        self.assertTrue(np.array_equal(joint_constraint_world_start, np.array([0, 10, 20, 30, 30])))
 
     def test_world_count_tracking(self):
         """Test that world_count is properly tracked when using add_world."""

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -2154,13 +2154,14 @@ class TestModelJoints(unittest.TestCase):
         builder = ModelBuilder()
         parent = builder.add_link(xform=parent_body_xform)
         child = builder.add_link(xform=child_body_xform)
+        root_joint = builder.add_joint_fixed(parent=-1, child=parent, parent_xform=parent_body_xform)
         joint = builder.add_joint_free(
             parent=parent,
             child=child,
             parent_xform=parent_xform,
             child_xform=child_xform,
         )
-        builder.add_articulation([joint])
+        builder.add_articulation([root_joint, joint])
 
         parent_anchor_world = parent_body_xform * parent_xform
         expected_joint_q = wp.transform_inverse(parent_anchor_world) * child_body_xform * child_xform
@@ -3130,6 +3131,27 @@ class TestModelJoints(unittest.TestCase):
         self.assertIn("already belongs to articulation", str(context.exception))
         self.assertIn("joint_2", str(context.exception))  # joint2's key
 
+    def test_articulation_validation_rejects_cross_articulation_joint(self):
+        """Reject joints that connect separate articulations during finalization."""
+        builder = ModelBuilder()
+
+        base = builder.add_link(label="base")
+        base_joint = builder.add_joint_revolute(parent=-1, child=base, label="base_joint")
+        builder.add_articulation([base_joint], label="base_articulation")
+
+        pendulum = builder.add_link(label="pendulum")
+        mount_joint = builder.add_joint_revolute(parent=base, child=pendulum, label="mount_joint")
+        builder.add_articulation([mount_joint], label="pendulum_articulation")
+
+        with self.assertRaises(ValueError) as context:
+            builder.finalize()
+
+        error_msg = str(context.exception)
+        self.assertIn("pendulum_articulation", error_msg)
+        self.assertIn("mount_joint", error_msg)
+        self.assertIn("base", error_msg)
+        self.assertIn("same articulation", error_msg)
+
     def test_joint_world_validation(self):
         """Test that joints validate parent/child bodies belong to current world"""
         builder = ModelBuilder()
@@ -3506,9 +3528,10 @@ class TestModelWorld(unittest.TestCase):
             b1 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()), mass=10.0)
             b2 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5), wp.quat_identity()), mass=5.0)
             b3 = world_builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 1.0), wp.quat_identity()), mass=2.5)
+            j0 = world_builder.add_joint_fixed(parent=-1, child=b1)
             j1 = world_builder.add_joint_revolute(parent=b1, child=b2, axis=(0, 1, 0))
             j2 = world_builder.add_joint_revolute(parent=b2, child=b3, axis=(0, 1, 0))
-            world_builder.add_articulation([j1, j2])
+            world_builder.add_articulation([j0, j1, j2])
             world_builder.add_shape_sphere(
                 body=b1, xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()), radius=0.1
             )
@@ -3553,7 +3576,7 @@ class TestModelWorld(unittest.TestCase):
         self.assertEqual(model.particle_count, 9)  # 3 global + 2*3 = 9
         self.assertEqual(model.body_count, 12)  # 3 global + 3*3 = 12
         self.assertEqual(model.shape_count, 12)  # 3 global + 3*3 = 12
-        self.assertEqual(model.joint_count, 9)  # 3 global + 2*3 = 9
+        self.assertEqual(model.joint_count, 12)  # 3 global + 3*3 = 12
         self.assertEqual(model.articulation_count, 6)  # 3 global + 1*3 = 6
 
         # Verify group assignments
@@ -3596,14 +3619,11 @@ class TestModelWorld(unittest.TestCase):
 
         if len(joint_world) > 0:
             self.assertEqual(joint_world[0], -1)  # ground body's free joint
-            self.assertEqual(joint_world[1], 0)
-            self.assertEqual(joint_world[2], 0)
-            self.assertEqual(joint_world[3], 1)
-            self.assertEqual(joint_world[4], 1)
-            self.assertEqual(joint_world[5], 2)
-            self.assertEqual(joint_world[6], 2)
-            self.assertEqual(joint_world[7], -1)  # floor body's free joint
-            self.assertEqual(joint_world[8], -1)  # ball body's free joint
+            self.assertTrue(np.all(joint_world[1:4] == 0))
+            self.assertTrue(np.all(joint_world[4:7] == 1))
+            self.assertTrue(np.all(joint_world[7:10] == 2))
+            self.assertEqual(joint_world[10], -1)  # floor body's free joint
+            self.assertEqual(joint_world[11], -1)  # ball body's free joint
 
         if len(articulation_world) > 0:
             self.assertEqual(articulation_world[0], -1)  # ground body's articulation
@@ -3675,11 +3695,11 @@ class TestModelWorld(unittest.TestCase):
         self.assertTrue(np.array_equal(particle_world_start, np.array([1, 3, 5, 7, 9])))
         self.assertTrue(np.array_equal(body_world_start, np.array([1, 4, 7, 10, 12])))
         self.assertTrue(np.array_equal(shape_world_start, np.array([1, 4, 7, 10, 12])))
-        self.assertTrue(np.array_equal(joint_world_start, np.array([1, 3, 5, 7, 9])))
+        self.assertTrue(np.array_equal(joint_world_start, np.array([1, 4, 7, 10, 12])))
         self.assertTrue(np.array_equal(articulation_world_start, np.array([1, 2, 3, 4, 6])))
         self.assertTrue(np.array_equal(joint_dof_world_start, np.array([6, 8, 10, 12, 24])))
         self.assertTrue(np.array_equal(joint_coord_world_start, np.array([7, 9, 11, 13, 27])))
-        self.assertTrue(np.array_equal(joint_constraint_world_start, np.array([0, 10, 20, 30, 30])))
+        self.assertTrue(np.array_equal(joint_constraint_world_start, np.array([0, 16, 32, 48, 48])))
 
     def test_world_count_tracking(self):
         """Test that world_count is properly tracked when using add_world."""

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -1142,11 +1142,11 @@ def _build_single_body_pendulum(joint_kind: str, parent_kinematic: bool, gravity
     builder = newton.ModelBuilder(gravity=(0.0, 0.0, -gravity), up_axis=newton.Axis.Z)
     builder.request_state_attributes("body_parent_f")
 
+    articulation_joints = []
     if parent_kinematic:
-        parent_link = builder.add_body(xform=wp.transform_identity())
+        parent_link = builder.add_link(xform=wp.transform_identity(), is_kinematic=True)
         builder.add_shape_box(parent_link, hx=0.05, hy=0.05, hz=0.05)
-        # Replace the default DYNAMIC flag with KINEMATIC.
-        builder.body_flags[parent_link] = int(newton.BodyFlags.KINEMATIC)
+        articulation_joints.append(builder.add_joint_free(child=parent_link))
     else:
         parent_link = -1
 
@@ -1181,7 +1181,8 @@ def _build_single_body_pendulum(joint_kind: str, parent_kinematic: bool, gravity
     else:
         raise ValueError(f"Unsupported joint kind: {joint_kind}")
 
-    builder.add_articulation([joint])
+    articulation_joints.append(joint)
+    builder.add_articulation(articulation_joints)
     return builder, child_link
 
 


### PR DESCRIPTION
## Description

Reject articulated joints whose parent body belongs to a different articulation during `ModelBuilder.finalize()`.

Newton evaluates and assembles an articulation under the assumption that connected ancestor joints share its articulation metadata. A joint between two separately registered articulations violates that invariant and can produce incorrect kinematics and dynamics results. Finalization now identifies both articulations, the offending joint, and its parent body before the invalid model can be used.

The check is intentionally limited to cross-articulation connections. Existing rootless mechanisms whose parent body is not owned by another articulation remain accepted for solver-specific use. Existing test fixtures that crossed articulation boundaries were corrected: connected chains now share one articulation, while cable anchors outside the cable articulation are created as unarticulated links instead of separate single-body articulations.

The articulation documentation also links directly to `ModelBuilder.add_urdf`, `ModelBuilder.add_mjcf`, and `ModelBuilder.add_usd`: callers should use `parent_body` and `base_joint` when composing imported assets so the new joints are appended to the parent's articulation.

Closes #3968.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k test_model
uv run --extra dev -m newton.tests -k test_custom_attributes
uv run --extra dev -m newton.tests -k test_05_model_conversions_base_assignment_non_floating_root
uv run --extra dev -m newton.tests -k test_cable_chain_connectivity_cpu
uv run --extra dev -m newton.tests -k test_xpbd_parent_force_
uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest docs/concepts/custom_attributes.rst
uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest docs/concepts/articulations.rst
uvx pre-commit run -a
```

All 17 cable attachment, drive, limit, and enabled-toggle tests reported by the Ubuntu ARM job were also rerun together and passed.

The new regression was run before the validation change and failed because `ModelBuilder.finalize()` did not raise an error.

## Bug fix

**Steps to reproduce:**

1. Create an articulation rooted at the world.
2. Create a second articulation whose root joint uses a body from the first articulation as its parent.
3. Finalize the model.
4. Observe that finalization accepts the unsupported cross-articulation topology.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
base = builder.add_link(label="base")
base_joint = builder.add_joint_revolute(parent=-1, child=base)
builder.add_articulation([base_joint], label="base_articulation")

pendulum = builder.add_link(label="pendulum")
mount_joint = builder.add_joint_revolute(parent=base, child=pendulum)
builder.add_articulation([mount_joint], label="pendulum_articulation")

builder.finalize()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model finalization now rejects joints connecting separate articulations.
  * Articulations must form complete kinematic trees rooted in the world.
  * Improved validation messages identify conflicting articulation relationships.

* **Documentation**
  * Clarified unsupported cross-articulation joints and articulation requirements.
  * Added guidance for appending imported assets using importer configuration options.

* **Tests**
  * Expanded coverage for articulation validation, free and fixed root joints, joint attributes, kinematic bodies, and cable anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->