### PR TITLE
[Kamino] Fix metrics for NaN in the solution

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -802,6 +802,8 @@ def _compute_joint_kinematics_residual_dense(
 
     # Retrieve the size and index offset of the joint constraint
     num_cts_j = model_joint_num_kinematic_cts[jid]
+    if num_cts_j == 0:
+        return
     cts_offset_j = model_joint_kinematic_cts_offset_total_cts[jid] - model_info_total_cts_offset[wid]
 
     # Retrieve the world-specific info
@@ -865,6 +867,8 @@ def _compute_joint_kinematics_residual_sparse(
     # Retrieve the size and index offset of the joint constraint
     num_dyn_cts_j = model_joint_num_dynamic_cts[jid]
     num_kin_cts_j = model_joint_num_kinematic_cts[jid]
+    if num_kin_cts_j == 0:
+        return
     kin_cts_offset_j = model_joint_kinematic_cts_offset[jid] - model_info_joint_kinematic_cts_offset[wid]
 
     # Retrieve the starting index for the non-zero blocks for the current joint
@@ -1082,11 +1086,8 @@ def _compute_dual_problem_metrics(
         njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
 
-    if (
-        _vector_has_nan(ncts, vio, solution_lambdas)
-        or _vector_has_nan(ncts, vio, buffer_v)
-        or _vector_has_nan(nc, cio, problem_mu)
-    ):
+    lambdas_has_nan = _vector_has_nan(ncts, vio, solution_lambdas)
+    if lambdas_has_nan or _vector_has_nan(ncts, vio, buffer_v) or _vector_has_nan(nc, cio, problem_mu):
         r_ncp_p = wp.nan
         r_ncp_p_argmax = wp.int32(-1)
         r_ncp_d = wp.nan
@@ -1096,7 +1097,7 @@ def _compute_dual_problem_metrics(
         r_ncp_natmap = wp.nan
         r_ncp_natmap_argmax = wp.int32(-1)
 
-    if _vector_has_nan(ncts, vio, solution_lambdas) or _vector_has_nan(ncts, vio, problem_v_f):
+    if lambdas_has_nan or _vector_has_nan(ncts, vio, problem_v_f):
         f_ncp = wp.nan
         f_ccp = wp.nan
 
@@ -1197,11 +1198,8 @@ def _compute_dual_problem_metrics_sparse(
         njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
 
-    if (
-        _vector_has_nan(ncts, vio, solution_lambdas)
-        or _vector_has_nan(ncts, vio, buffer_v)
-        or _vector_has_nan(nc, cio, problem_mu)
-    ):
+    lambdas_has_nan = _vector_has_nan(ncts, vio, solution_lambdas)
+    if lambdas_has_nan or _vector_has_nan(ncts, vio, buffer_v) or _vector_has_nan(nc, cio, problem_mu):
         r_ncp_p = wp.nan
         r_ncp_p_argmax = wp.int32(-1)
         r_ncp_d = wp.nan
@@ -1211,7 +1209,7 @@ def _compute_dual_problem_metrics_sparse(
         r_ncp_natmap = wp.nan
         r_ncp_natmap_argmax = wp.int32(-1)
 
-    if _vector_has_nan(ncts, vio, solution_lambdas) or _vector_has_nan(ncts, vio, problem_v_f):
+    if lambdas_has_nan or _vector_has_nan(ncts, vio, problem_v_f):
         f_ncp = wp.nan
         f_ccp = wp.nan
 

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -770,6 +770,7 @@ def _compute_eom_residual(
     argmax_key = wp.int64(build_pair_key2(wp.uint32(bid), wp.uint32(r_eom_argmax_i)))
     _atomic_update_metric_max(metric_r_eom, metric_r_eom_argmax, wid, r_eom_i, argmax_key)
 
+
 @wp.kernel
 def _compute_joint_kinematics_residual_dense(
     # Inputs:
@@ -990,7 +991,9 @@ def _compute_cts_contacts_residual(
     if wp.isnan(r_cts_contacts_k) or r_cts_contacts_k > 0.0:
         # Update the per-world maximum residual and argmax index
         argmax_key = wcid
-        _atomic_update_metric_max(metric_r_cts_contacts, metric_r_cts_contacts_argmax, wid, r_cts_contacts_k, argmax_key)
+        _atomic_update_metric_max(
+            metric_r_cts_contacts, metric_r_cts_contacts_argmax, wid, r_cts_contacts_k, argmax_key
+        )
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -245,6 +245,8 @@ class SolutionMetricsData:
     margin-shifted signed distance stored in the ``w`` component of the contact
     `gapfunc`. Negative `d_k` denotes penetration.
 
+    A NaN contact gap produces a NaN metric and an argmax of `-1`.
+
     Shape of ``(num_worlds,)``.
     """
 
@@ -697,21 +699,21 @@ def compute_vector_difference_infnorm(
         Maximum absolute difference and index of the largest component. If either
         input segment contains NaN, returns ``(nan, -1)``.
     """
-    max = float(0.0)
+    max_val = float(0.0)
     argmax = wp.int32(-1)
-    has_nan = wp.isnan(x[vio]) or wp.isnan(y[vio])
+    has_nan = wp.bool(False)
     for i in range(dim):
         v_i = vio + i
         if wp.isnan(x[v_i]) or wp.isnan(y[v_i]):
             has_nan = True
         else:
             err = wp.abs(x[v_i] - y[v_i])
-            max = wp.max(max, err)
-            if err == max:
+            max_val = wp.max(max_val, err)
+            if err == max_val:
                 argmax = i
     if has_nan:
         return wp.nan, wp.int32(-1)
-    return max, argmax
+    return max_val, argmax
 
 
 ###

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -75,6 +75,7 @@ A typical example for using this module is:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import warp as wp
 
@@ -551,6 +552,131 @@ def compute_v_plus_sparse(
 
 
 @wp.func
+def _vector_has_nan(dim: wp.int32, vio: wp.int32, vector: wp.array[wp.float32]) -> wp.bool:
+    """Checks whether an active vector segment contains NaN.
+
+    Returns ``True`` if any element in ``vector[vio: vio + dim]`` is NaN.
+    """
+    for i in range(dim):
+        if wp.isnan(vector[vio + i]):
+            return True
+    return False
+
+
+@wp.func
+def _spatial_vector_abs_infnorm(v: wp.spatial_vectorf, dim: wp.int32) -> tuple[wp.float32, wp.int32]:
+    """Returns the infinity norm of the first ``dim`` absolute components and the argmax index.
+
+    Scans the first ``dim`` components once. If any active component is NaN,
+    returns ``(nan, -1)``; otherwise on equal values the earliest index is kept
+    as argmax.
+    """
+    max_val = wp.abs(v[0])
+    argmax = wp.int32(0)
+    has_nan = wp.isnan(v[0])
+    for i in range(1, dim):
+        raw = v[i]
+        if wp.isnan(raw):
+            has_nan = True
+        else:
+            val = wp.abs(raw)
+            if val > max_val:
+                max_val = val
+                argmax = wp.int32(i)
+    if has_nan:
+        return wp.nan, wp.int32(-1)
+    return max_val, argmax
+
+
+@wp.func
+def _vector_segment_abs_infnorm(
+    dim: wp.int32,
+    offset: wp.int32,
+    vector: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
+    """Returns the infinity norm of ``abs(vector[offset:offset+dim])`` and the argmax index.
+
+    Scans the segment once. If any active component is NaN, returns ``(nan, -1)``;
+    otherwise on equal values the earliest index is kept as argmax.
+    """
+    max_val = wp.abs(vector[offset])
+    argmax = wp.int32(0)
+    has_nan = wp.isnan(vector[offset])
+    for i in range(1, dim):
+        raw = vector[offset + i]
+        if wp.isnan(raw):
+            has_nan = True
+        else:
+            v = wp.abs(raw)
+            if v > max_val:
+                max_val = v
+                argmax = wp.int32(i)
+    if has_nan:
+        return wp.nan, wp.int32(-1)
+    return max_val, argmax
+
+
+@wp.func
+def _atomic_mark_nan(metric: wp.array[wp.float32], index: wp.int32):
+    """Atomically marks a metric as NaN.
+
+    Once ``metric[index]`` is NaN, it is left unchanged by later calls. Concurrent
+    finite updates from other threads may still race until this write succeeds.
+    """
+    while True:
+        current = metric[index]
+        if wp.isnan(current):
+            return
+        if wp.atomic_cas(metric, index, current, wp.nan) == current:
+            return
+
+
+@wp.func
+def _atomic_max_if_finite(metric: wp.array[wp.float32], index: wp.int32, value: wp.float32) -> wp.float32:
+    """Atomically updates a finite maximum.
+
+    If ``metric[index]`` is already NaN, returns it unchanged and performs no
+    update. Otherwise atomically stores ``max(metric[index], value)``. ``value``
+    is assumed finite; NaN inputs are not propagated here—callers should use
+    :func:`_atomic_mark_nan` instead.
+    """
+    while True:
+        current = metric[index]
+        if wp.isnan(current):
+            return current
+        candidate = wp.max(current, value)
+        previous = wp.atomic_cas(metric, index, current, candidate)
+        if previous == current:
+            return previous
+
+
+@wp.func
+def _atomic_update_metric_max(
+    metric: wp.array[wp.float32],
+    metric_argmax: wp.array[Any],
+    wid: wp.int32,
+    value: wp.float32,
+    argmax_key: Any,
+):
+    """Atomically updates a per-world metric maximum and its argmax key.
+
+    Generic over ``wp.int32`` and ``wp.int64`` argmax keys: ``metric_argmax`` and
+    ``argmax_key`` must use the same concrete type at each call site.
+
+    If ``value`` is NaN, marks ``metric[wid]`` as NaN and sets ``metric_argmax[wid]``
+    to ``-1``. Otherwise atomically stores the finite maximum and, when ``value`` is
+    at least the previous maximum, stores ``argmax_key``.
+    """
+    if wp.isnan(value):
+        _atomic_mark_nan(metric, wid)
+        wp.atomic_exch(metric_argmax, wid, type(argmax_key)(-1))
+    else:
+        previous_max = _atomic_max_if_finite(metric, wid, value)
+        if value >= previous_max:
+            wp.atomic_exch(metric_argmax, wid, argmax_key)
+
+
+@wp.func
 def compute_vector_difference_infnorm(
     dim: wp.int32,
     vio: wp.int32,
@@ -568,16 +694,23 @@ def compute_vector_difference_infnorm(
         y: The second vector.
 
     Returns:
-        Maximum absolute difference and index of the largest component.
+        Maximum absolute difference and index of the largest component. If either
+        input segment contains NaN, returns ``(nan, -1)``.
     """
     max = float(0.0)
     argmax = wp.int32(-1)
+    has_nan = wp.isnan(x[vio]) or wp.isnan(y[vio])
     for i in range(dim):
         v_i = vio + i
-        err = wp.abs(x[v_i] - y[v_i])
-        max = wp.max(max, err)
-        if err == max:
-            argmax = i
+        if wp.isnan(x[v_i]) or wp.isnan(y[v_i]):
+            has_nan = True
+        else:
+            err = wp.abs(x[v_i] - y[v_i])
+            max = wp.max(max, err)
+            if err == max:
+                argmax = i
+    if has_nan:
+        return wp.nan, wp.int32(-1)
     return max, argmax
 
 
@@ -626,20 +759,16 @@ def _compute_eom_residual(
     S_i = wp.skew(omega_i_p)
 
     # Compute the per-body EoM residual over linear and angular parts
-    r_linear_i = wp.abs(m_i * (v_i - v_i_p) - dt * (m_i * g + f_i))
-    r_angular_i = wp.abs(I_i @ (omega_i - omega_i_p) - dt * (tau_i - S_i @ (I_i @ omega_i_p)))
+    r_linear_i = m_i * (v_i - v_i_p) - dt * (m_i * g + f_i)
+    r_angular_i = I_i @ (omega_i - omega_i_p) - dt * (tau_i - S_i @ (I_i @ omega_i_p))
     r_i = wp.spatial_vectorf(*r_linear_i, *r_angular_i)
 
-    # Compute the per-body maximum residual and argmax index
-    r_eom_i = wp.max(r_i)
-    r_eom_argmax_i = wp.int32(wp.argmax(r_i))
+    # Compute the per-body maximum residual and argmax index.
+    r_eom_i, r_eom_argmax_i = _spatial_vector_abs_infnorm(r_i, wp.int32(6))
 
     # Update the per-world maximum residual and argmax index
-    previous_max = wp.atomic_max(metric_r_eom, wid, r_eom_i)
-    if r_eom_i >= previous_max:
-        argmax_key = wp.int64(build_pair_key2(wp.uint32(bid), wp.uint32(r_eom_argmax_i)))
-        wp.atomic_exch(metric_r_eom_argmax, wp.int32(wid), argmax_key)
-
+    argmax_key = wp.int64(build_pair_key2(wp.uint32(bid), wp.uint32(r_eom_argmax_i)))
+    _atomic_update_metric_max(metric_r_eom, metric_r_eom_argmax, wid, r_eom_i, argmax_key)
 
 @wp.kernel
 def _compute_joint_kinematics_residual_dense(
@@ -696,16 +825,12 @@ def _compute_joint_kinematics_residual_dense(
             for i in range(6):
                 j_v_j[j] += jacobian_cts_data[mio_j + i] * u_i_B[i]
 
-    # Compute the per-joint kinematics residual and local argmax
-    j_v_j_abs = wp.abs(j_v_j)
-    kin_argmax_local = wp.argmax(j_v_j_abs)
-    r_kinematics_j = j_v_j_abs[kin_argmax_local]
+    # Compute the per-joint kinematics residual and local argmax.
+    r_kinematics_j, kin_argmax_local = _spatial_vector_abs_infnorm(j_v_j, num_cts_j)
 
     # Update the per-world maximum residual and argmax index
-    previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
-    if r_kinematics_j >= previous_max:
-        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cts_offset_j - kgo) + kin_argmax_local))
-        wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
+    argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cts_offset_j - kgo) + wp.uint32(kin_argmax_local)))
+    _atomic_update_metric_max(metric_r_kinematics, metric_r_kinematics_argmax, wid, r_kinematics_j, argmax_key)
 
 
 @wp.kernel
@@ -756,16 +881,12 @@ def _compute_joint_kinematics_residual_sparse(
             jac_block = jac_nzb_values[jac_j_nzb_start + num_kin_cts_j + j]
             j_v_j[j] += wp.dot(jac_block, u_i_B)
 
-    # Compute the per-joint kinematics residual and local argmax
-    j_v_j_abs = wp.abs(j_v_j)
-    kin_argmax_local = wp.argmax(j_v_j_abs)
-    r_kinematics_j = j_v_j_abs[kin_argmax_local]
+    # Compute the per-joint kinematics residual and local argmax.
+    r_kinematics_j, kin_argmax_local = _spatial_vector_abs_infnorm(j_v_j, num_kin_cts_j)
 
     # Update the per-world maximum residual and argmax index
-    previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
-    if r_kinematics_j >= previous_max:
-        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(kin_cts_offset_j) + kin_argmax_local))
-        wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
+    argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(kin_cts_offset_j) + wp.uint32(kin_argmax_local)))
+    _atomic_update_metric_max(metric_r_kinematics, metric_r_kinematics_argmax, wid, r_kinematics_j, argmax_key)
 
 
 @wp.kernel
@@ -792,19 +913,13 @@ def _compute_cts_joints_residual(
     r_cts_joints_j = wp.float32(0.0)
     argmax_j = wp.int32(0)
     if num_cts_j > 0:
-        r_cts_joints_j = wp.abs(data_joints_r_j[cio_j])
-        for j in range(1, num_cts_j):
-            v = wp.abs(data_joints_r_j[cio_j + j])
-            if v > r_cts_joints_j:
-                r_cts_joints_j = v
-                argmax_j = wp.int32(j)
+        r_cts_joints_j, argmax_j = _vector_segment_abs_infnorm(num_cts_j, cio_j, data_joints_r_j)
+
+    cio_j_loc = cio_j - model_info_joint_kinematic_cts_offset[wid]
 
     # Update the per-world maximum residual and argmax index
-    previous_max = wp.atomic_max(metric_r_cts_joints, wid, r_cts_joints_j)
-    if r_cts_joints_j >= previous_max:
-        cio_j_loc = cio_j - model_info_joint_kinematic_cts_offset[wid]
-        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cio_j_loc + argmax_j)))
-        wp.atomic_exch(metric_r_cts_joints_argmax, wid, argmax_key)
+    argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cio_j_loc + argmax_j)))
+    _atomic_update_metric_max(metric_r_cts_joints, metric_r_cts_joints_argmax, wid, r_cts_joints_j, argmax_key)
 
 
 @wp.kernel
@@ -838,10 +953,8 @@ def _compute_cts_limits_residual(
     r_cts_limits_l = wp.abs(limit_r_q[lid])
 
     # Update the per-world maximum residual
-    previous_max = wp.atomic_max(metric_r_cts_limits, wid, r_cts_limits_l)
-    if r_cts_limits_l >= previous_max:
-        argmax_key = wp.int64(build_pair_key2(wp.uint32(wlid), wp.uint32(dof)))
-        wp.atomic_exch(metric_r_cts_limits_argmax, wid, argmax_key)
+    argmax_key = wp.int64(build_pair_key2(wp.uint32(wlid), wp.uint32(dof)))
+    _atomic_update_metric_max(metric_r_cts_limits, metric_r_cts_limits_argmax, wid, r_cts_limits_l, argmax_key)
 
 
 @wp.kernel
@@ -871,12 +984,13 @@ def _compute_cts_contacts_residual(
     gapfunc = contact_gapfunc[cid]
 
     # Compute unilateral penetration depth from the margin-shifted signed distance.
-    r_cts_contacts_k = wp.max(0.0, -gapfunc[3])
+    r_cts_contacts_k = wp.where(wp.isnan(gapfunc[3]), wp.nan, wp.max(0.0, -gapfunc[3]))
 
-    # Update the per-world maximum residual and argmax index
-    previous_max = wp.atomic_max(metric_r_cts_contacts, wid, r_cts_contacts_k)
-    if r_cts_contacts_k > 0.0 and r_cts_contacts_k >= previous_max:
-        wp.atomic_exch(metric_r_cts_contacts_argmax, wid, wcid)
+    # Both NaN and positive penetration need to be stored as metrics.
+    if wp.isnan(r_cts_contacts_k) or r_cts_contacts_k > 0.0:
+        # Update the per-world maximum residual and argmax index
+        argmax_key = wcid
+        _atomic_update_metric_max(metric_r_cts_contacts, metric_r_cts_contacts_argmax, wid, r_cts_contacts_k, argmax_key)
 
 
 @wp.kernel
@@ -964,6 +1078,24 @@ def _compute_dual_problem_metrics(
     r_ncp_natmap, r_ncp_natmap_argmax = compute_ncp_natural_map_residual(
         njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
+
+    if (
+        _vector_has_nan(ncts, vio, solution_lambdas)
+        or _vector_has_nan(ncts, vio, buffer_v)
+        or _vector_has_nan(nc, cio, problem_mu)
+    ):
+        r_ncp_p = wp.nan
+        r_ncp_p_argmax = wp.int32(-1)
+        r_ncp_d = wp.nan
+        r_ncp_d_argmax = wp.int32(-1)
+        r_ncp_c = wp.nan
+        r_ncp_c_argmax = wp.int32(-1)
+        r_ncp_natmap = wp.nan
+        r_ncp_natmap_argmax = wp.int32(-1)
+
+    if _vector_has_nan(ncts, vio, solution_lambdas) or _vector_has_nan(ncts, vio, problem_v_f):
+        f_ncp = wp.nan
+        f_ccp = wp.nan
 
     # Store the computed metrics in the output arrays
     metric_r_v_plus[wid] = r_v_plus
@@ -1061,6 +1193,24 @@ def _compute_dual_problem_metrics_sparse(
     r_ncp_natmap, r_ncp_natmap_argmax = compute_ncp_natural_map_residual(
         njc, nl, nc, vio, lcgo, ccgo, cio, problem_mu, buffer_v, solution_lambdas
     )
+
+    if (
+        _vector_has_nan(ncts, vio, solution_lambdas)
+        or _vector_has_nan(ncts, vio, buffer_v)
+        or _vector_has_nan(nc, cio, problem_mu)
+    ):
+        r_ncp_p = wp.nan
+        r_ncp_p_argmax = wp.int32(-1)
+        r_ncp_d = wp.nan
+        r_ncp_d_argmax = wp.int32(-1)
+        r_ncp_c = wp.nan
+        r_ncp_c_argmax = wp.int32(-1)
+        r_ncp_natmap = wp.nan
+        r_ncp_natmap_argmax = wp.int32(-1)
+
+    if _vector_has_nan(ncts, vio, solution_lambdas) or _vector_has_nan(ncts, vio, problem_v_f):
+        f_ncp = wp.nan
+        f_ccp = wp.nan
 
     # Store the computed metrics in the output arrays
     metric_r_v_plus[wid] = r_v_plus

--- a/newton/tests/kamino/test_kamino_solvers_metrics.py
+++ b/newton/tests/kamino/test_kamino_solvers_metrics.py
@@ -12,7 +12,10 @@ from newton._src.solvers.kamino._src.dynamics.dual import DualProblem
 from newton._src.solvers.kamino._src.integrators.euler import integrate_euler_semi_implicit
 from newton._src.solvers.kamino._src.kinematics.jacobians import SparseSystemJacobians
 from newton._src.solvers.kamino._src.models.builders.basics import build_box_on_plane, build_boxes_hinged
-from newton._src.solvers.kamino._src.models.builders.testing import build_unary_revolute_joint_test
+from newton._src.solvers.kamino._src.models.builders.testing import (
+    build_free_joint_test,
+    build_unary_revolute_joint_test,
+)
 from newton._src.solvers.kamino._src.solvers.metrics import SolutionMetrics
 from newton._src.solvers.kamino._src.solvers.padmm import PADMMSolver
 from newton._src.solvers.kamino._src.solvers.padmm.types import PADMMData
@@ -970,7 +973,28 @@ class TestSolverMetrics(unittest.TestCase):
                 self.assertTrue(np.isnan(metrics.data.r_eom.numpy()[0]))
                 self.assertTrue(np.isnan(metrics.data.r_kinematics.numpy()[0]))
 
-    def test_13_dual_residual_nan_dense_and_sparse(self):
+    def test_13_free_joint_kinematics_residual_dense_and_sparse(self):
+        """Leave kinematics metrics unset for a FREE joint."""
+        for sparse in (False, True):
+            with self.subTest(sparse=sparse):
+                test = TestSetup(
+                    builder_fn=build_free_joint_test,
+                    max_world_contacts=1,
+                    gravity=False,
+                    perturb=False,
+                    device=self.default_device,
+                    sparse=sparse,
+                )
+                test.build()
+                metrics = SolutionMetrics(model=test.model)
+
+                metrics.reset()
+                metrics._evaluate_primal_problem_perf(test.model, test.data, test.state_p, test.jacobians)
+
+                np.testing.assert_array_equal(metrics.data.r_kinematics.numpy(), [0.0])
+                np.testing.assert_array_equal(metrics.data.r_kinematics_argmax.numpy(), [-1])
+
+    def test_14_dual_residual_nan_dense_and_sparse(self):
         """Propagate a NaN solution multiplier into dual analysis metrics."""
         for sparse in (False, True):
             with self.subTest(sparse=sparse):
@@ -1010,7 +1034,7 @@ class TestSolverMetrics(unittest.TestCase):
                         msg=f"{metric_name} did not propagate NaN",
                     )
 
-    def test_14_dual_metric_input_nan(self):
+    def test_15_dual_metric_input_nan(self):
         """Propagate NaN dual inputs through their affected analysis metrics."""
         for input_name in ("v_plus", "v_f", "mu"):
             with self.subTest(input_name=input_name):
@@ -1057,7 +1081,7 @@ class TestSolverMetrics(unittest.TestCase):
                             msg=f"{metric_name} did not propagate {input_name} NaN",
                         )
 
-    def test_15_metrics_reset_clears_nan(self):
+    def test_16_metrics_reset_clears_nan(self):
         """Clear a reported NaN before evaluating a finite joint residual."""
         test = TestSetup(
             builder_fn=build_boxes_hinged,

--- a/newton/tests/kamino/test_kamino_solvers_metrics.py
+++ b/newton/tests/kamino/test_kamino_solvers_metrics.py
@@ -12,6 +12,7 @@ from newton._src.solvers.kamino._src.dynamics.dual import DualProblem
 from newton._src.solvers.kamino._src.integrators.euler import integrate_euler_semi_implicit
 from newton._src.solvers.kamino._src.kinematics.jacobians import SparseSystemJacobians
 from newton._src.solvers.kamino._src.models.builders.basics import build_box_on_plane, build_boxes_hinged
+from newton._src.solvers.kamino._src.models.builders.testing import build_unary_revolute_joint_test
 from newton._src.solvers.kamino._src.solvers.metrics import SolutionMetrics
 from newton._src.solvers.kamino._src.solvers.padmm import PADMMSolver
 from newton._src.solvers.kamino._src.solvers.padmm.types import PADMMData
@@ -877,6 +878,7 @@ class TestSolverMetrics(unittest.TestCase):
         np.testing.assert_array_equal(argmax, [-1, -1])
 
     def test_08_contact_residual_mixed_signed_distances(self):
+        """Report the largest penetration per world."""
         residual, argmax = self._evaluate_contact_residuals(
             [
                 (0, 0, 0.5),
@@ -889,6 +891,195 @@ class TestSolverMetrics(unittest.TestCase):
 
         np.testing.assert_allclose(residual, [0.1, 0.4])
         np.testing.assert_array_equal(argmax, [1, 2])
+
+    def test_09_contact_residual_nan(self):
+        """Propagate a NaN contact gap into the contact metric."""
+        residual, _ = self._evaluate_contact_residuals([(0, 0, np.nan), (1, 0, -0.2)])
+
+        self.assertTrue(np.isnan(residual[0]))
+        self.assertAlmostEqual(residual[1], 0.2)
+
+    def test_10_joint_residual_nan(self):
+        """Propagate a NaN joint residual into the joint constraint metric."""
+        test = TestSetup(
+            builder_fn=build_boxes_hinged,
+            max_world_contacts=8,
+            gravity=False,
+            perturb=False,
+            device=self.default_device,
+        )
+        test.build()
+        metrics = SolutionMetrics(model=test.model)
+        residuals = test.data.joints.r_j.numpy()
+        joint_offset = test.model.joints.kinematic_cts_offset.numpy()[0]
+        residuals[joint_offset] = np.nan
+        test.data.joints.r_j.assign(residuals)
+        metrics.reset()
+        metrics._evaluate_constraint_violations_perf(test.model, test.data)
+        self.assertTrue(np.isnan(metrics.data.r_cts_joints.numpy()[0]))
+
+    def test_11_limit_residual_nan(self):
+        """Propagate a NaN limit residual into the limit constraint metric."""
+        test = TestSetup(
+            builder_fn=build_unary_revolute_joint_test,
+            max_world_contacts=1,
+            gravity=False,
+            perturb=False,
+            device=self.default_device,
+        )
+        test.build()
+        metrics = SolutionMetrics(model=test.model)
+        residuals = test.limits.data.r_q.numpy()
+        residuals[0] = np.nan
+        wids = test.limits.data.wid.numpy()
+        lids = test.limits.data.lid.numpy()
+        dofs = test.limits.data.dof.numpy()
+        wids[0] = 0
+        lids[0] = 0
+        dofs[0] = 0
+        test.limits.data.model_active_limits.assign(np.array([1], dtype=np.int32))
+        test.limits.data.r_q.assign(residuals)
+        test.limits.data.wid.assign(wids)
+        test.limits.data.lid.assign(lids)
+        test.limits.data.dof.assign(dofs)
+        metrics.reset()
+        metrics._evaluate_constraint_violations_perf(test.model, test.data, limits=test.limits)
+        self.assertTrue(np.isnan(metrics.data.r_cts_limits.numpy()[0]))
+
+    def test_12_primal_residual_nan_dense_and_sparse(self):
+        """Propagate a NaN body velocity into dense and sparse primal metrics."""
+        for sparse in (False, True):
+            with self.subTest(sparse=sparse):
+                test = TestSetup(
+                    builder_fn=build_boxes_hinged,
+                    max_world_contacts=8,
+                    gravity=False,
+                    perturb=False,
+                    device=self.default_device,
+                    sparse=sparse,
+                )
+                test.build()
+                metrics = SolutionMetrics(model=test.model)
+                velocities = test.data.bodies.u_i.numpy()
+                bid_follower = test.model.joints.bid_F.numpy()[0]
+                velocities[bid_follower, 0] = np.nan
+                test.data.bodies.u_i.assign(velocities)
+                metrics.reset()
+                metrics._evaluate_primal_problem_perf(test.model, test.data, test.state_p, test.jacobians)
+
+                self.assertTrue(np.isnan(metrics.data.r_eom.numpy()[0]))
+                self.assertTrue(np.isnan(metrics.data.r_kinematics.numpy()[0]))
+
+    def test_13_dual_residual_nan_dense_and_sparse(self):
+        """Propagate a NaN solution multiplier into dual analysis metrics."""
+        for sparse in (False, True):
+            with self.subTest(sparse=sparse):
+                test = TestSetup(
+                    builder_fn=build_box_on_plane,
+                    max_world_contacts=4,
+                    gravity=False,
+                    perturb=False,
+                    device=self.default_device,
+                    sparse=sparse,
+                )
+                test.build()
+                metrics = SolutionMetrics(model=test.model)
+                with wp.ScopedDevice(test.model.device):
+                    sigma = wp.zeros(test.model.size.num_worlds, dtype=wp.vec2f)
+                    lambdas = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                    v_plus = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                lambda_values = lambdas.numpy()
+                vio = test.problem.data.vio.numpy()[0]
+                lambda_values[vio + test.problem.data.ccgo.numpy()[0]] = np.nan
+                lambdas.assign(lambda_values)
+
+                metrics.reset()
+                metrics._evaluate_dual_problem_perf(sigma, lambdas, v_plus, test.problem)
+
+                for metric_name in (
+                    "r_v_plus",
+                    "r_ncp_primal",
+                    "r_ncp_dual",
+                    "r_ncp_compl",
+                    "r_vi_natmap",
+                    "f_ncp",
+                    "f_ccp",
+                ):
+                    self.assertTrue(
+                        np.isnan(getattr(metrics.data, metric_name).numpy()[0]),
+                        msg=f"{metric_name} did not propagate NaN",
+                    )
+
+    def test_14_dual_metric_input_nan(self):
+        """Propagate NaN dual inputs through their affected analysis metrics."""
+        for input_name in ("v_plus", "v_f", "mu"):
+            with self.subTest(input_name=input_name):
+                test = TestSetup(
+                    builder_fn=build_box_on_plane,
+                    max_world_contacts=4,
+                    gravity=False,
+                    perturb=False,
+                    device=self.default_device,
+                )
+                test.build()
+                metrics = SolutionMetrics(model=test.model)
+                with wp.ScopedDevice(test.model.device):
+                    sigma = wp.zeros(test.model.size.num_worlds, dtype=wp.vec2f)
+                    lambdas = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                    v_plus = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                vio = test.problem.data.vio.numpy()[0]
+                contact_offset = test.problem.data.ccgo.numpy()[0]
+
+                if input_name == "v_plus":
+                    values = v_plus.numpy()
+                    values[vio + contact_offset] = np.nan
+                    v_plus.assign(values)
+                elif input_name == "v_f":
+                    values = test.problem.data.v_f.numpy()
+                    values[vio + contact_offset] = np.nan
+                    test.problem.data.v_f.assign(values)
+                else:
+                    values = test.problem.data.mu.numpy()
+                    values[test.problem.data.cio.numpy()[0]] = np.nan
+                    test.problem.data.mu.assign(values)
+
+                metrics.reset()
+                metrics._evaluate_dual_problem_perf(sigma, lambdas, v_plus, test.problem)
+                if input_name == "mu":
+                    self.assertTrue(np.isfinite(metrics.data.r_v_plus.numpy()[0]))
+                else:
+                    self.assertTrue(np.isnan(metrics.data.r_v_plus.numpy()[0]))
+
+                if input_name != "v_plus":
+                    for metric_name in ("r_ncp_primal", "r_ncp_dual", "r_ncp_compl", "r_vi_natmap"):
+                        self.assertTrue(
+                            np.isnan(getattr(metrics.data, metric_name).numpy()[0]),
+                            msg=f"{metric_name} did not propagate {input_name} NaN",
+                        )
+
+    def test_15_metrics_reset_clears_nan(self):
+        """Clear a reported NaN before evaluating a finite joint residual."""
+        test = TestSetup(
+            builder_fn=build_boxes_hinged,
+            max_world_contacts=8,
+            gravity=False,
+            perturb=False,
+            device=self.default_device,
+        )
+        test.build()
+        metrics = SolutionMetrics(model=test.model)
+        residuals = test.data.joints.r_j.numpy()
+        residuals[test.model.joints.kinematic_cts_offset.numpy()[0]] = np.nan
+        test.data.joints.r_j.assign(residuals)
+        metrics.reset()
+        metrics._evaluate_constraint_violations_perf(test.model, test.data)
+        self.assertTrue(np.isnan(metrics.data.r_cts_joints.numpy()[0]))
+
+        residuals.fill(0.0)
+        test.data.joints.r_j.assign(residuals)
+        metrics.reset()
+        metrics._evaluate_constraint_violations_perf(test.model, test.data)
+        self.assertTrue(np.isfinite(metrics.data.r_cts_joints.numpy()[0]))
 
 
 ###

--- a/newton/tests/kamino/test_kamino_solvers_metrics.py
+++ b/newton/tests/kamino/test_kamino_solvers_metrics.py
@@ -897,10 +897,11 @@ class TestSolverMetrics(unittest.TestCase):
 
     def test_09_contact_residual_nan(self):
         """Propagate a NaN contact gap into the contact metric."""
-        residual, _ = self._evaluate_contact_residuals([(0, 0, np.nan), (1, 0, -0.2)])
+        residual, argmax = self._evaluate_contact_residuals([(0, 0, np.nan), (1, 0, -0.2)])
 
         self.assertTrue(np.isnan(residual[0]))
         self.assertAlmostEqual(residual[1], 0.2)
+        np.testing.assert_array_equal(argmax, [-1, 0])
 
     def test_10_joint_residual_nan(self):
         """Propagate a NaN joint residual into the joint constraint metric."""
@@ -1036,50 +1037,59 @@ class TestSolverMetrics(unittest.TestCase):
 
     def test_15_dual_metric_input_nan(self):
         """Propagate NaN dual inputs through their affected analysis metrics."""
-        for input_name in ("v_plus", "v_f", "mu"):
-            with self.subTest(input_name=input_name):
-                test = TestSetup(
-                    builder_fn=build_box_on_plane,
-                    max_world_contacts=4,
-                    gravity=False,
-                    perturb=False,
-                    device=self.default_device,
-                )
-                test.build()
-                metrics = SolutionMetrics(model=test.model)
-                with wp.ScopedDevice(test.model.device):
-                    sigma = wp.zeros(test.model.size.num_worlds, dtype=wp.vec2f)
-                    lambdas = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
-                    v_plus = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
-                vio = test.problem.data.vio.numpy()[0]
-                contact_offset = test.problem.data.ccgo.numpy()[0]
+        for sparse in (False, True):
+            for input_name in ("v_plus", "v_f", "mu"):
+                with self.subTest(sparse=sparse, input_name=input_name):
+                    test = TestSetup(
+                        builder_fn=build_box_on_plane,
+                        max_world_contacts=4,
+                        gravity=False,
+                        perturb=False,
+                        device=self.default_device,
+                        sparse=sparse,
+                    )
+                    test.build()
+                    metrics = SolutionMetrics(model=test.model)
+                    with wp.ScopedDevice(test.model.device):
+                        sigma = wp.zeros(test.model.size.num_worlds, dtype=wp.vec2f)
+                        lambdas = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                        v_plus = wp.zeros(test.model.size.sum_of_max_total_cts, dtype=wp.float32)
+                    vio = test.problem.data.vio.numpy()[0]
+                    contact_offset = test.problem.data.ccgo.numpy()[0]
 
-                if input_name == "v_plus":
-                    values = v_plus.numpy()
-                    values[vio + contact_offset] = np.nan
-                    v_plus.assign(values)
-                elif input_name == "v_f":
-                    values = test.problem.data.v_f.numpy()
-                    values[vio + contact_offset] = np.nan
-                    test.problem.data.v_f.assign(values)
-                else:
-                    values = test.problem.data.mu.numpy()
-                    values[test.problem.data.cio.numpy()[0]] = np.nan
-                    test.problem.data.mu.assign(values)
+                    if input_name == "v_plus":
+                        values = v_plus.numpy()
+                        values[vio + contact_offset] = np.nan
+                        v_plus.assign(values)
+                    elif input_name == "v_f":
+                        values = test.problem.data.v_f.numpy()
+                        values[vio + contact_offset] = np.nan
+                        test.problem.data.v_f.assign(values)
+                    else:
+                        values = test.problem.data.mu.numpy()
+                        values[test.problem.data.cio.numpy()[0]] = np.nan
+                        test.problem.data.mu.assign(values)
 
-                metrics.reset()
-                metrics._evaluate_dual_problem_perf(sigma, lambdas, v_plus, test.problem)
-                if input_name == "mu":
-                    self.assertTrue(np.isfinite(metrics.data.r_v_plus.numpy()[0]))
-                else:
-                    self.assertTrue(np.isnan(metrics.data.r_v_plus.numpy()[0]))
+                    metrics.reset()
+                    metrics._evaluate_dual_problem_perf(sigma, lambdas, v_plus, test.problem)
+                    if input_name == "mu":
+                        self.assertTrue(np.isfinite(metrics.data.r_v_plus.numpy()[0]))
+                    else:
+                        self.assertTrue(np.isnan(metrics.data.r_v_plus.numpy()[0]))
 
-                if input_name != "v_plus":
-                    for metric_name in ("r_ncp_primal", "r_ncp_dual", "r_ncp_compl", "r_vi_natmap"):
-                        self.assertTrue(
-                            np.isnan(getattr(metrics.data, metric_name).numpy()[0]),
-                            msg=f"{metric_name} did not propagate {input_name} NaN",
-                        )
+                    if input_name != "v_plus":
+                        for metric_name in ("r_ncp_primal", "r_ncp_dual", "r_ncp_compl", "r_vi_natmap"):
+                            self.assertTrue(
+                                np.isnan(getattr(metrics.data, metric_name).numpy()[0]),
+                                msg=f"{metric_name} did not propagate {input_name} NaN",
+                            )
+
+                    if input_name == "v_f":
+                        for metric_name in ("f_ncp", "f_ccp"):
+                            self.assertTrue(
+                                np.isnan(getattr(metrics.data, metric_name).numpy()[0]),
+                                msg=f"{metric_name} did not propagate v_f NaN",
+                            )
 
     def test_16_metrics_reset_clears_nan(self):
         """Clear a reported NaN before evaluating a finite joint residual."""


### PR DESCRIPTION
## Description

Warp max does not propagate NaN value: `wp.max(v, NaN) -> v`. The result was that all metrics remain 0.0 in case the solution contains NaNs. This PR propagates the NaN values over the max finite such that it is correctly reflected in the metrics.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved solver metric handling when calculations contain invalid or missing numerical values.
  - Residual and objective metrics now consistently report undefined results instead of misleading values.
  - Preserved relevant maximum-error locations for easier diagnosis.
  - Resetting metrics now reliably clears previous invalid results before new calculations.
  - Free joints no longer contribute incorrectly to kinematics metrics.

- **Tests**
  - Expanded coverage across contact, joint, limit, primal, and dual solver metrics in dense and sparse modes.
  - Added regression coverage confirming correct handling of free-joint kinematics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->