### PR TITLE
Bump newton-assets and Menagerie pins

### DIFF
--- a/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
@@ -1185,7 +1185,7 @@ class TestUSDImporter(unittest.TestCase):
 
         # Check the loaded contents
         self.assertEqual(builder_usd.num_bodies, 31)
-        self.assertEqual(builder_usd.num_joints, 36)
+        self.assertEqual(builder_usd.num_joints, 37)
         self.assertEqual(builder_usd.num_geoms, 31)
 
     def test_import_model_dr_legs_with_boxes(self):
@@ -1200,7 +1200,7 @@ class TestUSDImporter(unittest.TestCase):
 
         # Check the loaded contents
         self.assertEqual(builder_usd.num_bodies, 31)
-        self.assertEqual(builder_usd.num_joints, 36)
+        self.assertEqual(builder_usd.num_joints, 37)
         self.assertEqual(builder_usd.num_geoms, 3)
 
     def test_import_model_dr_legs_with_meshes_and_boxes(self):
@@ -1215,7 +1215,7 @@ class TestUSDImporter(unittest.TestCase):
 
         # Check the loaded contents
         self.assertEqual(builder_usd.num_bodies, 31)
-        self.assertEqual(builder_usd.num_joints, 36)
+        self.assertEqual(builder_usd.num_joints, 37)
         self.assertEqual(builder_usd.num_geoms, 34)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")

--- a/newton/_src/utils/download_assets.py
+++ b/newton/_src/utils/download_assets.py
@@ -20,10 +20,10 @@ from warp._src.thirdparty.appdirs import user_cache_dir
 # commit.  Update these SHAs when assets change upstream and the new versions
 # have been validated against Newton's test suite.
 NEWTON_ASSETS_URL = "https://github.com/newton-physics/newton-assets.git"
-NEWTON_ASSETS_REF = "26c7f5ccaadd9a163f4d6c8f867c789b3ac57d83"
+NEWTON_ASSETS_REF = "a96f0973b6ae69c90609f9fafef9d2c1db2d6431"
 
 MENAGERIE_URL = "https://github.com/google-deepmind/mujoco_menagerie.git"
-MENAGERIE_REF = "affef0836947b64cc06c4ab1cbf0152835693374"
+MENAGERIE_REF = "da76818e269b82289eba39808e2fb91d679d6994"
 
 _SHA_RE = re.compile(r"[0-9a-f]{40}")
 

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1805,13 +1805,10 @@ class TestMenagerieUSD_Robotiq2f85V4(TestMenagerieUSD):
     num_steps = 20
     fk_enabled = True
     # Menagerie PR #252 corrected the source finger pads from 2e-6 kg to
-    # 0.0035 kg. The pinned USD was generated from the old source and still
-    # authors the old mass on its colliders; the test below tracks that fixture.
+    # 0.0035 kg. The pinned USD is generated from that corrected source, so it
+    # authors physics:mass = 0.00175 on each pad collider and agrees with the
+    # MJCF geom masses; body mass and inertia now compare exactly.
     dynamics_tolerance = 1e-4
-
-    def _compare_inertia(self, newton_mjw: Any, native_mjw: Any) -> None:
-        # body_mass differs for finger pads (see class docstring).
-        pass
 
     def test_pad_mass_matches_source_scale(self):
         """The pinned MJCF and USD agree on the finger-pad mass scale."""
@@ -1824,9 +1821,6 @@ class TestMenagerieUSD_Robotiq2f85V4(TestMenagerieUSD):
             native_id = self._mj_model.body(body_name).id
             newton_id = self._body_map[native_id]
             pad_masses.append((body_name, newton_mass[newton_id], native_mass[native_id]))
-
-        if all(np.isclose(usd_mass, 2.0e-6) for _, usd_mass, _ in pad_masses):
-            self.skipTest("Pinned USD fixture still authors the pre-Menagerie-#252 finger-pad mass")
 
         for body_name, usd_mass, mjcf_mass in pad_masses:
             np.testing.assert_allclose(


### PR DESCRIPTION
## Description

The structured USD robots in `newton-assets` have been regenerated so they all derive from a single Menagerie revision ([newton-physics/newton-assets#49](https://github.com/newton-physics/newton-assets/pull/49)). This bumps `NEWTON_ASSETS_REF` to pick that up, and moves `MENAGERIE_REF` to the same revision the assets were converted from.

Both pins have to move together. `test_menagerie_usd_mujoco.py` compares a USD import against the native MJCF parse of the same robot, so a USD asset built from `da76818` has to be compared against `da76818` MJCF — leaving `MENAGERIE_REF` on `affef08` compares two different revisions of the robot.

Opening as a draft to get CI results on the asset update.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/newton/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Newton and MuJoCo Menagerie assets to newer revisions.

* **Bug Fixes**
  * Corrected Robotiq 2F-85 finger-pad mass data and improved consistency checks between USD and MJCF formats.
  * Updated DR Legs model expectations to recognize the corrected joint count across supported USD import variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->