### PR TITLE
Fix heightfield contact using prism skirt instead of top face

### DIFF
--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -546,6 +546,34 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
                     point_a = alpha * vert_a(v1) + beta * vert_a(v2) + gamma * vert_a(v3)
                     point_b = alpha * v1.B + beta * v2.B + gamma * v3.B
 
+                    # A heightfield triangle is extruded 1 m along -Z into a solid prism
+                    # (see support_map) so GJK/MPR can resolve shapes reaching its back side.
+                    # Only the top face is a real surface; the skirt and bottom cap are inside
+                    # the terrain. Once B's center passes below the face the portal can settle
+                    # on the skirt, reporting about a metre of penetration along -Z, which
+                    # pushes B further in instead of separating it. Penetration depth is the
+                    # minimum support width over all directions, so the width along the face
+                    # normal bounds the true depth from above; taking it when it is smaller
+                    # discards the skirt solution without changing which pairs collide.
+                    if geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
+                        prism_n = wp.cross(geom_a.scale, geom_a.auxiliary)
+                        prism_n_sq = wp.length_sq(prism_n)
+                        if prism_n_sq >= 1.0e-24:
+                            prism_n = prism_n / wp.sqrt(prism_n_sq)
+                            # The extrusion is along -Z in this frame, so the outward face
+                            # normal is +Z whatever the triangle's winding.
+                            if prism_n[2] < 0.0:
+                                prism_n = -prism_n
+                            prism_sv = mpr_support(
+                                geom_a, geom_b, prism_n, orientation_b, position_b, extend, data_provider
+                            )
+                            prism_pen = wp.dot(prism_sv.BtoA, prism_n)
+                            if prism_pen < penetration:
+                                normal = prism_n
+                                penetration = prism_pen
+                                point_b = prism_sv.B
+                                point_a = prism_sv.B + prism_pen * prism_n
+
                 return hit, point_a, point_b, normal, penetration
 
             # Determine what region of the wedge the origin is in

--- a/newton/tests/test_heightfield.py
+++ b/newton/tests/test_heightfield.py
@@ -356,6 +356,58 @@ class TestHeightfield(unittest.TestCase):
         contact_count = int(contacts.rigid_contact_count.numpy()[0])
         self.assertGreater(contact_count, 0, "No contacts detected between sphere and heightfield")
 
+    def test_heightfield_box_penetration_uses_top_face(self):
+        """A box sunk into a flat heightfield reports its true depth along +Z, not the prism skirt.
+
+        ``support_map`` extrudes a heightfield triangle 1 m along -Z so GJK/MPR can resolve
+        shapes reaching its back side. The skirt and bottom cap are interior to the terrain and
+        cannot carry a contact, but once the box's center passes below the surface the portal
+        can settle on them: a pre-fix build reports roughly a metre of penetration with a normal
+        of (0, 0, -1), which pushes the box further into the ground instead of separating it.
+
+        The surface is flat and the box is axis-aligned, so the expected answer needs no
+        collision code: the penetration is how far the box's underside sits below z = 0 and the
+        normal is +Z. Depths on both sides of the box's half-thickness are checked because that
+        is where the pre-fix behavior changes.
+        """
+        half_z = 0.02
+        for depth in (0.005, 0.019, 0.021, 0.05):
+            with self.subTest(depth=depth):
+                builder = newton.ModelBuilder()
+
+                nrow, ncol = 21, 21
+                elevation = np.zeros((nrow, ncol), dtype=np.float32)
+                hfield = Heightfield(data=elevation, nrow=nrow, ncol=ncol, hx=1.0, hy=1.0, min_z=0.0, max_z=1.0)
+                builder.add_shape_heightfield(heightfield=hfield)
+
+                body = builder.add_body(xform=wp.transform((0.0, 0.0, half_z - depth), wp.quat_identity()))
+                builder.add_shape_box(body=body, hx=0.2, hy=0.065, hz=half_z)
+
+                model = builder.finalize()
+                state = model.state()
+
+                pipeline = newton.CollisionPipeline(model, requires_grad=True)
+                contacts = pipeline.contacts()
+                pipeline.collide(state, contacts)
+
+                count = int(contacts.rigid_contact_count.numpy()[0])
+                self.assertGreater(count, 0, "no contacts between box and heightfield")
+                distance = contacts.rigid_contact_diff_distance.numpy()[:count]
+                normal = contacts.rigid_contact_normal.numpy()[:count]
+
+                deepest = int(np.argmin(distance))
+                self.assertAlmostEqual(
+                    float(distance[deepest]),
+                    -depth,
+                    places=4,
+                    msg=f"deepest contact reports {distance[deepest]:.4f} m for a {depth:.4f} m overlap",
+                )
+                self.assertGreater(
+                    float(normal[deepest][2]),
+                    0.9,
+                    msg=f"deepest contact normal {normal[deepest]} does not point out of the surface",
+                )
+
     def test_heightfield_native_collision_scaled(self):
         """Per-instance ``scale`` on ``add_shape_heightfield`` is honored by narrow-phase.
 


### PR DESCRIPTION
  A heightfield triangle is extruded 1 m along -Z into a solid prism (`support_map` in
  `newton/_src/geometry/support_function.py`) so GJK/MPR can resolve shapes reaching its
  back side. The skirt and bottom cap are interior to the terrain and cannot carry a
  contact, but once the other shape's center passes below the top face the portal can
  settle on them. The reported penetration then jumps to roughly the extrusion depth with
  a normal of (0, 0, -1), so the solver drives the shape further into the terrain instead
  of separating it, and the next substep reads an even deeper overlap. 

  Penetration depth is the minimum support width over all directions, so the width along
  the triangle's face normal bounds the true depth from above. This PR takes it when it is
  the smaller of the two, which discards the skirt solution and leaves the set of colliding
  pairs unchanged. The change is scoped to `GeoTypeEx.TRIANGLE_PRISM`; the triangle-mesh
  path is untouched.

  Targeting `release-1.5` because that is what Isaac Lab pins. `mpr.py` is identical on
  `main`, so the commit cherry-picks cleanly if you would rather land it there first.

  ## Checklist
 
  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [ ] Changelog fragment — `changelog/` does not exist on `release-1.5`; happy to add one
        if this is retargeted at `main

 ## Test plan

`  uv run --extra dev -m newton.tests -k test_heightfield_box_penetration_uses_top_face`
 
  Fails on `release-1.5` — all four subtests, e.g. `-1.0190 m` reported for a `0.0210 m`
  overlap — and passes with this change.

  ## Bug fix

  **Steps to reproduce:**

  1. Build a flat heightfield and rest a thin box on it.
  2. Lower the box past its own half-thickness.
  3. Observe the reported penetration jump to about the 1 m extrusion depth, with the
     contact normal pointing into the terrain.

  **Minimal reproduction:**

  ```python
  import numpy as np
  import warp as wp

  import newton

  HALF_Z = 0.02
  DEPTH = 0.021  # just past the box's half-thickness

  builder = newton.ModelBuilder()
  elevation = np.zeros((21, 21), dtype=np.float32)
  builder.add_shape_heightfield(
      heightfield=newton.Heightfield(
          data=elevation, nrow=21, ncol=21, hx=1.0, hy=1.0, min_z=0.0, max_z=1.0
      )
  )   
  body = builder.add_body(xform=wp.transform((0.0, 0.0, HALF_Z - DEPTH), wp.quat_identity()))
  builder.add_shape_box(body=body, hx=0.2, hy=0.065, hz=HALF_Z)

  model = builder.finalize()
  pipeline = newton.CollisionPipeline(model, requires_grad=True)
  contacts = pipeline.contacts()
  pipeline.collide(model.state(), contacts)

  n = int(contacts.rigid_contact_count.numpy()[0])
  d = contacts.rigid_contact_diff_distance.numpy()[:n]
  k = int(np.argmin(d))
  print(d[k], contacts.rigid_contact_normal.numpy()[:n][k])
  # release-1.5: -1.019  [ 0.  0. -1.]
  # this PR:     -0.021  [ 0.  0.  1.]
 ```
  
  
  Downstream effect. On Isaac Lab Isaac-Velocity-Rough-G1 / UnitreeA1 / UnitreeGo2 all had NaN issues by default. After changing they all complete the full training loop.
