### PR TITLE
Fix int64 mesh normal indices

### DIFF
--- a/changelog/3985.fixed.md
+++ b/changelog/3985.fixed.md
@@ -1,0 +1,1 @@
+Support Warp mesh indices with non-`int32` integer dtypes in `compute_vertex_normals()`.

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -116,7 +116,11 @@ def compute_vertex_normals(
             normals_wp.zero_()
         if len(indices_wp) == 0 or len(points) == 0:
             return normals_wp
-        indices_i32 = indices_wp if indices_wp.dtype == wp.int32 else indices_wp.view(dtype=wp.int32)
+        if indices_wp.dtype == wp.int32:
+            indices_i32 = indices_wp
+        else:
+            indices_i32 = wp.empty(indices_wp.shape, dtype=wp.int32, device=indices_wp.device)
+            wp.utils.array_cast(in_array=indices_wp, out_array=indices_i32)
         wp.launch(
             accumulate_vertex_normals,
             dim=len(indices_i32) // 3,

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -103,6 +103,8 @@ def compute_vertex_normals(
                 raise ValueError("indices must be flat or (N, 3) for NumPy inputs.")
             indices_wp = wp.array(indices_np, dtype=wp.int32, device=device_obj)
         indices_wp = cast(wp.array, indices_wp)
+        if not wp.types.type_is_int(indices_wp.dtype):
+            raise TypeError(f"Warp indices must use an integer scalar dtype, got {indices_wp.dtype}.")
         if indices_wp.ndim == 2:
             if indices_wp.shape[1] != 3:
                 raise ValueError("indices must be flat or (N, 3) for Warp inputs.")

--- a/newton/tests/test_mesh_utils.py
+++ b/newton/tests/test_mesh_utils.py
@@ -28,6 +28,8 @@ class TestComputeVertexNormals(unittest.TestCase):
             warp_index_cases = {
                 "flat Warp": wp.array([0, 1, 2], dtype=wp.int32, device=device),
                 "triangle-shaped Warp": wp.array([[0, 1, 2]], dtype=wp.int32, device=device),
+                "flat int64 Warp": wp.array([0, 1, 2], dtype=wp.int64, device=device),
+                "triangle-shaped int64 Warp": wp.array([[0, 1, 2]], dtype=wp.int64, device=device),
                 "flat NumPy": np.array([0, 1, 2], dtype=np.int32),
                 "triangle-shaped NumPy": np.array([[0, 1, 2]], dtype=np.int32),
             }

--- a/newton/tests/test_mesh_utils.py
+++ b/newton/tests/test_mesh_utils.py
@@ -62,6 +62,24 @@ class TestComputeVertexNormals(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "indices must be flat or \\(N, 3\\) for Warp inputs"):
                     compute_vertex_normals(points, indices)
 
+    def test_invalid_warp_index_dtypes(self):
+        """Reject non-scalar-integer Warp index dtypes."""
+        points = wp.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            dtype=wp.vec3,
+            device="cpu",
+        )
+        invalid_indices = {
+            "floating-point": wp.array([0.0, 1.0, 2.0], dtype=wp.float32, device="cpu"),
+            "boolean": wp.array([False, True, True], dtype=wp.bool, device="cpu"),
+            "composite": wp.array([wp.vec3i(0, 1, 2)], dtype=wp.vec3i, device="cpu"),
+        }
+
+        for name, indices in invalid_indices.items():
+            with self.subTest(dtype=name):
+                with self.assertRaisesRegex(TypeError, "Warp indices must use an integer scalar dtype"):
+                    compute_vertex_normals(points, indices)
+
     def test_invalid_numpy_index_layouts(self):
         """Reject NumPy indices that are neither flat nor triangle-shaped."""
         points_np = np.array(


### PR DESCRIPTION
## Description

Replace the incompatible `int64`-to-`int32` Warp array view in `compute_vertex_normals()` with a device-side numeric cast. Extend the existing index-layout test to cover flat and `(N, 3)` `wp.int64` arrays on the basic CPU and CUDA devices.

Closes #3985.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- Ran all three tests in `newton/tests/test_mesh_utils.py` against the current source module on CPU and H100 CUDA; all passed with no warnings.
- Ran Ruff format and lint checks on both changed Python files.
- Ran the Towncrier 25.8.0 draft build and `git diff --check`.

## Bug fix

**Steps to reproduce:**

1. Create a Warp vertex array and an equivalent `wp.int64` triangle index array.
2. Call `compute_vertex_normals(points, indices)`.
3. Observe `TypeError` because Warp cannot view 8-byte `int64` elements as 4-byte `int32` elements.

**Minimal reproduction:**

```python
import warp as wp

from newton._src.utils.mesh import compute_vertex_normals


points = wp.array(
    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
    dtype=wp.vec3,
    device="cpu",
)
indices = wp.array([0, 1, 2], dtype=wp.int64, device="cpu")

compute_vertex_normals(points, indices)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `compute_vertex_normals()` now supports Warp mesh index arrays using integer types beyond `int32`, including `int64`.

* **Bug Fixes**
  * Improved handling of flat and triangle-shaped `int64` mesh index arrays when calculating vertex normals.
  * Invalid non-integer index types now produce a clear error instead of failing during processing.

* **Tests**
  * Added coverage for supported non-`int32` index layouts and rejected index types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->