### PR TITLE
Centralize AWS runner cleanup

### DIFF
--- a/scripts/ci/aws/README.md
+++ b/scripts/ci/aws/README.md
@@ -1,112 +1,151 @@
 # AWS CI infrastructure
 
-This directory contains the source templates for AWS resources used by Newton
-CI. If the templates exist only in AWS, maintainers have to reconstruct the
-deployed configuration from console history during an incident. Checking them
-into Git gives us a reviewable change history and a known version to restore.
+This directory contains the source templates for AWS resources used by Newton CI. Keeping the templates in Git provides a reviewable history and a known version to restore during an incident. These files are source files, not examples or generated output.
 
-That history is why these files belong in the repository. They are source files,
-not examples or generated output. The templates contain no credentials,
-secrets, private endpoints, or notification subscribers. They do not grant
-access to AWS, and commits to this directory do not deploy automatically.
+The templates contain no credentials, secrets, private endpoints, or notification subscribers. A Git commit does not deploy AWS resources or change AWS access. Deploying the watchdog template creates an IAM role with the permissions described below.
 
-Put future AWS CI templates here too. This gives the small group that maintains
-the infrastructure one place to look and keeps AWS details out of the rest of
-the project.
+## AWS terms used here
+
+AWS has a name for almost every part of this setup. These definitions describe what each term means for the Newton CI watchdog.
+
+| Term | Meaning in this README |
+| --- | --- |
+| AWS account | The account owns these resources and is charged for what they use. Before an update, `sts get-caller-identity` helps you check that the AWS CLI is pointed at the Newton CI account. |
+| [Region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) | A separate AWS location with a code such as `us-east-1`. Resources in one Region usually do not appear in another. The watchdog is deployed in `us-east-1` but checks runners in several Regions. |
+| [AWS CLI profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) | A named set of credentials and settings for AWS commands. `AWS_PROFILE` selects the profile, which determines the identity and account used by the commands below. |
+| [EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) and [EBS volume](https://docs.aws.amazon.com/ebs/latest/userguide/what-is-ebs.html) | An EC2 instance is the virtual machine that runs a CI job. An EBS volume is its attached disk. The runner workflow tags both so operators can trace them back to GitHub. |
+| [CloudFormation template, stack, and change set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-overview.html) | A template is a YAML file that describes AWS resources. A stack is the live group of resources that CloudFormation manages from the template. A change set previews an update; creating one does not apply the proposed changes. |
+| [IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) and [policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) | The role is the identity that Lambda uses when it calls AWS. Its policy says which API actions are allowed and under what conditions. Here, that means scanning EC2 and terminating only instances with the ownership tag. |
+| [Lambda](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html) | The service that runs the watchdog's Python code without a dedicated server. Each scheduled check is one Lambda invocation. |
+| [EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html) | The timer for the watchdog. Its scheduled rule invokes the Lambda function every 15 minutes. |
+| [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html) | The service that stores the Lambda logs and the numbers reported by the watchdog. CloudWatch alarms watch those metrics and Lambda errors, then send alarm state changes to SNS. |
+| [SNS topic](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) and [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) | An SNS topic sends alarm notifications to its subscribers. An ARN is the unique AWS identifier for a resource. `AlertTopicArn` points the stack at an existing topic without putting its subscribers in this repository. |
+| [Resource tag](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) and ownership boundary | A tag is a key-value label on an AWS resource. The watchdog searches for `created-by=github-actions-newton-role`, and its IAM policy checks the same tag before termination. That repeated check is the ownership boundary. |
+| [Control plane](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/control-planes-and-data-planes.html) | The administrative APIs that create, change, describe, and delete AWS resources. The watchdog uses EC2 control-plane calls to find and terminate runners in monitored Regions. Its own stack lives in `us-east-1`. |
+| Shadow mode, canary, and rollback | Shadow mode records what the watchdog would terminate without doing it. A canary limits real termination to one repository before wider cleanup is enabled. A rollback restores the saved template and parameters through a reverse change set. |
 
 ## Runner attribution tags
 
-The runner workflows apply repository, trigger, workload, and run identifiers
-as resource tags on EC2 instances and attached EBS volumes. These tags support
-resource-level attribution through the EC2 console and APIs. The AWS account
-used by Newton CI does not allow user-defined cost-allocation tags, so these
-keys cannot be activated as Cost Explorer or Cost and Usage Report dimensions.
+The runner workflows apply repository, trigger, workload, and run identifiers as resource tags on EC2 instances and attached EBS volumes. These tags support resource-level attribution through the EC2 console and APIs. The AWS account used by Newton CI does not allow user-defined cost-allocation tags, so these keys cannot be activated as Cost Explorer or Cost and Usage Report dimensions.
 
-## Inventory
+## Inventory and safety boundaries
 
 | Template | Stack | Region | Required parameters |
 | --- | --- | --- | --- |
 | `overdue-newton-github-runner-watchdog.yaml` | `overdue-newton-github-runner-watchdog` | `us-east-1` | `AlertTopicArn` |
 
-The deployer must supply `AlertTopicArn` because the template has no default.
-This keeps notification routing and subscriber details outside the repository.
+`AlertTopicArn` is the only required template parameter. It has no default and must identify the existing SNS topic that receives watchdog alarm transitions. The optional parameters have these defaults:
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `TerminateAfterMinutes` | `90` | Age at which an owned running instance becomes a cleanup candidate. Accepts values from `1` through `120`. |
+| `TerminationEnabled` | `false` | Enables termination when set to `true`. `false` is shadow mode, which records instances that the watchdog would terminate without terminating them. |
+| `RequiredRepository` | Empty string | Requires an exact repository tag when nonempty. It must be set when termination is enabled with `TerminateAfterMinutes` below `90`. It is additional to, not a replacement for, the permanent ownership boundary. |
+
+The permanent ownership boundary is `created-by=github-actions-newton-role`. The watchdog discovers only instances with this tag, and its IAM policy permits termination only for instances with the same tag.
+
+The watchdog stack runs in `us-east-1`. Its EventBridge rule, Lambda function, logs, metrics, and alarms are regional resources, so the stack has one home region. The Lambda function creates boto3 EC2 clients for each monitored region: `us-east-1`, `us-east-2`, `us-west-2`, `ap-northeast-1`, and `ap-northeast-2`.
 
 ## Validate and review a change
 
-Authenticate the AWS CLI, check that the selected profile points to the intended
-account, then validate the template:
+Run [`cfn-lint`](https://github.com/aws-cloudformation/cfn-lint) locally before signing in to AWS. It checks resource types and properties against the CloudFormation schemas:
 
 ```bash
-NEWTON_AWS_PROFILE=isaac-sim-CS-Admin
-NEWTON_AWS_REGION=us-east-1
-NEWTON_WATCHDOG_STACK=overdue-newton-github-runner-watchdog
-NEWTON_CHANGE_SET=aws-runner-watchdog-update
+uvx --from cfn-lint cfn-lint \
+  scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
+```
 
-aws --profile "$NEWTON_AWS_PROFILE" sts get-caller-identity
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation validate-template \
-  --region "$NEWTON_AWS_REGION" \
+Next, authenticate the AWS CLI and confirm that the selected profile is for the intended account. `validate-template` sends the template to CloudFormation for a syntax check. It does not replace the schema checks from `cfn-lint`:
+
+```bash
+if [ -z "${AWS_PROFILE:-}" ]; then
+  echo "AWS_PROFILE must name the intended AWS CLI profile" >&2
+  exit 1
+fi
+
+AWS_REGION=us-east-1
+WATCHDOG_STACK=overdue-newton-github-runner-watchdog
+CHANGE_SET=runner-watchdog-update
+EVIDENCE_DIR="$(mktemp -d)" || exit 1
+
+aws --profile "$AWS_PROFILE" sts get-caller-identity
+aws --profile "$AWS_PROFILE" cloudformation validate-template \
+  --region "$AWS_REGION" \
   --template-body file://scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
 ```
 
-Before creating a change set, save the stack's current template and parameters
-outside the repository in case you need to roll back. Read the alert action on
-the deployed alarm and verify that it points to the intended SNS topic:
+Neither command tests the Python code embedded in the Lambda resource. `scripts/ci/tests/test_watchdog_logic.py` covers that behavior.
+
+Save the current template, parameters, and stack status outside the repository before an update. Keep that evidence until the change is no longer needed for rollback.
 
 ```bash
-NEWTON_ALERT_TOPIC_ARN="$(
-  aws --profile "$NEWTON_AWS_PROFILE" cloudwatch describe-alarms \
-    --region "$NEWTON_AWS_REGION" \
-    --alarm-names overdue-newton-github-runner-watchdog \
-    --query 'MetricAlarms[0].AlarmActions[0]' \
-    --output text
-)"
+aws --profile "$AWS_PROFILE" cloudformation get-template \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --query TemplateBody \
+  --output text > "$EVIDENCE_DIR/current-template.yaml" || exit 1
 
-case "$NEWTON_ALERT_TOPIC_ARN" in
-  arn:aws:sns:us-east-1:*) ;;
-  *) echo "Unexpected alert topic ARN" >&2; exit 1 ;;
-esac
+[ -s "$EVIDENCE_DIR/current-template.yaml" ] || {
+  echo "Saved template is empty" >&2
+  exit 1
+}
 
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation create-change-set \
-  --region "$NEWTON_AWS_REGION" \
-  --stack-name "$NEWTON_WATCHDOG_STACK" \
-  --change-set-name "$NEWTON_CHANGE_SET" \
+aws --profile "$AWS_PROFILE" cloudformation describe-stacks \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --query 'Stacks[0].{Parameters:Parameters,StackStatus:StackStatus}' \
+  --output json > "$EVIDENCE_DIR/current-stack.json" || exit 1
+
+[ -s "$EVIDENCE_DIR/current-stack.json" ] || {
+  echo "Saved stack configuration is empty" >&2
+  exit 1
+}
+```
+
+Use the committed template and a reviewed CloudFormation change set. This update example keeps cleanup disabled explicitly. `AlertTopicArn` uses the current stack value; creating a new stack requires supplying that required parameter with the real SNS topic ARN outside this document.
+
+```bash
+aws --profile "$AWS_PROFILE" cloudformation create-change-set \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --change-set-name "$CHANGE_SET" \
   --change-set-type UPDATE \
   --template-body file://scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml \
-  --parameters "ParameterKey=AlertTopicArn,ParameterValue=$NEWTON_ALERT_TOPIC_ARN" \
+  --parameters \
+    'ParameterKey=AlertTopicArn,UsePreviousValue=true' \
+    'ParameterKey=TerminateAfterMinutes,ParameterValue=90' \
+    'ParameterKey=TerminationEnabled,ParameterValue=false' \
+    'ParameterKey=RequiredRepository,ParameterValue=' \
   --capabilities CAPABILITY_NAMED_IAM
 
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation wait change-set-create-complete \
-  --region "$NEWTON_AWS_REGION" \
-  --stack-name "$NEWTON_WATCHDOG_STACK" \
-  --change-set-name "$NEWTON_CHANGE_SET"
+aws --profile "$AWS_PROFILE" cloudformation wait change-set-create-complete \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --change-set-name "$CHANGE_SET"
 
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation describe-change-set \
-  --region "$NEWTON_AWS_REGION" \
-  --stack-name "$NEWTON_WATCHDOG_STACK" \
-  --change-set-name "$NEWTON_CHANGE_SET"
+aws --profile "$AWS_PROFILE" cloudformation describe-change-set \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --change-set-name "$CHANGE_SET"
 ```
 
-Read the complete change set before executing it. This stack has a named IAM
-role, so the update requires `CAPABILITY_NAMED_IAM`. Pay close attention to IAM
-changes, and stop if the change set contains an unexpected replacement,
-deletion, resource, or permission change.
-
-Execute only after review:
+The stack has a named IAM role, so every change set requires `CAPABILITY_NAMED_IAM`. Review the full change set before execution and stop if it includes an unexpected replacement, deletion, resource, or permission change. Operators enable cleanup only through reviewed parameter changes.
 
 ```bash
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation execute-change-set \
-  --region "$NEWTON_AWS_REGION" \
-  --stack-name "$NEWTON_WATCHDOG_STACK" \
-  --change-set-name "$NEWTON_CHANGE_SET"
+aws --profile "$AWS_PROFILE" cloudformation execute-change-set \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK" \
+  --change-set-name "$CHANGE_SET"
 
-aws --profile "$NEWTON_AWS_PROFILE" cloudformation wait stack-update-complete \
-  --region "$NEWTON_AWS_REGION" \
-  --stack-name "$NEWTON_WATCHDOG_STACK"
+aws --profile "$AWS_PROFILE" cloudformation wait stack-update-complete \
+  --region "$AWS_REGION" \
+  --stack-name "$WATCHDOG_STACK"
 ```
 
-After deployment, invoke the watchdog, confirm that it emits fresh metrics and
-logs, then check the alarm state. Investigate any stack drift before making
-another change. If verification fails, restore the saved template and parameters
-with a reviewed reverse change set. Do not update stack-managed resources
-directly because CloudFormation will no longer have an accurate record of their
-configuration.
+Local tests can exercise template behavior, but they cannot prove AWS IAM enforcement.
+
+## Failure handling and rollback
+
+The watchdog collects regional scan and per-instance termination failures so it can continue the remaining work. Any collected failure causes the invocation to fail after the watchdog emits metrics and structured output. The native Lambda error alarm catches those failed invocations.
+
+To roll back a deployed stack change, create and review a reverse CloudFormation change set using the saved template and parameters, then execute it. One-time migration rollback and legacy-resource handling are intentionally outside this permanent README.

--- a/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
+++ b/scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml
@@ -1,10 +1,34 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Alert when tagged Newton GitHub runners remain active too long.
+Description: Report and clean up tagged Newton GitHub runners that remain active too long.
 
 Parameters:
   AlertTopicArn:
     Type: String
     Description: Existing SNS topic ARN for watchdog alarm transitions.
+  TerminateAfterMinutes:
+    Type: Number
+    Default: 90
+    MinValue: 1
+    MaxValue: 120
+    Description: Age at which an owned running instance becomes a cleanup candidate.
+  TerminationEnabled:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether the watchdog may terminate cleanup candidates.
+  RequiredRepository:
+    Type: String
+    Default: ""
+    Description: Optional exact repository tag required during a cleanup canary.
+
+Conditions:
+  RestrictTerminationByRepository:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: RequiredRepository
+          - ""
 
 Resources:
   WatchdogRole:
@@ -30,9 +54,28 @@ Resources:
               - Sid: DiscoverInstances
                 Effect: Allow
                 Action:
-                  - ec2:DescribeRegions
                   - ec2:DescribeInstances
                 Resource: "*"
+              - Fn::If:
+                  - RestrictTerminationByRepository
+                  - Sid: TerminateCanaryRepositoryRunners
+                    Effect: Allow
+                    Action: ec2:TerminateInstances
+                    Resource:
+                      Fn::Sub: arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*
+                    Condition:
+                      StringEquals:
+                        ec2:ResourceTag/created-by: github-actions-newton-role
+                        ec2:ResourceTag/GitHub-Repository:
+                          Ref: RequiredRepository
+                  - Sid: TerminateOwnedRunners
+                    Effect: Allow
+                    Action: ec2:TerminateInstances
+                    Resource:
+                      Fn::Sub: arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*
+                    Condition:
+                      StringEquals:
+                        ec2:ResourceTag/created-by: github-actions-newton-role
               - Sid: PublishWatchdogMetrics
                 Effect: Allow
                 Action: cloudwatch:PutMetricData
@@ -50,21 +93,28 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: overdue-newton-github-runner-watchdog
-      Description: Report tagged Newton runners active for at least 120 minutes.
+      Description: Report and clean up tagged Newton GitHub runners active too long.
       Runtime: python3.12
       Handler: index.lambda_handler
       Role:
         Fn::GetAtt:
           - WatchdogRole
           - Arn
-      Timeout: 60
+      Timeout: 120
       MemorySize: 128
       Environment:
         Variables:
-          MAX_AGE_MINUTES: "120"
+          ALERT_AFTER_MINUTES: "120"
+          MONITORED_REGIONS: us-east-1,us-east-2,us-west-2,ap-northeast-1,ap-northeast-2
+          REQUIRED_REPOSITORY:
+            Ref: RequiredRepository
+          TERMINATE_AFTER_MINUTES:
+            Ref: TerminateAfterMinutes
+          TERMINATION_ENABLED:
+            Ref: TerminationEnabled
       Code:
         ZipFile: |
-          """Report overdue Newton GitHub runner instances across AWS regions."""
+          """Report and clean up tagged Newton GitHub runner instances."""
 
           from __future__ import annotations
 
@@ -75,15 +125,75 @@ Resources:
 
           CREATED_BY = "github-actions-newton-role"
           METRIC_NAMESPACE = "Newton/GitHubRunnerWatchdog"
+          PRODUCTION_TERMINATE_AFTER_MINUTES = 90
 
 
-          def find_overdue_instances(region_names, ec2_factory, now, max_age_minutes):
-              """Return matching running instances at least the maximum age."""
+          def parse_bool(value):
+              """Parse an exact lower-case Boolean string."""
+              if value == "true":
+                  return True
+              if value == "false":
+                  return False
+              raise ValueError("TERMINATION_ENABLED must be 'true' or 'false'")
+
+
+          def load_config(environ):
+              """Return validated cleanup configuration from an environment mapping."""
+              region_names = [
+                  region.strip()
+                  for region in environ.get("MONITORED_REGIONS", "").split(",")
+                  if region.strip()
+              ]
+              terminate_after_minutes = float(environ["TERMINATE_AFTER_MINUTES"])
+              alert_after_minutes = int(environ["ALERT_AFTER_MINUTES"])
+              termination_enabled = parse_bool(environ["TERMINATION_ENABLED"])
+              required_repository = environ.get("REQUIRED_REPOSITORY", "")
+
+              if not region_names:
+                  raise ValueError("MONITORED_REGIONS must not be empty")
+              if not 1 <= terminate_after_minutes <= alert_after_minutes:
+                  raise ValueError(
+                      "TERMINATE_AFTER_MINUTES must be between 1 and "
+                      "ALERT_AFTER_MINUTES"
+                  )
+              if alert_after_minutes != 120:
+                  raise ValueError("ALERT_AFTER_MINUTES must be 120")
+              if (
+                  termination_enabled
+                  and terminate_after_minutes < PRODUCTION_TERMINATE_AFTER_MINUTES
+                  and not required_repository
+              ):
+                  raise ValueError(
+                      "RequiredRepository must not be empty when termination is enabled "
+                      "below the production threshold"
+                  )
+
+              return {
+                  "region_names": region_names,
+                  "terminate_after_minutes": terminate_after_minutes,
+                  "alert_after_minutes": alert_after_minutes,
+                  "termination_enabled": termination_enabled,
+                  "required_repository": required_repository,
+              }
+
+
+          def scan_runner_instances(
+              region_names,
+              ec2_factory,
+              now,
+              terminate_after_minutes,
+              alert_after_minutes,
+              required_repository,
+          ):
+              """Return owned, candidate, overdue, and failed regional scan records."""
               filters = [
                   {"Name": "tag:created-by", "Values": [CREATED_BY]},
                   {"Name": "instance-state-name", "Values": ["running"]},
               ]
+              owned = []
+              candidates = []
               overdue = []
+              failures = []
 
               for region in region_names:
                   try:
@@ -93,42 +203,105 @@ Resources:
                               for instance in reservation.get("Instances", []):
                                   launch_time = instance["LaunchTime"]
                                   age_minutes = int((now - launch_time).total_seconds() // 60)
-                                  if age_minutes < max_age_minutes:
-                                      continue
                                   tags = {tag["Key"]: tag["Value"] for tag in instance.get("Tags", [])}
-                                  overdue.append(
-                                      {
-                                          "instance_id": instance["InstanceId"],
-                                          "instance_type": instance["InstanceType"],
-                                          "region": region,
-                                          "launch_time": launch_time.isoformat(),
-                                          "age_minutes": age_minutes,
-                                          "repository": tags.get("GitHub-Repository", "unknown"),
-                                          "trigger": tags.get("Newton-Trigger", "unknown"),
-                                          "workload": tags.get("Newton-Workload", "unknown"),
-                                          "run_id": tags.get("GitHub-Run-ID", "unknown"),
-                                          "run_attempt": tags.get("GitHub-Run-Attempt", "unknown"),
-                                      }
-                                  )
+                                  repository = tags.get("GitHub-Repository")
+                                  record = {
+                                      "instance_id": instance["InstanceId"],
+                                      "instance_type": instance["InstanceType"],
+                                      "region": region,
+                                      "launch_time": launch_time.isoformat(),
+                                      "age_minutes": age_minutes,
+                                      "repository": repository if repository is not None else "unknown",
+                                      "trigger": tags.get("Newton-Trigger", "unknown"),
+                                      "workload": tags.get("Newton-Workload", "unknown"),
+                                      "run_id": tags.get("GitHub-Run-ID", "unknown"),
+                                      "run_attempt": tags.get("GitHub-Run-Attempt", "unknown"),
+                                  }
+                                  owned.append(record)
+                                  if age_minutes >= terminate_after_minutes and (
+                                      not required_repository
+                                      or repository == required_repository
+                                  ):
+                                      candidates.append(record)
+                                  if age_minutes >= alert_after_minutes:
+                                      overdue.append(record)
                   except Exception as error:
-                      raise RuntimeError(f"Failed to scan region {region}") from error
+                      failures.append({"operation": "scan", "region": region, "error": str(error)})
 
-              overdue.sort(key=lambda item: (-item["age_minutes"], item["region"], item["instance_id"]))
-              return overdue
+              sort_key = lambda item: (-item["age_minutes"], item["region"], item["instance_id"])
+              owned.sort(key=sort_key)
+              candidates.sort(key=sort_key)
+              overdue.sort(key=sort_key)
+              failures.sort(key=lambda item: (item["operation"], item["region"], item.get("instance_id", "")))
+              return {
+                  "owned": owned,
+                  "candidates": candidates,
+                  "overdue": overdue,
+                  "failures": failures,
+              }
 
 
-          def publish_metrics(cloudwatch, overdue_instances):
-              """Publish aggregate overdue-runner metrics."""
+          def apply_cleanup(candidates, ec2_factory, termination_enabled):
+              """Return cleanup decisions, terminated records, and failures."""
+              decisions = []
+              terminated = []
+              failures = []
+
+              for candidate in candidates:
+                  if not termination_enabled:
+                      decisions.append({**candidate, "decision": "would_terminate"})
+                      continue
+                  try:
+                      ec2_factory(candidate["region"]).terminate_instances(
+                          InstanceIds=[candidate["instance_id"]]
+                      )
+                  except Exception as error:
+                      decisions.append(
+                          {**candidate, "decision": "termination_failed", "error": str(error)}
+                      )
+                      failures.append(
+                          {
+                              "operation": "terminate",
+                              "region": candidate["region"],
+                              "instance_id": candidate["instance_id"],
+                              "error": str(error),
+                          }
+                      )
+                  else:
+                      decisions.append({**candidate, "decision": "terminated"})
+                      terminated.append(candidate)
+
+              failures.sort(key=lambda item: (item["operation"], item["region"], item.get("instance_id", "")))
+              return {"decisions": decisions, "terminated": terminated, "failures": failures}
+
+
+          def publish_metrics(cloudwatch, owned, candidates, terminated, overdue):
+              """Publish aggregate runner cleanup and alert metrics."""
               oldest_age = max(
-                  (instance["age_minutes"] for instance in overdue_instances),
+                  (instance["age_minutes"] for instance in owned),
                   default=0,
               )
               cloudwatch.put_metric_data(
                   Namespace=METRIC_NAMESPACE,
                   MetricData=[
                       {
+                          "MetricName": "OwnedRunnerCount",
+                          "Value": float(len(owned)),
+                          "Unit": "Count",
+                      },
+                      {
+                          "MetricName": "TerminationCandidateCount",
+                          "Value": float(len(candidates)),
+                          "Unit": "Count",
+                      },
+                      {
+                          "MetricName": "TerminatedRunnerCount",
+                          "Value": float(len(terminated)),
+                          "Unit": "Count",
+                      },
+                      {
                           "MetricName": "OverdueRunnerCount",
-                          "Value": float(len(overdue_instances)),
+                          "Value": float(len(overdue)),
                           "Unit": "Count",
                       },
                       {
@@ -141,36 +314,53 @@ Resources:
 
 
           def lambda_handler(event, context):
-              """Scan enabled regions and publish global overdue-runner metrics."""
+              """Scan configured regions, clean up candidates, and publish metrics."""
               import boto3
 
               home_region = os.environ.get("AWS_REGION", "us-east-1")
-              max_age_minutes = int(os.environ.get("MAX_AGE_MINUTES", "60"))
-              home_ec2 = boto3.client("ec2", region_name=home_region)
-              region_names = sorted(
-                  region["RegionName"]
-                  for region in home_ec2.describe_regions(AllRegions=False)["Regions"]
-              )
+              config = load_config(os.environ)
               now = datetime.now(timezone.utc)
-              overdue = find_overdue_instances(
-                  region_names,
+              scan = scan_runner_instances(
+                  config["region_names"],
                   lambda region: boto3.client("ec2", region_name=region),
                   now,
-                  max_age_minutes,
+                  config["terminate_after_minutes"],
+                  config["alert_after_minutes"],
+                  config["required_repository"],
               )
-              publish_metrics(
-                  boto3.client("cloudwatch", region_name=home_region),
-                  overdue,
+              cleanup = apply_cleanup(
+                  scan["candidates"],
+                  lambda region: boto3.client("ec2", region_name=region),
+                  config["termination_enabled"],
               )
+              failures = scan["failures"] + cleanup["failures"]
 
               summary = {
                   "scan_time": now.isoformat(),
-                  "scanned_region_count": len(region_names),
-                  "max_age_minutes": max_age_minutes,
-                  "overdue_count": len(overdue),
-                  "overdue_instances": overdue,
+                  "scanned_region_count": len(config["region_names"]),
+                  "scanned_regions": config["region_names"],
+                  "terminate_after_minutes": config["terminate_after_minutes"],
+                  "alert_after_minutes": config["alert_after_minutes"],
+                  "termination_enabled": config["termination_enabled"],
+                  "required_repository": config["required_repository"],
+                  "owned_count": len(scan["owned"]),
+                  "candidate_count": len(scan["candidates"]),
+                  "terminated_count": len(cleanup["terminated"]),
+                  "overdue_count": len(scan["overdue"]),
+                  "decisions": cleanup["decisions"],
+                  "overdue_instances": scan["overdue"],
+                  "failures": failures,
               }
               print(json.dumps(summary, sort_keys=True))
+              publish_metrics(
+                  boto3.client("cloudwatch", region_name=home_region),
+                  scan["owned"],
+                  scan["candidates"],
+                  cleanup["terminated"],
+                  scan["overdue"],
+              )
+              if failures:
+                  raise RuntimeError("Watchdog encountered cleanup failures")
               return summary
       Tags:
         - Key: Project
@@ -182,8 +372,8 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: overdue-newton-github-runner-watchdog-schedule
-      Description: Scan for overdue Newton GitHub runners every four hours.
-      ScheduleExpression: rate(4 hours)
+      Description: Scan and clean up tagged Newton GitHub runners every 15 minutes.
+      ScheduleExpression: rate(15 minutes)
       State: ENABLED
       Targets:
         - Arn:
@@ -217,12 +407,40 @@ Resources:
       Namespace: Newton/GitHubRunnerWatchdog
       MetricName: OverdueRunnerCount
       Statistic: Maximum
-      Period: 21600
+      Period: 1800
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: breaching
+      AlarmActions:
+        - Ref: AlertTopicArn
+      OKActions:
+        - Ref: AlertTopicArn
+      Tags:
+        - Key: Project
+          Value: Newton
+        - Key: Purpose
+          Value: RunnerCostGuard
+
+  WatchdogErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: newton-github-runner-cleanup-errors
+      AlarmDescription: The Newton GitHub runner cleanup Lambda invocation failed.
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Ref: WatchdogFunction
+      Statistic: Sum
+      Period: 900
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
       AlarmActions:
         - Ref: AlertTopicArn
       OKActions:
@@ -240,3 +458,6 @@ Outputs:
   AlarmName:
     Value:
       Ref: WatchdogAlarm
+  ErrorAlarmName:
+    Value:
+      Ref: WatchdogErrorAlarm

--- a/scripts/ci/discover_aws_runner_config.py
+++ b/scripts/ci/discover_aws_runner_config.py
@@ -22,6 +22,13 @@ from typing import Any
 AwsCall = Callable[..., Any]
 Warn = Callable[[str], None]
 AWS_CLI_TIMEOUT_SECONDS = 120
+ALLOWED_REGIONS = (
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+)
 
 
 def warning(message: str) -> None:
@@ -246,9 +253,32 @@ def set_output(name: str, value: str) -> None:
             output_file.write(f"{name}={value}\n")
 
 
+def parse_region_candidates(value: str) -> list[str]:
+    """Return ordered runner regions after enforcing the cleanup allowlist.
+
+    Args:
+        value: Space-separated AWS region candidates.
+
+    Returns:
+        Region candidates in caller-specified order.
+
+    Raises:
+        ValueError: If a candidate is outside the watchdog allowlist.
+    """
+    regions = value.split()
+    unsupported_regions = sorted(set(regions).difference(ALLOWED_REGIONS))
+    if unsupported_regions:
+        raise ValueError(f"Unsupported AWS runner regions: {', '.join(unsupported_regions)}")
+    return regions
+
+
 def main() -> int:
     """Entry point for the workflow step."""
-    regions = os.environ["AWS_REGION_CANDIDATES"].split()
+    try:
+        regions = parse_region_candidates(os.environ["AWS_REGION_CANDIDATES"])
+    except ValueError as exc:
+        error(str(exc))
+        return 1
     instance_type = os.environ["AWS_INSTANCE_TYPE"]
     tag_key = os.environ["AWS_RUNNER_RESOURCE_TAG"]
 

--- a/scripts/ci/tests/test_runner_region_contract.py
+++ b/scripts/ci/tests/test_runner_region_contract.py
@@ -19,7 +19,6 @@ RUNNER_WORKFLOWS = (
     ROOT / ".github" / "workflows" / "aws_gpu_benchmarks.yml",
     ROOT / ".github" / "workflows" / "minimum_deps_tests.yml",
     ROOT / ".github" / "workflows" / "warp_nightly_tests.yml",
-    ROOT / ".github" / "workflows" / "mujoco_warp_tests.yml",
 )
 
 spec = importlib.util.spec_from_file_location("discover_aws_runner_config", DISCOVERY_SCRIPT)

--- a/scripts/ci/tests/test_runner_region_contract.py
+++ b/scripts/ci/tests/test_runner_region_contract.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check that AWS runner launch regions remain covered by the watchdog."""
+
+import importlib.util
+import re
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+DISCOVERY_SCRIPT = ROOT / "scripts" / "ci" / "discover_aws_runner_config.py"
+WATCHDOG_TEMPLATE = ROOT / "scripts" / "ci" / "aws" / "overdue-newton-github-runner-watchdog.yaml"
+RUNNER_WORKFLOWS = (
+    ROOT / ".github" / "workflows" / "aws_gpu_tests.yml",
+    ROOT / ".github" / "workflows" / "aws_gpu_benchmarks.yml",
+    ROOT / ".github" / "workflows" / "minimum_deps_tests.yml",
+    ROOT / ".github" / "workflows" / "warp_nightly_tests.yml",
+    ROOT / ".github" / "workflows" / "mujoco_warp_tests.yml",
+)
+
+spec = importlib.util.spec_from_file_location("discover_aws_runner_config", DISCOVERY_SCRIPT)
+assert spec is not None and spec.loader is not None
+discovery = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(discovery)
+
+
+def _environment_value(path: Path, name: str) -> str:
+    prefix = f"{name}:"
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped.removeprefix(prefix).strip()
+    raise AssertionError(f"Missing {name} in {path}")
+
+
+def _workflow_default_regions(path: Path) -> tuple[str, ...]:
+    value = _environment_value(path, "AWS_REGION_CANDIDATES")
+    if value.startswith("${{"):
+        match = re.search(r"\|\| '([^']+)'", value)
+        if match is None:
+            raise AssertionError(f"Missing fallback region list in {path}")
+        value = match.group(1)
+    return tuple(value.split())
+
+
+class TestRunnerRegionContract(unittest.TestCase):
+    def test_preserves_supported_region_subsets_in_caller_order(self):
+        """Preserve caller ordering when every candidate is supported."""
+        self.assertEqual(
+            discovery.parse_region_candidates("ap-northeast-2 us-east-1 us-west-2"),
+            ["ap-northeast-2", "us-east-1", "us-west-2"],
+        )
+
+    def test_rejects_runner_regions_outside_the_watchdog_allowlist(self):
+        """Reject unsupported regions before making AWS discovery calls."""
+
+        def unexpected_discovery(*args, **kwargs):
+            self.fail("AWS discovery was called for an unsupported region")
+
+        environment = {
+            "AWS_REGION_CANDIDATES": "us-east-1 eu-west-1",
+            "AWS_INSTANCE_TYPE": "g7e.2xlarge",
+            "AWS_RUNNER_RESOURCE_TAG": "newton-github-runner",
+        }
+        output = StringIO()
+
+        with (
+            patch.dict("os.environ", environment, clear=True),
+            patch.object(discovery, "discover_candidates", unexpected_discovery),
+            redirect_stdout(output),
+        ):
+            result = discovery.main()
+
+        self.assertEqual(result, 1)
+        self.assertIn("eu-west-1", output.getvalue())
+
+    def test_keeps_runner_region_allowlists_synchronized(self):
+        """Keep every runner workflow aligned with the watchdog allowlist."""
+        self.assertTrue(
+            hasattr(discovery, "ALLOWED_REGIONS"),
+            "The discovery script must expose its enforced region allowlist",
+        )
+        allowed_regions = tuple(discovery.ALLOWED_REGIONS)
+        watchdog_regions = tuple(_environment_value(WATCHDOG_TEMPLATE, "MONITORED_REGIONS").split(","))
+
+        self.assertEqual(watchdog_regions, allowed_regions)
+        for workflow in RUNNER_WORKFLOWS:
+            with self.subTest(workflow=workflow.name):
+                self.assertEqual(_workflow_default_regions(workflow), allowed_regions)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/tests/test_watchdog_logic.py
+++ b/scripts/ci/tests/test_watchdog_logic.py
@@ -1,28 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""Exercise the watchdog's instance-selection and attribution logic locally.
+"""Exercise the watchdog's embedded Lambda behavior with local AWS fakes.
 
-These tests execute the Lambda source embedded in the CloudFormation template
-with a fake EC2 paginator. They catch repository-filter regressions and missing
-attribution-tag handling, but do not call AWS or validate CloudFormation, IAM,
-or boto3 behavior. Those behaviors require deployment and live smoke checks.
+These tests execute the Python embedded in the CloudFormation template and
+fake only its EC2 and CloudWatch boundaries. They do not validate
+CloudFormation, IAM, boto3, regional AWS behavior, or actual termination.
+Those behaviors require deployment and live smoke checks.
 """
 
 import textwrap
 import unittest
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
+from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[3]
 TEMPLATE = ROOT / "scripts" / "ci" / "aws" / "overdue-newton-github-runner-watchdog.yaml"
 
 
 class FilteringPaginator:
-    def __init__(self, instances):
+    def __init__(self, instances, error=None):
         self.instances = instances
+        self.error = error
 
     def paginate(self, Filters):
+        if self.error is not None:
+            raise self.error
+
         matching = self.instances
         for item in Filters:
             name = item["Name"]
@@ -40,13 +48,47 @@ class FilteringPaginator:
 
 
 class FakeEc2:
-    def __init__(self, instances):
+    def __init__(self, instances, pagination_error=None, termination_error=None):
         self.instances = instances
+        self.pagination_error = pagination_error
+        self.termination_error = termination_error
+        self.termination_calls = []
 
     def get_paginator(self, operation):
         if operation != "describe_instances":
             raise AssertionError(f"Unexpected operation: {operation}")
-        return FilteringPaginator(self.instances)
+        return FilteringPaginator(self.instances, self.pagination_error)
+
+    def terminate_instances(self, InstanceIds):
+        self.termination_calls.append(InstanceIds)
+        if self.termination_error is not None:
+            raise self.termination_error
+
+
+class FakeCloudWatch:
+    def __init__(self, error=None):
+        self.metric_calls = []
+        self.error = error
+
+    def put_metric_data(self, **kwargs):
+        self.metric_calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+
+
+class FakeBoto3:
+    def __init__(self, regional_ec2, cloudwatch):
+        self.regional_ec2 = regional_ec2
+        self.cloudwatch = cloudwatch
+        self.client_calls = []
+
+    def client(self, service_name, region_name):
+        self.client_calls.append((service_name, region_name))
+        if service_name == "ec2":
+            return self.regional_ec2[region_name]
+        if service_name == "cloudwatch":
+            return self.cloudwatch
+        raise AssertionError(f"Unexpected service: {service_name}")
 
 
 class TestWatchdogLogic(unittest.TestCase):
@@ -56,6 +98,8 @@ class TestWatchdogLogic(unittest.TestCase):
         marker = "        ZipFile: |\n"
         self.assertIn(marker, template)
         source_lines = []
+        # Stop at the YAML indentation boundary so tests execute the exact
+        # embedded source without adding a YAML parser dependency.
         for line in template[template.index(marker) + len(marker) :].splitlines(keepends=True):
             if line.strip() and not line.startswith("          "):
                 break
@@ -66,7 +110,15 @@ class TestWatchdogLogic(unittest.TestCase):
         return namespace
 
     @staticmethod
-    def _instance(now, *, repository=None, include_attribution=True):
+    def _instance(
+        now,
+        *,
+        age_minutes=90,
+        instance_id="i-0123456789abcdef0",
+        repository=None,
+        include_attribution=True,
+        state="running",
+    ):
         tags = [{"Key": "created-by", "Value": "github-actions-newton-role"}]
         if repository is not None:
             tags.append({"Key": "GitHub-Repository", "Value": repository})
@@ -80,75 +132,48 @@ class TestWatchdogLogic(unittest.TestCase):
                 ]
             )
         return {
-            "InstanceId": "i-0123456789abcdef0",
+            "InstanceId": instance_id,
             "InstanceType": "g7e.2xlarge",
-            "LaunchTime": now - timedelta(minutes=90),
-            "State": {"Name": "running"},
+            "LaunchTime": now - timedelta(minutes=age_minutes),
+            "State": {"Name": state},
             "Tags": tags,
         }
 
-    def test_watchdog_finds_owned_runners_from_any_repository(self):
-        """Report an overdue owned runner regardless of repository tag value."""
+    def test_watchdog_filters_owned_running_instances_and_applies_thresholds(self):
+        """Select owned running runners at the candidate and overdue thresholds."""
         namespace = self._lambda_namespace()
         now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
-        instance = self._instance(now, repository="example/newton")
+        instances = [
+            self._instance(now, age_minutes=89, instance_id="i-89"),
+            self._instance(now, age_minutes=90, instance_id="i-90"),
+            self._instance(now, age_minutes=119, instance_id="i-119"),
+            self._instance(now, age_minutes=120, instance_id="i-120"),
+            self._instance(now, age_minutes=95, instance_id="i-missing", include_attribution=False),
+            self._instance(now, age_minutes=130, instance_id="i-unowned"),
+            self._instance(now, age_minutes=130, instance_id="i-stopped", state="stopped"),
+        ]
+        instances[5]["Tags"][0]["Value"] = "another-runner-role"
 
-        overdue = namespace["find_overdue_instances"](
+        scan = namespace["scan_runner_instances"](
             ["us-east-2"],
-            lambda region: FakeEc2([instance]),
+            lambda region: FakeEc2(instances),
             now,
-            60,
+            90,
+            120,
+            "",
         )
 
         self.assertEqual(
-            overdue,
-            [
-                {
-                    "instance_id": "i-0123456789abcdef0",
-                    "instance_type": "g7e.2xlarge",
-                    "region": "us-east-2",
-                    "launch_time": "2026-08-08T10:30:00+00:00",
-                    "age_minutes": 90,
-                    "repository": "example/newton",
-                    "trigger": "manual",
-                    "workload": "gpu-unit-tests",
-                    "run_id": "123456",
-                    "run_attempt": "2",
-                }
-            ],
+            [item["instance_id"] for item in scan["owned"]],
+            ["i-120", "i-119", "i-missing", "i-90", "i-89"],
         )
-
-    def test_watchdog_excludes_unowned_instances(self):
-        """Exclude overdue instances not owned by Newton."""
-        namespace = self._lambda_namespace()
-        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
-        instance = self._instance(now)
-        instance["Tags"][0]["Value"] = "other-runner-role"
-
-        overdue = namespace["find_overdue_instances"](
-            ["us-east-2"],
-            lambda region: FakeEc2([instance]),
-            now,
-            60,
-        )
-
-        self.assertEqual(overdue, [])
-
-    def test_watchdog_tolerates_missing_attribution_tags(self):
-        """Report unknown metadata for runners created before attribution tags."""
-        namespace = self._lambda_namespace()
-        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
-        instance = self._instance(now, include_attribution=False)
-
-        overdue = namespace["find_overdue_instances"](
-            ["us-west-2"],
-            lambda region: FakeEc2([instance]),
-            now,
-            60,
-        )
-
         self.assertEqual(
-            {key: overdue[0][key] for key in ("repository", "trigger", "workload", "run_id", "run_attempt")},
+            [item["instance_id"] for item in scan["candidates"]],
+            ["i-120", "i-119", "i-missing", "i-90"],
+        )
+        self.assertEqual([item["instance_id"] for item in scan["overdue"]], ["i-120"])
+        self.assertEqual(
+            {key: scan["owned"][2][key] for key in ("repository", "trigger", "workload", "run_id", "run_attempt")},
             {
                 "repository": "unknown",
                 "trigger": "unknown",
@@ -157,6 +182,258 @@ class TestWatchdogLogic(unittest.TestCase):
                 "run_attempt": "unknown",
             },
         )
+        self.assertEqual(scan["failures"], [])
+
+    def test_watchdog_requires_an_exact_present_repository_tag(self):
+        """Restrict cleanup candidates to an exact repository tag value.
+
+        Keep eligibility based on the raw tag: a missing tag is displayed as
+        ``"unknown"`` in diagnostics, but must not match that fallback value.
+        """
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        instances = [
+            self._instance(now, instance_id="i-selected", repository="example/selected"),
+            self._instance(now, instance_id="i-other", repository="example/other"),
+            self._instance(now, instance_id="i-missing"),
+            self._instance(now, instance_id="i-tagged-unknown", repository="unknown"),
+        ]
+
+        selected_scan = namespace["scan_runner_instances"](
+            ["ap-northeast-1"],
+            lambda region: FakeEc2(instances),
+            now,
+            90,
+            120,
+            "example/selected",
+        )
+        unknown_scan = namespace["scan_runner_instances"](
+            ["ap-northeast-1"],
+            lambda region: FakeEc2(instances),
+            now,
+            90,
+            120,
+            "unknown",
+        )
+
+        self.assertEqual([item["instance_id"] for item in selected_scan["candidates"]], ["i-selected"])
+        self.assertEqual(
+            [item["repository"] for item in unknown_scan["owned"]],
+            ["unknown", "example/other", "example/selected", "unknown"],
+        )
+        self.assertEqual(
+            [item["instance_id"] for item in unknown_scan["candidates"]],
+            ["i-tagged-unknown"],
+        )
+
+    def test_watchdog_rejects_unrestricted_low_threshold_before_aws_calls(self):
+        """Reject enabled low-threshold cleanup without a required repository.
+
+        Validate this safety boundary before creating AWS clients so a
+        misconfigured aggressive cleanup cannot inspect or terminate runners.
+        """
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        invalid_boto3 = FakeBoto3({}, FakeCloudWatch())
+        unrestricted_environment = {
+            "AWS_REGION": "us-east-1",
+            "MONITORED_REGIONS": "us-east-1",
+            "TERMINATE_AFTER_MINUTES": "10",
+            "ALERT_AFTER_MINUTES": "120",
+            "TERMINATION_ENABLED": "true",
+            "REQUIRED_REPOSITORY": "",
+        }
+
+        with (
+            patch.dict("os.environ", unrestricted_environment, clear=True),
+            patch.dict("sys.modules", {"boto3": SimpleNamespace(client=invalid_boto3.client)}),
+            self.assertRaisesRegex(ValueError, "RequiredRepository"),
+        ):
+            namespace["lambda_handler"]({}, None)
+
+        self.assertEqual(invalid_boto3.client_calls, [])
+
+        accepted_boto3 = FakeBoto3({"us-east-1": FakeEc2([])}, FakeCloudWatch())
+        namespace["datetime"] = SimpleNamespace(now=lambda zone: now)
+        with (
+            patch.dict(
+                "os.environ",
+                {**unrestricted_environment, "REQUIRED_REPOSITORY": "example/selected"},
+                clear=True,
+            ),
+            patch.dict("sys.modules", {"boto3": SimpleNamespace(client=accepted_boto3.client)}),
+            redirect_stdout(StringIO()),
+        ):
+            summary = namespace["lambda_handler"]({}, None)
+
+        self.assertEqual(summary["required_repository"], "example/selected")
+        self.assertEqual(
+            accepted_boto3.client_calls,
+            [("ec2", "us-east-1"), ("cloudwatch", "us-east-1")],
+        )
+
+    def test_watchdog_accepts_fractional_termination_threshold(self):
+        """Accept fractional thresholds allowed by CloudFormation."""
+        namespace = self._lambda_namespace()
+        environment = {
+            "MONITORED_REGIONS": "us-east-1",
+            "TERMINATE_AFTER_MINUTES": "90.5",
+            "ALERT_AFTER_MINUTES": "120",
+            "TERMINATION_ENABLED": "false",
+            "REQUIRED_REPOSITORY": "",
+        }
+
+        try:
+            config = namespace["load_config"](environment)
+        except ValueError as exc:
+            self.fail(f"CloudFormation-valid threshold was rejected: {exc}")
+
+        self.assertEqual(config["terminate_after_minutes"], 90.5)
+
+    def test_watchdog_reports_would_terminate_without_terminating_in_shadow_mode(self):
+        """Record shadow-mode cleanup decisions without calling EC2 termination."""
+        namespace = self._lambda_namespace()
+        candidate = {"instance_id": "i-shadow", "region": "us-west-2", "age_minutes": 90}
+        ec2 = FakeEc2([])
+
+        cleanup = namespace["apply_cleanup"]([candidate], lambda region: ec2, False)
+
+        self.assertEqual(
+            cleanup["decisions"],
+            [
+                {
+                    "instance_id": "i-shadow",
+                    "region": "us-west-2",
+                    "age_minutes": 90,
+                    "decision": "would_terminate",
+                }
+            ],
+        )
+        self.assertEqual(cleanup["terminated"], [])
+        self.assertEqual(cleanup["failures"], [])
+        self.assertEqual(ec2.termination_calls, [])
+
+    def test_watchdog_completes_healthy_work_before_raising_collected_failures(self):
+        """Complete healthy cleanup work before raising collected failures.
+
+        Deliberately fail one regional scan and one termination while a second
+        termination remains healthy. The handler must finish all possible work
+        and emit its diagnostics before it raises the collected failures.
+        """
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        failed_ec2 = FakeEc2(
+            [self._instance(now, instance_id="i-termination-failed")],
+            termination_error=RuntimeError("termination denied"),
+        )
+        successful_ec2 = FakeEc2([self._instance(now, age_minutes=120, instance_id="i-terminated")])
+        cloudwatch = FakeCloudWatch()
+        boto3 = FakeBoto3(
+            {
+                "ap-northeast-1": FakeEc2([], pagination_error=RuntimeError("scan unavailable")),
+                "us-east-1": failed_ec2,
+                "us-west-2": successful_ec2,
+            },
+            cloudwatch,
+        )
+        environment = {
+            "AWS_REGION": "us-east-1",
+            "MONITORED_REGIONS": "ap-northeast-1,us-east-1,us-west-2",
+            "TERMINATE_AFTER_MINUTES": "90",
+            "ALERT_AFTER_MINUTES": "120",
+            "TERMINATION_ENABLED": "true",
+            "REQUIRED_REPOSITORY": "",
+        }
+        namespace["datetime"] = SimpleNamespace(now=lambda zone: now)
+        output = StringIO()
+
+        with (
+            patch.dict("os.environ", environment, clear=True),
+            patch.dict("sys.modules", {"boto3": SimpleNamespace(client=boto3.client)}),
+            redirect_stdout(output),
+            self.assertRaisesRegex(RuntimeError, "Watchdog encountered cleanup failures"),
+        ):
+            namespace["lambda_handler"]({}, None)
+
+        summary = namespace["json"].loads(output.getvalue())
+        self.assertEqual(summary["scanned_regions"], ["ap-northeast-1", "us-east-1", "us-west-2"])
+        self.assertEqual(summary["owned_count"], 2)
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["terminated_count"], 1)
+        self.assertEqual(summary["overdue_count"], 1)
+        decisions = {item["instance_id"]: item for item in summary["decisions"]}
+        self.assertEqual(set(decisions), {"i-terminated", "i-termination-failed"})
+        self.assertEqual(decisions["i-terminated"]["decision"], "terminated")
+        self.assertNotIn("error", decisions["i-terminated"])
+        self.assertEqual(decisions["i-termination-failed"]["decision"], "termination_failed")
+        self.assertEqual(decisions["i-termination-failed"]["error"], "termination denied")
+        self.assertEqual(
+            summary["failures"],
+            [
+                {"operation": "scan", "region": "ap-northeast-1", "error": "scan unavailable"},
+                {
+                    "operation": "terminate",
+                    "region": "us-east-1",
+                    "instance_id": "i-termination-failed",
+                    "error": "termination denied",
+                },
+            ],
+        )
+        self.assertEqual(failed_ec2.termination_calls, [["i-termination-failed"]])
+        self.assertEqual(successful_ec2.termination_calls, [["i-terminated"]])
+        self.assertEqual(
+            cloudwatch.metric_calls,
+            [
+                {
+                    "Namespace": "Newton/GitHubRunnerWatchdog",
+                    "MetricData": [
+                        {"MetricName": "OwnedRunnerCount", "Value": 2.0, "Unit": "Count"},
+                        {"MetricName": "TerminationCandidateCount", "Value": 2.0, "Unit": "Count"},
+                        {"MetricName": "TerminatedRunnerCount", "Value": 1.0, "Unit": "Count"},
+                        {"MetricName": "OverdueRunnerCount", "Value": 1.0, "Unit": "Count"},
+                        {"MetricName": "OldestRunnerAgeMinutes", "Value": 120.0, "Unit": "Count"},
+                    ],
+                }
+            ],
+        )
+
+    def test_watchdog_emits_summary_before_cloudwatch_failure(self):
+        """Emit the structured summary before propagating a metrics failure.
+
+        Print the summary first so operators retain cleanup diagnostics when
+        CloudWatch publishing fails and the invocation raises.
+        """
+        namespace = self._lambda_namespace()
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        cloudwatch = FakeCloudWatch(error=RuntimeError("metrics unavailable"))
+        boto3 = FakeBoto3(
+            {"us-west-2": FakeEc2([self._instance(now, instance_id="i-metric-failure")])},
+            cloudwatch,
+        )
+        environment = {
+            "AWS_REGION": "us-east-1",
+            "MONITORED_REGIONS": "us-west-2",
+            "TERMINATE_AFTER_MINUTES": "90",
+            "ALERT_AFTER_MINUTES": "120",
+            "TERMINATION_ENABLED": "false",
+            "REQUIRED_REPOSITORY": "",
+        }
+        namespace["datetime"] = SimpleNamespace(now=lambda zone: now)
+        output = StringIO()
+
+        with (
+            patch.dict("os.environ", environment, clear=True),
+            patch.dict("sys.modules", {"boto3": SimpleNamespace(client=boto3.client)}),
+            redirect_stdout(output),
+            self.assertRaisesRegex(RuntimeError, "metrics unavailable"),
+        ):
+            namespace["lambda_handler"]({}, None)
+
+        summary = namespace["json"].loads(output.getvalue())
+        self.assertEqual(summary["owned_count"], 1)
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["decisions"][0]["decision"], "would_terminate")
+        self.assertEqual(len(cloudwatch.metric_calls), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> This PR is not yet the active production cleanup path. The updated template was tested in AWS in termination-disabled shadow mode and with one repository-scoped disposable-instance canary. After the canary, the stack was returned to termination-disabled 90-minute shadow mode. The five legacy regional cleanup schedules remain active until the post-merge rollout.

This builds on the 120-minute watchdog threshold merged in #3978 and extends the existing CloudFormation-managed watchdog into one cleanup path for Newton GitHub runners across the five AWS regions used by CI. Termination is disabled by default. When enabled, the Lambda considers owned runners eligible after 90 minutes while retaining the 120-minute overdue alert.

The execution role can terminate only instances tagged `created-by=github-actions-newton-role`. An optional repository filter applies the same additional restriction in both the Lambda and IAM, and enabled thresholds below 90 minutes are rejected unless that filter is present.

Regional scans and per-instance termination failures are isolated so remaining work continues. The Lambda emits structured diagnostics and metrics before surfacing failures through the native Lambda error alarm.

The PR changes only the existing CloudFormation template, its `unittest` coverage, and the AWS infrastructure README. The README documents the durable template interface and safe deployment defaults; the one-time shadow, canary, and cutover procedure stays in the PR test plan rather than becoming permanent documentation.

## Motivation

Runner cleanup currently depends on five regional Lambda functions and five schedules that are maintained separately. Their code, runtimes, execution roles, and logging policies have drifted. That means a safety fix or policy change has to be checked and applied in several places, and one region can behave differently from the others.

The existing watchdog already scans those regions and reports overdue runners. Extending it to handle cleanup makes reporting and termination use the same discovery and safety checks. Operators review one version-controlled CloudFormation stack and one execution role instead of comparing five regional copies. The `created-by=github-actions-newton-role` tag condition still limits what the watchdog may terminate, and shadow mode shows operators what it would terminate before cleanup is enabled.

## Post-merge rollout

After this PR is approved and merged, deploy the merged template with `TerminationEnabled=true`, `TerminateAfterMinutes=90`, and an empty `RequiredRepository` so cleanup applies to instances carrying the Newton GitHub ownership tag. Verify a successful five-region scan and healthy alarms, then disable the five legacy regional cleanup schedules. Until that cutover is complete, centralized termination remains disabled and legacy cleanup remains active.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] This infrastructure-only change does not require a changelog fragment

## Test plan

- [x] `uv run --extra dev -m unittest scripts.ci.tests.test_watchdog_logic scripts.ci.tests.test_runner_region_contract scripts.ci.tests.test_runner_workflow_contract` (13 tests passed)
- [x] `uv run --extra dev python -m py_compile scripts/ci/tests/test_watchdog_logic.py`
- [x] `uvx pre-commit run -a`
- [x] `uvx --from cfn-lint cfn-lint scripts/ci/aws/overdue-newton-github-runner-watchdog.yaml`
- [x] Validate the template with AWS CloudFormation in `us-east-1`
- [x] Deploy in termination-disabled shadow mode and verify all five regions, metrics, alarms, and stack drift
- [x] Run the repository-scoped disposable-instance canary from `shi-eric/newton`: [workflow run 32313723593](https://github.com/shi-eric/newton/actions/runs/32313723593) confirmed centralized termination at 10 minutes while a concurrent `newton-physics/newton` runner remained running
- [x] Restore termination-disabled 90-minute shadow mode and confirm zero failures and an `IN_SYNC` stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the AWS runner watchdog with configurable regions, alert and cleanup thresholds, repository filtering, and optional automatic termination.
  * Added shadow-mode operation, expanded monitoring metrics, cleanup reporting, regional failure tracking, and a dedicated error alarm.
  * Increased monitoring frequency to every 15 minutes and added supported-region validation.
* **Bug Fixes**
  * Improved handling and reporting of scan, cleanup, and monitoring failures.
* **Documentation**
  * Updated AWS CI guidance with safer deployment workflows, configuration details, regional coverage, and rollback procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->