### PR TITLE
Fix heightfield contact corner case

### DIFF
--- a/changelog/+heightfield-deep-contacts-6d2f8a41.fixed.md
+++ b/changelog/+heightfield-deep-contacts-6d2f8a41.fixed.md
@@ -1,0 +1,1 @@
+Keep deeply penetrating heightfield contacts on the physical surface instead of the internal triangle-prism skirt.

--- a/newton/_src/geometry/collision_core.py
+++ b/newton/_src/geometry/collision_core.py
@@ -296,21 +296,21 @@ def post_process_triangle_contact(
                 normal_local = -normal_local
             normal_world = wp.quat_rotate(rot_a, normal_local)
 
-            data_provider = SupportMapDataProvider()
-            direction_b = wp.quat_rotate_inv(rot_b, -normal_world)
-            point_b = support_map(shape_b, direction_b, data_provider)
-            point_b = wp.quat_rotate(rot_b, point_b) + pos_b_adjusted
-            distance = wp.dot(point_b - pos_a_adjusted, normal_world)
-
-            center_local = wp.quat_rotate_inv(rot_a, contact_data.contact_point_center - pos_a_adjusted)
-            center_local -= wp.dot(center_local, normal_local) * normal_local
+            point_b_world = (
+                contact_data.contact_point_center
+                + 0.5 * contact_data.contact_distance * contact_data.contact_normal_a_to_b
+            )
+            point_b_local = wp.quat_rotate_inv(rot_a, point_b_world - pos_a_adjusted)
+            projected_b = point_b_local - wp.dot(point_b_local, normal_local) * normal_local
             point_a = closest_point_on_triangle(
-                center_local,
+                projected_b,
                 wp.vec3(0.0),
                 shape_a.scale,
                 shape_a.auxiliary,
             )
-
+            distance = float(0.0)
+            if wp.length_sq(point_a - projected_b) < 1.0e-10:
+                distance = wp.dot(point_b_local - point_a, normal_local)
             contact_data.contact_point_center = (
                 wp.quat_rotate(rot_a, point_a) + pos_a_adjusted + 0.5 * distance * normal_world
             )

--- a/newton/_src/geometry/collision_core.py
+++ b/newton/_src/geometry/collision_core.py
@@ -16,6 +16,7 @@ from .support_function import (
     GenericShapeData,
     GeoTypeEx,
     SupportMapDataProvider,
+    closest_point_on_triangle,
     pack_mesh_ptr,
     support_map,
     unpack_mesh_ptr,
@@ -273,6 +274,52 @@ def post_process_axial_on_discrete_contact(
             contact_data.contact_point_center = projected_point
 
     return contact_data
+
+
+@wp.func
+def post_process_triangle_contact(
+    contact_data: ContactData,
+    shape_a: GenericShapeData,
+    pos_a_adjusted: wp.vec3,
+    rot_a: wp.quat,
+    shape_b: GenericShapeData,
+    pos_b_adjusted: wp.vec3,
+    rot_b: wp.quat,
+) -> ContactData:
+    """Constrain heightfield-prism contacts to their physical triangle face."""
+    if shape_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM) and contact_data.contact_distance < 0.0:
+        normal_local = wp.cross(shape_a.scale, shape_a.auxiliary)
+        normal_length_sq = wp.length_sq(normal_local)
+        if normal_length_sq >= 1.0e-20:
+            normal_local = normal_local / wp.sqrt(normal_length_sq)
+            if normal_local[2] < 0.0:
+                normal_local = -normal_local
+            normal_world = wp.quat_rotate(rot_a, normal_local)
+
+            data_provider = SupportMapDataProvider()
+            direction_b = wp.quat_rotate_inv(rot_b, -normal_world)
+            point_b = support_map(shape_b, direction_b, data_provider)
+            point_b = wp.quat_rotate(rot_b, point_b) + pos_b_adjusted
+            distance = wp.dot(point_b - pos_a_adjusted, normal_world)
+
+            center_local = wp.quat_rotate_inv(rot_a, contact_data.contact_point_center - pos_a_adjusted)
+            center_local -= wp.dot(center_local, normal_local) * normal_local
+            point_a = closest_point_on_triangle(
+                center_local,
+                wp.vec3(0.0),
+                shape_a.scale,
+                shape_a.auxiliary,
+            )
+
+            contact_data.contact_point_center = (
+                wp.quat_rotate(rot_a, point_a) + pos_a_adjusted + 0.5 * distance * normal_world
+            )
+            contact_data.contact_normal_a_to_b = normal_world
+            contact_data.contact_distance = distance
+
+    return post_process_axial_on_discrete_contact(
+        contact_data, shape_a, pos_a_adjusted, rot_a, shape_b, pos_b_adjusted, rot_b
+    )
 
 
 def create_compute_gjk_mpr_contacts(

--- a/newton/_src/geometry/contact_reduction_global.py
+++ b/newton/_src/geometry/contact_reduction_global.py
@@ -66,6 +66,7 @@ from ..utils.heightfield import HeightfieldData, get_triangle_shape_from_heightf
 from .collision_core import (
     create_compute_gjk_mpr_contacts,
     get_triangle_shape_from_mesh,
+    post_process_triangle_contact,
 )
 from .contact_data import ContactData, compute_contact_approach_speed
 from .contact_reduction import (
@@ -2372,8 +2373,11 @@ def mesh_triangle_contacts_to_reducer_kernel(
         gap_b = shape_gap[shape_b]
         gap_sum = gap_a + gap_b
 
-        # Compute and write contacts using GJK/MPR
-        wp.static(create_compute_gjk_mpr_contacts(write_contact_to_reducer))(
+        wp.static(
+            create_compute_gjk_mpr_contacts(
+                write_contact_to_reducer, post_process_contact=post_process_triangle_contact
+            )
+        )(
             shape_data_a,
             shape_data_b,
             quat_a,

--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -36,16 +36,9 @@ from typing import Any
 import warp as wp
 
 from .support_function import (
-    GeoTypeEx,
-    _support_map_box,
-    closest_point_on_triangle,
-    support_map,
-    support_map_lean,
-    unpack_mesh_ptr,
+    create_shape_center_function,
+    create_shape_support_function,
 )
-from .types import GeoType
-
-MPR_BOX_SUPPORT_TIE_EPSILON = 1.0e-6
 
 
 @wp.struct
@@ -81,19 +74,8 @@ def create_support_map_function(support_func: Any, use_precomputed_center: bool 
         - geometric_center: Computes geometric center of Minkowski difference
     """
 
-    fuse_builtin_box_support = support_func is support_map or support_func is support_map_lean
-
-    @wp.func
-    def shape_support(geom: Any, direction: wp.vec3, data_provider: Any) -> wp.vec3:
-        result = wp.vec3(0.0, 0.0, 0.0)
-        if wp.static(fuse_builtin_box_support):
-            if geom.shape_type == GeoType.BOX:
-                result = _support_map_box(geom, direction)
-            else:
-                result = support_func(geom, direction, data_provider)
-        else:
-            result = support_func(geom, direction, data_provider)
-        return result
+    shape_support = create_shape_support_function(support_func)
+    geometric_center = create_shape_center_function(use_precomputed_center)
 
     # Support mapping functions (these replace the MinkowskiDiff struct methods)
     @wp.func
@@ -174,139 +156,6 @@ def create_support_map_function(support_func: Any, use_precomputed_center: bool 
 
         return v
 
-    @wp.func
-    def geometric_center(
-        geom_a: Any,
-        geom_b: Any,
-        orientation_b: wp.quat,
-        position_b: wp.vec3,
-        data_provider: Any,
-    ) -> Vert:
-        """
-        Compute geometric center of Minkowski difference.
-
-        Used by MPR and GJK as the initial interior point ``v0`` of the
-        Minkowski difference.  A poor ``v0`` — far outside one of the
-        shapes — is a known cause of MPR portal degeneracy when the
-        partner is a thin/flat primitive (e.g. a single mesh triangle),
-        because the chosen ray direction can produce supports that all
-        collapse onto a single vertex of the partner.
-
-        For most primitives the local origin is already a sensible interior
-        point. For ``CONVEX_MESH``, the uncached mode computes the scaled hull
-        AABB and uses its center. When ``use_precomputed_center`` is enabled,
-        this scan is skipped and ``geom.center`` is used for both shapes.
-        Callers selecting that mode must populate each convex mesh center with
-        a valid interior-point approximation rather than relying on the default
-        zero vector.
-
-        For triangles (and triangle prisms) on shape A the center on
-        shape A is replaced by the closest point on the triangle to
-        shape B's center (using the freshly computed B center), giving
-        MPR and GJK a much better starting point when the triangle is
-        large relative to the convex.
-
-        Args:
-            geom_a: Shape A geometry data
-            geom_b: Shape B geometry data
-            orientation_b: Orientation of shape B
-            position_b: Position of shape B
-            data_provider: Support mapping data provider
-
-        Returns:
-            Vert containing geometric centers of both shapes.  ``B`` is
-            in world space; ``BtoA = center_a - center.B`` mixes A-local
-            with world space, which is the convention used by the
-            ``solve_mpr_core`` / ``solve_gjk_core`` callers.
-        """
-        center = Vert()
-
-        if wp.static(use_precomputed_center):
-            center_a = geom_a.center
-            center_b_local = geom_b.center
-        else:
-            center_a = wp.vec3(0.0, 0.0, 0.0)
-            center_b_local = wp.vec3(0.0, 0.0, 0.0)
-
-            if geom_a.shape_type == int(GeoType.CONVEX_MESH):
-                mesh_ptr_a = unpack_mesh_ptr(geom_a.auxiliary)
-                mesh_a = wp.mesh_get(mesh_ptr_a)
-                scale_a = geom_a.scale
-                num_verts_a = mesh_a.points.shape[0]
-                v0_a = wp.cw_mul(mesh_a.points[0], scale_a)
-                min_a = v0_a
-                max_a = v0_a
-                for i in range(1, num_verts_a):
-                    v_a = wp.cw_mul(mesh_a.points[i], scale_a)
-                    min_a = wp.min(min_a, v_a)
-                    max_a = wp.max(max_a, v_a)
-                center_a = 0.5 * (min_a + max_a)
-
-            if geom_b.shape_type == int(GeoType.CONVEX_MESH):
-                mesh_ptr_b = unpack_mesh_ptr(geom_b.auxiliary)
-                mesh_b = wp.mesh_get(mesh_ptr_b)
-                scale_b = geom_b.scale
-                num_verts_b = mesh_b.points.shape[0]
-                v0_b = wp.cw_mul(mesh_b.points[0], scale_b)
-                min_b = v0_b
-                max_b = v0_b
-                for i in range(1, num_verts_b):
-                    v_b = wp.cw_mul(mesh_b.points[i], scale_b)
-                    min_b = wp.min(min_b, v_b)
-                    max_b = wp.max(max_b, v_b)
-                center_b_local = 0.5 * (min_b + max_b)
-
-        center_b_world = position_b + wp.quat_rotate(orientation_b, center_b_local)
-        center_b_to_a = center_a - center_b_world
-
-        if geom_a.shape_type == int(GeoTypeEx.TRIANGLE) or geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
-            # Start near the local contact region.  A small centroid bias keeps
-            # adjacent triangles' manifold witnesses distinct at a shared
-            # edge, but bound it by the normal center-to-plane distance so a
-            # large face cannot turn the initial MPR ray nearly tangential.
-            tri_a = wp.vec3(0.0, 0.0, 0.0)
-            tri_b = geom_a.scale
-            tri_c = geom_a.auxiliary
-            face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
-            face_normal_length_sq = wp.length_sq(face_normal)
-            proj = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
-
-            if face_normal_length_sq >= 1.0e-20:
-                face_normal_length = wp.sqrt(face_normal_length_sq)
-                face_normal_unit = face_normal / face_normal_length
-                signed_plane_distance = wp.dot(center_b_world - tri_a, face_normal_unit)
-                plane_proj = center_b_world - signed_plane_distance * face_normal_unit
-
-                # Reconstruct face-region offsets directly.  Subtracting two
-                # large, nearby positions can otherwise leave a spurious
-                # tangential component in the initial MPR ray.
-                inside_face = (
-                    wp.dot(wp.cross(tri_b - tri_a, plane_proj - tri_a), face_normal) >= 0.0
-                    and wp.dot(wp.cross(tri_c - tri_b, plane_proj - tri_b), face_normal) >= 0.0
-                    and wp.dot(wp.cross(tri_a - tri_c, plane_proj - tri_c), face_normal) >= 0.0
-                )
-                if inside_face:
-                    proj = plane_proj
-                    center_b_to_a = -signed_plane_distance * face_normal_unit
-                else:
-                    center_b_to_a = proj - center_b_world
-
-                centroid = (tri_a + tri_b + tri_c) / 3.0
-                to_centroid = centroid - proj
-                to_centroid -= wp.dot(to_centroid, face_normal_unit) * face_normal_unit
-                distance_to_centroid = wp.length(to_centroid)
-                if distance_to_centroid > 1.0e-12:
-                    nudge_distance = 0.01 * wp.min(distance_to_centroid, wp.abs(signed_plane_distance))
-                    center_b_to_a += to_centroid * (nudge_distance / distance_to_centroid)
-
-            else:
-                center_b_to_a = proj - center_b_world
-
-        center.B = center_b_world
-        center.BtoA = center_b_to_a
-
-        return center
-
     return support_map_b, minkowski_support, geometric_center
 
 
@@ -332,43 +181,8 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
     else:
         _support_map_b, _minkowski_support, geometric_center = create_support_map_function(support_func)
 
-    fuse_builtin_box_support = support_func is support_map or support_func is support_map_lean
-
-    @wp.func
-    def centered_box_support(geom: Any, direction: wp.vec3, data_provider: Any) -> wp.vec3:
-        result = wp.vec3(0.0, 0.0, 0.0)
-        if wp.static(fuse_builtin_box_support):
-            if geom.shape_type == GeoType.BOX:
-                # Reuse the absolute direction for the built-in box support and MPR's tie policy.
-                abs_direction = wp.vec3(wp.abs(direction[0]), wp.abs(direction[1]), wp.abs(direction[2]))
-                result = _support_map_box(geom, direction)
-
-                contribution = wp.cw_mul(abs_direction, geom.scale)
-                threshold = MPR_BOX_SUPPORT_TIE_EPSILON * (contribution[0] + contribution[1] + contribution[2])
-                if contribution[0] <= threshold:
-                    result[0] = 0.0
-                if contribution[1] <= threshold:
-                    result[1] = 0.0
-                if contribution[2] <= threshold:
-                    result[2] = 0.0
-            else:
-                result = support_func(geom, direction, data_provider)
-        else:
-            result = support_func(geom, direction, data_provider)
-            if geom.shape_type == GeoType.BOX:
-                # A nearly tied box face has infinitely many valid support points. Its center
-                # avoids feeding solver-scale rotation noise into MPR's portal topology.
-                contribution = wp.cw_mul(wp.abs(direction), geom.scale)
-                threshold = MPR_BOX_SUPPORT_TIE_EPSILON * (contribution[0] + contribution[1] + contribution[2])
-                if contribution[0] <= threshold:
-                    result[0] = 0.0
-                if contribution[1] <= threshold:
-                    result[1] = 0.0
-                if contribution[2] <= threshold:
-                    result[2] = 0.0
-        return result
-
-    _, mpr_support, _ = create_support_map_function(centered_box_support)
+    shape_support = create_shape_support_function(support_func, center_ties=True)
+    _, mpr_support, _ = create_support_map_function(shape_support)
 
     @wp.func
     def solve_mpr_core(
@@ -420,32 +234,8 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
         normal = v0.BtoA
         if wp.length_sq(normal) < NUMERIC_EPSILON:
-            used_triangle_fallback = bool(False)
-            if geom_a.shape_type == int(GeoTypeEx.TRIANGLE) or geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
-                tri_a = wp.vec3(0.0, 0.0, 0.0)
-                tri_b = geom_a.scale
-                tri_c = geom_a.auxiliary
-                face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
-                face_normal_length_sq = wp.length_sq(face_normal)
-                if face_normal_length_sq >= 1.0e-20:
-                    face_normal = face_normal / wp.sqrt(face_normal_length_sq)
-                    proj = closest_point_on_triangle(v0.B, tri_a, tri_b, tri_c)
-                    centroid = (tri_a + tri_b + tri_c) / 3.0
-                    to_centroid = centroid - proj
-                    to_centroid -= wp.dot(to_centroid, face_normal) * face_normal
-                    to_centroid_length_sq = wp.length_sq(to_centroid)
-
-                    # Use the face normal for coincident triangle/convex
-                    # centers, retaining a small triangle-specific bias.
-                    fallback_dir = -face_normal
-                    if wp.dot(v0.B - proj, face_normal) < 0.0:
-                        fallback_dir = face_normal
-                    if to_centroid_length_sq > 1.0e-20:
-                        fallback_dir += 0.01 * to_centroid / wp.sqrt(to_centroid_length_sq)
-                    v0.BtoA = wp.normalize(fallback_dir) * 1.0e-5
-                    used_triangle_fallback = True
-
-            if not used_triangle_fallback:
+            v0.BtoA = geometric_center.fallback(geom_a, v0.B)
+            if wp.length_sq(v0.BtoA) < NUMERIC_EPSILON:
                 # Probe three axes and use the direction with most support.
                 best_dot = float(-1.0e30)
                 best_dir = wp.vec3(1.0, 0.0, 0.0)

--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -22,6 +22,7 @@ from ..geometry.collision_core import (
     mesh_vs_convex_midphase,
     post_process_axial_on_discrete_contact,
     post_process_minkowski_only,
+    post_process_triangle_contact,
 )
 from ..geometry.collision_primitive import (
     _collide_plane_capsule_contacts,
@@ -1646,8 +1647,7 @@ def create_narrow_phase_process_mesh_triangle_contacts_kernel(writer_func: Any):
             gap_b = shape_gap[shape_b]
             gap_sum = gap_a + gap_b
 
-            # Compute and write contacts using GJK/MPR with standard post-processing
-            wp.static(create_compute_gjk_mpr_contacts(writer_func))(
+            wp.static(create_compute_gjk_mpr_contacts(writer_func, post_process_contact=post_process_triangle_contact))(
                 shape_data_a,
                 shape_data_b,
                 quat_a,

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -539,7 +539,26 @@ class MinkowskiCenter:
 
 
 def create_shape_center_function(use_precomputed_center: bool = False):
-    """Create a Minkowski center function with built-in shape policies."""
+    """Create the common Minkowski-center function used by MPR and GJK.
+
+    The returned function supplies the initial interior point of the
+    Minkowski difference. Most primitives use their local origin. Uncached
+    convex meshes use the center of their scaled AABB, while cached callers
+    use ``geom.center`` and must provide a valid interior-point approximation.
+
+    Triangle-like shape A needs a partner-relative seed. Its center is moved
+    to the point on the physical triangle nearest shape B's center and nudged
+    toward the triangle centroid. This avoids portals collapsing onto one
+    vertex when a large, thin triangle is paired with a much smaller shape.
+
+    Args:
+        use_precomputed_center: Use the center stored in each geometry instead
+            of computing convex-mesh AABB centers.
+
+    Returns:
+        A shape-center function with a ``fallback`` attribute for the
+        coincident-center case.
+    """
 
     @wp.func
     def shape_center(
@@ -549,6 +568,19 @@ def create_shape_center_function(use_precomputed_center: bool = False):
         position_b: wp.vec3,
         data_provider: Any,
     ) -> MinkowskiCenter:
+        """Compute an interior point of the Minkowski difference.
+
+        Args:
+            geom_a: Shape A geometry data.
+            geom_b: Shape B geometry data.
+            orientation_b: Shape B orientation relative to shape A.
+            position_b: Shape B position relative to shape A.
+            data_provider: Support-map data provider.
+
+        Returns:
+            Centers in the relative frame. ``B`` is shape B's center and
+            ``BtoA`` points from it to the selected center on shape A.
+        """
         center = MinkowskiCenter()
         if wp.static(use_precomputed_center):
             center_a = geom_a.center

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -28,6 +28,7 @@ defining generic shape data structures that work across all primitive types.
 """
 
 import enum
+from typing import Any
 
 import warp as wp
 
@@ -37,6 +38,7 @@ from .types import GeoType
 # Near-zero direction components (e.g. from quaternion rotation noise ~1e-14)
 # are treated as non-negative, biasing toward the +1 vertex.
 BOX_SUPPORT_DEADBAND = 1.0e-10
+_CENTERED_BOX_SUPPORT_TIE_EPSILON = 1.0e-6
 
 
 @wp.func_native("""
@@ -386,6 +388,181 @@ def support_map_lean(geom: GenericShapeData, direction: wp.vec3, data_provider: 
         result = n * radius
 
     return result
+
+
+def create_shape_support_function(support_func: Any, center_ties: bool = False):
+    """Create a support function with built-in shape policies."""
+    fuse_builtin_box_support = support_func is support_map or support_func is support_map_lean
+
+    if center_ties:
+
+        @wp.func
+        def shape_support(geom: Any, direction: wp.vec3, data_provider: Any) -> wp.vec3:
+            result = wp.vec3(0.0, 0.0, 0.0)
+            if wp.static(fuse_builtin_box_support):
+                if geom.shape_type == GeoType.BOX:
+                    abs_direction = wp.vec3(wp.abs(direction[0]), wp.abs(direction[1]), wp.abs(direction[2]))
+                    result = _support_map_box(geom, direction)
+                    contribution = wp.cw_mul(abs_direction, geom.scale)
+                    threshold = _CENTERED_BOX_SUPPORT_TIE_EPSILON * (
+                        contribution[0] + contribution[1] + contribution[2]
+                    )
+                    if contribution[0] <= threshold:
+                        result[0] = 0.0
+                    if contribution[1] <= threshold:
+                        result[1] = 0.0
+                    if contribution[2] <= threshold:
+                        result[2] = 0.0
+                else:
+                    result = support_func(geom, direction, data_provider)
+            else:
+                result = support_func(geom, direction, data_provider)
+                if geom.shape_type == GeoType.BOX:
+                    contribution = wp.cw_mul(wp.abs(direction), geom.scale)
+                    threshold = _CENTERED_BOX_SUPPORT_TIE_EPSILON * (
+                        contribution[0] + contribution[1] + contribution[2]
+                    )
+                    if contribution[0] <= threshold:
+                        result[0] = 0.0
+                    if contribution[1] <= threshold:
+                        result[1] = 0.0
+                    if contribution[2] <= threshold:
+                        result[2] = 0.0
+            return result
+
+    else:
+
+        @wp.func
+        def shape_support(geom: Any, direction: wp.vec3, data_provider: Any) -> wp.vec3:
+            result = wp.vec3(0.0, 0.0, 0.0)
+            if wp.static(fuse_builtin_box_support):
+                if geom.shape_type == GeoType.BOX:
+                    result = _support_map_box(geom, direction)
+                else:
+                    result = support_func(geom, direction, data_provider)
+            else:
+                result = support_func(geom, direction, data_provider)
+            return result
+
+    return shape_support
+
+
+@wp.func
+def _shape_center(geom: Any) -> wp.vec3:
+    """Return a local interior-point approximation for a supported shape."""
+    if geom.shape_type == int(GeoType.CONVEX_MESH):
+        mesh = wp.mesh_get(unpack_mesh_ptr(geom.auxiliary))
+        scale = geom.scale
+        first = wp.cw_mul(mesh.points[0], scale)
+        lower = first
+        upper = first
+        for i in range(1, mesh.points.shape[0]):
+            point = wp.cw_mul(mesh.points[i], scale)
+            lower = wp.min(lower, point)
+            upper = wp.max(upper, point)
+        return 0.5 * (lower + upper)
+    return wp.vec3(0.0)
+
+
+@wp.func
+def _adjust_minkowski_center(geom_a: Any, center_b_world: wp.vec3, center_b_to_a: wp.vec3) -> wp.vec3:
+    """Adjust the Minkowski center for shapes that need a local contact seed."""
+    if geom_a.shape_type != int(GeoTypeEx.TRIANGLE) and geom_a.shape_type != int(GeoTypeEx.TRIANGLE_PRISM):
+        return center_b_to_a
+
+    tri_a = wp.vec3(0.0)
+    tri_b = geom_a.scale
+    tri_c = geom_a.auxiliary
+    face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
+    face_normal_length_sq = wp.length_sq(face_normal)
+    projection = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
+    if face_normal_length_sq < 1.0e-20:
+        return projection - center_b_world
+
+    face_normal_unit = face_normal / wp.sqrt(face_normal_length_sq)
+    signed_plane_distance = wp.dot(center_b_world - tri_a, face_normal_unit)
+    plane_projection = center_b_world - signed_plane_distance * face_normal_unit
+    inside_face = (
+        wp.dot(wp.cross(tri_b - tri_a, plane_projection - tri_a), face_normal) >= 0.0
+        and wp.dot(wp.cross(tri_c - tri_b, plane_projection - tri_b), face_normal) >= 0.0
+        and wp.dot(wp.cross(tri_a - tri_c, plane_projection - tri_c), face_normal) >= 0.0
+    )
+    if inside_face:
+        projection = plane_projection
+        center_b_to_a = -signed_plane_distance * face_normal_unit
+    else:
+        center_b_to_a = projection - center_b_world
+
+    to_centroid = (tri_a + tri_b + tri_c) / 3.0 - projection
+    to_centroid -= wp.dot(to_centroid, face_normal_unit) * face_normal_unit
+    distance_to_centroid = wp.length(to_centroid)
+    if distance_to_centroid > 1.0e-12:
+        nudge_distance = 0.01 * wp.min(distance_to_centroid, wp.abs(signed_plane_distance))
+        center_b_to_a += to_centroid * (nudge_distance / distance_to_centroid)
+    return center_b_to_a
+
+
+@wp.func
+def _minkowski_center_fallback(geom_a: Any, center_b_world: wp.vec3) -> wp.vec3:
+    """Return a nonzero triangle seed when the Minkowski centers coincide."""
+    if geom_a.shape_type != int(GeoTypeEx.TRIANGLE) and geom_a.shape_type != int(GeoTypeEx.TRIANGLE_PRISM):
+        return wp.vec3(0.0)
+
+    tri_a = wp.vec3(0.0)
+    tri_b = geom_a.scale
+    tri_c = geom_a.auxiliary
+    face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
+    face_normal_length_sq = wp.length_sq(face_normal)
+    if face_normal_length_sq < 1.0e-20:
+        return wp.vec3(0.0)
+
+    face_normal /= wp.sqrt(face_normal_length_sq)
+    projection = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
+    to_centroid = (tri_a + tri_b + tri_c) / 3.0 - projection
+    to_centroid -= wp.dot(to_centroid, face_normal) * face_normal
+    to_centroid_length_sq = wp.length_sq(to_centroid)
+
+    fallback_direction = -face_normal
+    if wp.dot(center_b_world - projection, face_normal) < 0.0:
+        fallback_direction = face_normal
+    if to_centroid_length_sq > 1.0e-20:
+        fallback_direction += 0.01 * to_centroid / wp.sqrt(to_centroid_length_sq)
+    return wp.normalize(fallback_direction) * 1.0e-5
+
+
+@wp.struct
+class MinkowskiCenter:
+    """Store a Minkowski interior point and optional coincident-center fallback."""
+
+    B: wp.vec3
+    BtoA: wp.vec3
+
+
+def create_shape_center_function(use_precomputed_center: bool = False):
+    """Create a Minkowski center function with built-in shape policies."""
+
+    @wp.func
+    def shape_center(
+        geom_a: Any,
+        geom_b: Any,
+        orientation_b: wp.quat,
+        position_b: wp.vec3,
+        data_provider: Any,
+    ) -> MinkowskiCenter:
+        center = MinkowskiCenter()
+        if wp.static(use_precomputed_center):
+            center_a = geom_a.center
+            center_b_local = geom_b.center
+        else:
+            center_a = _shape_center(geom_a)
+            center_b_local = _shape_center(geom_b)
+
+        center.B = position_b + wp.quat_rotate(orientation_b, center_b_local)
+        center.BtoA = _adjust_minkowski_center(geom_a, center.B, center_a - center.B)
+        return center
+
+    shape_center.fallback = _minkowski_center_fallback
+    return shape_center
 
 
 @wp.func

--- a/newton/tests/test_heightfield.py
+++ b/newton/tests/test_heightfield.py
@@ -494,6 +494,30 @@ class TestHeightfield(unittest.TestCase):
 
         self.assertTrue(np.all(distance >= 0.0), f"penetrating boundary contacts: {distance}")
 
+    def test_heightfield_boundary_ignores_external_lowest_point(self):
+        """Ignore a penetrating support point outside the heightfield footprint."""
+        builder = newton.ModelBuilder()
+        self._add_flat_heightfield(builder)
+
+        rotation = wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.25 * wp.pi)
+        body = builder.add_body(xform=wp.transform((0.95, 0.0, 0.11), rotation))
+        builder.add_shape_box(body=body, hx=0.2, hy=0.05, hz=0.05)
+
+        model = builder.finalize()
+        for reduce_contacts in (False, True):
+            with self.subTest(reduce_contacts=reduce_contacts):
+                distance, normal, point0 = self._get_contact_kinematics(
+                    model, model.state(), reduce_contacts=reduce_contacts
+                )
+
+                self.assertGreater(len(distance), 0, "no contacts between box and heightfield boundary")
+                deepest = int(np.argmin(distance))
+                self.assertLess(float(distance[deepest]), -0.001)
+                self.assertGreater(float(distance[deepest]), -0.015, f"overestimated penetration: {distance}")
+                self.assertGreater(float(normal[deepest][2]), 0.999)
+                self.assertLessEqual(float(point0[deepest][0]), 1.0 + 1.0e-5)
+                self.assertAlmostEqual(float(point0[deepest][2]), 0.0, places=5)
+
     def test_heightfield_native_collision_scaled(self):
         """Per-instance ``scale`` on ``add_shape_heightfield`` is honored by narrow-phase.
 

--- a/newton/tests/test_heightfield.py
+++ b/newton/tests/test_heightfield.py
@@ -356,6 +356,144 @@ class TestHeightfield(unittest.TestCase):
         contact_count = int(contacts.rigid_contact_count.numpy()[0])
         self.assertGreater(contact_count, 0, "No contacts detected between sphere and heightfield")
 
+    def _get_contact_kinematics(self, model, state, *, reduce_contacts=True):
+        """Return contact distances, normals, and heightfield points for a model state."""
+        pipeline = newton.CollisionPipeline(model, reduce_contacts=reduce_contacts)
+        contacts = pipeline.contacts()
+        distance = wp.empty(contacts.rigid_contact_max, dtype=float, device=model.device)
+        point0 = wp.empty(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
+
+        pipeline.collide(state, contacts)
+        newton.eval_rigid_contact_kinematics(model, state, contacts, out_distance=distance, out_point0_world=point0)
+
+        count = int(contacts.rigid_contact_count.numpy()[0])
+        return (
+            distance.numpy()[:count],
+            contacts.rigid_contact_normal.numpy()[:count],
+            point0.numpy()[:count],
+        )
+
+    @staticmethod
+    def _add_flat_heightfield(builder, *, xform=None):
+        """Add a flat unit heightfield to a model builder."""
+        heightfield = Heightfield(
+            data=np.zeros((21, 21), dtype=np.float32),
+            nrow=21,
+            ncol=21,
+            hx=1.0,
+            hy=1.0,
+            min_z=0.0,
+            max_z=1.0,
+        )
+        builder.add_shape_heightfield(xform=xform, heightfield=heightfield)
+
+    def test_heightfield_box_penetration_uses_surface(self):
+        """Verify box penetration is resolved through the heightfield surface."""
+        half_z = 0.02
+        for depth in (0.005, 0.019, 0.021, 0.05):
+            with self.subTest(depth=depth):
+                builder = newton.ModelBuilder()
+                self._add_flat_heightfield(builder)
+
+                body = builder.add_body(xform=wp.transform((0.0, 0.0, half_z - depth), wp.quat_identity()))
+                builder.add_shape_box(body=body, hx=0.2, hy=0.065, hz=half_z)
+
+                model = builder.finalize()
+                distance, normal, point0 = self._get_contact_kinematics(model, model.state())
+
+                self.assertGreater(len(distance), 0, "no contacts between box and heightfield")
+                deepest = int(np.argmin(distance))
+                self.assertAlmostEqual(float(distance[deepest]), -depth, places=4)
+                self.assertGreater(float(normal[deepest][2]), 0.999)
+                self.assertAlmostEqual(float(point0[deepest][2]), 0.0, places=5)
+
+    def test_heightfield_sphere_penetration_uses_surface(self):
+        """Verify sphere penetration remains surface-normal below its center."""
+        radius = 0.02
+        for reduce_contacts in (False, True):
+            for depth in (0.005, 0.019, 0.021, 0.05):
+                with self.subTest(reduce_contacts=reduce_contacts, depth=depth):
+                    builder = newton.ModelBuilder()
+                    self._add_flat_heightfield(builder)
+
+                    body = builder.add_body(xform=wp.transform((0.0, 0.0, radius - depth), wp.quat_identity()))
+                    builder.add_shape_sphere(body=body, radius=radius)
+
+                    model = builder.finalize()
+                    distance, normal, point0 = self._get_contact_kinematics(
+                        model, model.state(), reduce_contacts=reduce_contacts
+                    )
+
+                    self.assertGreater(len(distance), 0, "no contacts between sphere and heightfield")
+                    deepest = int(np.argmin(distance))
+                    self.assertAlmostEqual(float(distance[deepest]), -depth, places=3)
+                    self.assertGreater(float(normal[deepest][2]), 0.999)
+                    self.assertAlmostEqual(float(point0[deepest][2]), 0.0, places=5)
+
+    def test_heightfield_sloped_penetration_uses_surface(self):
+        """Verify penetration follows a sloped heightfield face normal."""
+        slope = 0.25
+        radius = 0.05
+        depth = 0.08
+        x = np.linspace(-1.0, 1.0, 21, dtype=np.float32)
+        elevation = np.broadcast_to(slope * x, (21, 21)).copy()
+        expected_normal = np.array((-slope, 0.0, 1.0), dtype=np.float32)
+        expected_normal /= np.linalg.norm(expected_normal)
+
+        builder = newton.ModelBuilder()
+        heightfield = Heightfield(data=elevation, nrow=21, ncol=21, hx=1.0, hy=1.0)
+        builder.add_shape_heightfield(heightfield=heightfield)
+
+        center = expected_normal * (radius - depth)
+        body = builder.add_body(xform=wp.transform(wp.vec3(*center), wp.quat_identity()))
+        builder.add_shape_sphere(body=body, radius=radius)
+
+        model = builder.finalize()
+        distance, normal, point0 = self._get_contact_kinematics(model, model.state())
+
+        self.assertGreater(len(distance), 0, "no contacts between sphere and sloped heightfield")
+        deepest = int(np.argmin(distance))
+        self.assertAlmostEqual(float(distance[deepest]), -depth, places=3)
+        self.assertGreater(float(np.dot(normal[deepest], expected_normal)), 0.999)
+        self.assertAlmostEqual(float(point0[deepest][2] - slope * point0[deepest][0]), 0.0, places=5)
+
+    def test_heightfield_rotated_penetration_uses_surface(self):
+        """Verify penetration follows a transformed heightfield surface normal."""
+        radius = 0.05
+        depth = 0.08
+        rotation = wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.4)
+        expected_normal = np.asarray(wp.quat_rotate(rotation, wp.vec3(0.0, 0.0, 1.0)), dtype=np.float32)
+
+        builder = newton.ModelBuilder()
+        self._add_flat_heightfield(builder, xform=wp.transform(wp.vec3(0.0), rotation))
+
+        center = expected_normal * (radius - depth)
+        body = builder.add_body(xform=wp.transform(wp.vec3(*center), wp.quat_identity()))
+        builder.add_shape_sphere(body=body, radius=radius)
+
+        model = builder.finalize()
+        distance, normal, point0 = self._get_contact_kinematics(model, model.state())
+
+        self.assertGreater(len(distance), 0, "no contacts between sphere and rotated heightfield")
+        deepest = int(np.argmin(distance))
+        self.assertAlmostEqual(float(distance[deepest]), -depth, places=3)
+        self.assertGreater(float(np.dot(normal[deepest], expected_normal)), 0.999)
+        self.assertAlmostEqual(float(np.dot(point0[deepest], expected_normal)), 0.0, places=5)
+
+    def test_heightfield_boundary_has_no_skirt_contact(self):
+        """Verify the heightfield boundary does not expose the prism skirt."""
+        radius = 0.02
+        builder = newton.ModelBuilder()
+        self._add_flat_heightfield(builder)
+
+        body = builder.add_body(xform=wp.transform((1.0 + radius + 0.01, 0.0, -0.05), wp.quat_identity()))
+        builder.add_shape_sphere(body=body, radius=radius)
+
+        model = builder.finalize()
+        distance, _normal, _point0 = self._get_contact_kinematics(model, model.state())
+
+        self.assertTrue(np.all(distance >= 0.0), f"penetrating boundary contacts: {distance}")
+
     def test_heightfield_native_collision_scaled(self):
         """Per-instance ``scale`` on ``add_shape_heightfield`` is honored by narrow-phase.
 

--- a/newton/tests/test_mpr.py
+++ b/newton/tests/test_mpr.py
@@ -9,8 +9,9 @@ import numpy as np
 import warp as wp
 
 from newton import GeoType
-from newton._src.geometry.mpr import MPR_BOX_SUPPORT_TIE_EPSILON, create_solve_mpr
+from newton._src.geometry.mpr import create_solve_mpr
 from newton._src.geometry.support_function import (
+    _CENTERED_BOX_SUPPORT_TIE_EPSILON,
     GenericShapeData,
     GeoTypeEx,
     SupportMapDataProvider,
@@ -171,7 +172,7 @@ class TestMPRBoxSupportTie(unittest.TestCase):
 
     def test_support_tie_boundary_preserves_contact_witnesses(self):
         """Keep valid witnesses immediately below and above the box support tie threshold."""
-        angles = MPR_BOX_SUPPORT_TIE_EPSILON * np.array([0.5, 2.0], dtype=np.float32)
+        angles = _CENTERED_BOX_SUPPORT_TIE_EPSILON * np.array([0.5, 2.0], dtype=np.float32)
         orientations = np.zeros((len(angles), 4), dtype=np.float32)
         orientations[:, 0] = np.sin(0.5 * angles)
         orientations[:, 3] = np.cos(0.5 * angles)


### PR DESCRIPTION
## Description

Please also read the MR description here: https://github.com/newton-physics/newton/pull/3982

Fix deeply penetrating heightfield contacts selecting the internal triangle-prism skirt instead of the physical heightfield surface. Post-process penetrating heightfield contacts onto the finite triangle face so contact depth, normal, and witness point describe the actual terrain. Keep MPR and GJK shape-agnostic by moving shape-specific support and center policies into the support-function layer.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k penetration_uses_surface
uv run --extra dev -m newton.tests -k test_heightfield_boundary_has_no_skirt_contact
uv run --extra dev -m newton.tests -k large_triangle_contact_matches_small
uv run --extra dev -m newton.tests -k off_origin_convex_hull_contacts
uv run --extra dev -m newton.tests -k test_split_gjk_mpr_matches_fused_under_graph_capture
uv run --extra dev -m newton.tests -k mpr
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create a flat heightfield and a thin box resting on it.
2. Move the box center below the heightfield surface.
3. Observe a penetration near the 1 m prism extrusion depth with a downward normal instead of the physical overlap with an upward surface normal.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton

half_z = 0.02
depth = 0.021
builder = newton.ModelBuilder()
builder.add_shape_heightfield(
    heightfield=newton.Heightfield(
        data=np.zeros((21, 21), dtype=np.float32),
        nrow=21,
        ncol=21,
        hx=1.0,
        hy=1.0,
        min_z=0.0,
        max_z=1.0,
    )
)
body = builder.add_body(xform=wp.transform((0.0, 0.0, half_z - depth), wp.quat_identity()))
builder.add_shape_box(body=body, hx=0.2, hy=0.065, hz=half_z)
model = builder.finalize()
state = model.state()
pipeline = newton.CollisionPipeline(model)
contacts = pipeline.contacts()
distance = wp.empty(contacts.rigid_contact_max, dtype=float, device=model.device)
pipeline.collide(state, contacts)
newton.eval_rigid_contact_kinematics(model, state, contacts, out_distance=distance)
count = int(contacts.rigid_contact_count.numpy()[0])
deepest = int(np.argmin(distance.numpy()[:count]))
print(distance.numpy()[deepest], contacts.rigid_contact_normal.numpy()[deepest])
# Before: approximately -1.019 [0.0, 0.0, -1.0]
# After:  approximately -0.021 [0.0, 0.0,  1.0]
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deeply penetrating heightfield contacts so they remain on the physical surface instead of the internal skirt.
  * Improved contact points, normals, and penetration handling for sloped, rotated, and boundary heightfields.
  * Improved mesh-triangle contact accuracy and prevented invalid contacts outside heightfield boundaries.
  * Improved collision stability for box support and degenerate contact cases.

* **Tests**
  * Added regression coverage for box and sphere collisions across flat, sloped, rotated, and boundary heightfields.
  * Updated collision tests for improved box support handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->