### PR TITLE
Raise AWS runner watchdog threshold

### DIFF
--- a/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
+++ b/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
@@ -50,7 +50,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: overdue-newton-github-runner-watchdog
-      Description: Report tagged Newton runners active for at least 60 minutes.
+      Description: Report tagged Newton runners active for at least 120 minutes.
       Runtime: python3.12
       Handler: index.lambda_handler
       Role:
@@ -61,7 +61,7 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
-          MAX_AGE_MINUTES: "60"
+          MAX_AGE_MINUTES: "120"
       Code:
         ZipFile: |
           """Report overdue Newton GitHub runner instances across AWS regions."""
@@ -213,7 +213,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: overdue-newton-github-runner-watchdog
-      AlarmDescription: A tagged Newton GitHub runner is at least 60 minutes old, or the watchdog has stopped reporting.
+      AlarmDescription: A tagged Newton GitHub runner is at least 120 minutes old, or the watchdog has stopped reporting.
       Namespace: Newton/GitHubRunnerWatchdog
       MetricName: OverdueRunnerCount
       Statistic: Maximum


### PR DESCRIPTION
## Description

Raise the AWS runner watchdog threshold from 60 to 120 minutes.

The regional cleanup Lambdas now allow runners to run for 90 minutes, but the watchdog still classified them as overdue after 60 minutes. That could trigger an alert for a healthy job before cleanup was expected to run. A 120-minute threshold gives cleanup a 30-minute buffer.

The CloudFormation stack in `us-east-1` has already been updated, so this PR brings the version-controlled template back in sync with production.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] No changelog fragment is needed because this only changes CI infrastructure

## Test plan

- `uv run --extra dev -m unittest scripts/ci/tests/test_watchdog_logic.py -v`
- `uvx pre-commit run -a`
- Validated the template with AWS CloudFormation.
- Created and reviewed the CloudFormation change set, then applied it.
- Invoked the deployed watchdog manually. It scanned 17 enabled regions with a 120-minute threshold and reported no overdue runners.
- Confirmed the alarm is `OK` and the deployed stack is `IN_SYNC`.