### PR TITLE
Fix deprecated example API usage

### DIFF
--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -671,10 +671,10 @@ class with the following interface:
             """Optional per-step validation, called after every step() in test mode."""
             ...
 
-Every example **must** implement ``test_final()`` (or ``test_post_step()``, or both).
-The test harness runs examples with ``--viewer null --test`` and calls these methods to
-verify simulation correctness. An example that implements neither will raise
-``NotImplementedError`` in CI.
+Every example **must** implement ``test_final()``. Examples may additionally implement
+``test_post_step()`` for per-step validation. The test harness runs examples with
+``--viewer null --test`` and calls these methods to verify simulation correctness. An
+example without ``test_final()`` will raise ``NotImplementedError`` in CI.
 
 Discovery and registration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -683,6 +683,10 @@ Examples are discovered automatically: any file matching
 ``newton/examples/<category>/example_*.py`` is picked up by ``newton.examples.get_examples()``.
 The short name used on the command line is the filename without the ``example_`` prefix and
 ``.py`` extension (e.g. ``basic_pendulum``).
+
+The example test suite gives every discovered example a baseline CUDA test automatically.
+Add an explicit registration in ``newton/tests/test_examples.py`` only when an example needs
+tailored arguments, devices, dependencies, or additional variants.
 
 New examples must also be registered in the examples ``README.md`` with a                                                        
 ``python -m newton.examples <example_name>`` command and a 320x320 jpg screenshot.  

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -528,7 +528,10 @@ def run(example, args):
 
     perform_test = args is not None and args.test
     test_post_step = perform_test and hasattr(example, "test_post_step")
-    test_final = perform_test and hasattr(example, "test_final")
+    test_final = perform_test and callable(getattr(example, "test_final", None))
+
+    if perform_test and not test_final:
+        raise NotImplementedError("Examples must implement test_final() to run in test mode")
 
     browser = _ExampleBrowser(viewer, args) if not perform_test else None
 
@@ -570,10 +573,7 @@ def run(example, args):
         _throttle_render_fps(frame_start_time, render_fps)
 
     if perform_test:
-        if test_final:
-            example.test_final()
-        elif not (test_post_step or test_final):
-            raise NotImplementedError("Example does not have a test_final or test_post_step method")
+        example.test_final()
 
     viewer.close()
 

--- a/newton/examples/basic/example_basic_heightfield.py
+++ b/newton/examples/basic/example_basic_heightfield.py
@@ -21,6 +21,7 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer, args):
+        newton.use_coord_layout_targets = True
         self.fps = 100
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/contacts/example_contacts_rj45_plug.py
+++ b/newton/examples/contacts/example_contacts_rj45_plug.py
@@ -223,6 +223,7 @@ def _load_cable_centerline(stage) -> tuple[wp.vec3, ...]:
 
 class Example:
     def __init__(self, viewer, args=None):
+        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0
@@ -241,7 +242,6 @@ class Example:
         latch_mesh, lc = _load_mesh(stage, "/World/Latch")
 
         builder = newton.ModelBuilder(gravity=(0.0, 0.0, -9.81))
-        SolverVBD.register_custom_attributes(builder)
         builder.rigid_gap = 0.005
 
         builder.add_ground_plane()
@@ -293,7 +293,6 @@ class Example:
             angular_axes=None,
             parent_xform=wp.transform(plug_pos, wp.quat_identity()),
             child_xform=wp.transform_identity(),
-            custom_attributes={"vbd:joint_is_hard": 0},
         )
 
         # Revolute joint: plug -> latch (hinge along -X axis)
@@ -309,7 +308,6 @@ class Example:
             limit_upper=LATCH_LIMIT_UPPER,
             limit_kd=LATCH_LIMIT_KD,
             collision_filter_parent=True,
-            custom_attributes={"vbd:joint_is_hard": 0},
         )
 
         builder.add_articulation([d6_joint, rev_joint])

--- a/newton/examples/vbd/example_vbd_rigid_rigid_contact.py
+++ b/newton/examples/vbd/example_vbd_rigid_rigid_contact.py
@@ -86,8 +86,8 @@ def build_model(builder, params, seed=42):
 
     # Floor
     builder.add_shape_box(
-        -1,
-        wp.transform(wp.vec3(0.0, 0.0, elev - t / 2), wp.quat_identity()),
+        body=-1,
+        xform=wp.transform(wp.vec3(0.0, 0.0, elev - t / 2), wp.quat_identity()),
         hx=hx + t,
         hy=hy + t,
         hz=t / 2,
@@ -95,8 +95,8 @@ def build_model(builder, params, seed=42):
     )
     # Front wall (-Y)
     builder.add_shape_box(
-        -1,
-        wp.transform(wp.vec3(0.0, -(hy + t / 2), elev + hz / 2), wp.quat_identity()),
+        body=-1,
+        xform=wp.transform(wp.vec3(0.0, -(hy + t / 2), elev + hz / 2), wp.quat_identity()),
         hx=hx + t,
         hy=t / 2,
         hz=hz / 2,
@@ -104,8 +104,8 @@ def build_model(builder, params, seed=42):
     )
     # Back wall (+Y)
     builder.add_shape_box(
-        -1,
-        wp.transform(wp.vec3(0.0, hy + t / 2, elev + hz / 2), wp.quat_identity()),
+        body=-1,
+        xform=wp.transform(wp.vec3(0.0, hy + t / 2, elev + hz / 2), wp.quat_identity()),
         hx=hx + t,
         hy=t / 2,
         hz=hz / 2,
@@ -113,8 +113,8 @@ def build_model(builder, params, seed=42):
     )
     # Left wall (-X)
     builder.add_shape_box(
-        -1,
-        wp.transform(wp.vec3(-(hx + t / 2), 0.0, elev + hz / 2), wp.quat_identity()),
+        body=-1,
+        xform=wp.transform(wp.vec3(-(hx + t / 2), 0.0, elev + hz / 2), wp.quat_identity()),
         hx=t / 2,
         hy=hy,
         hz=hz / 2,
@@ -122,8 +122,8 @@ def build_model(builder, params, seed=42):
     )
     # Right wall (+X)
     builder.add_shape_box(
-        -1,
-        wp.transform(wp.vec3(hx + t / 2, 0.0, elev + hz / 2), wp.quat_identity()),
+        body=-1,
+        xform=wp.transform(wp.vec3(hx + t / 2, 0.0, elev + hz / 2), wp.quat_identity()),
         hx=t / 2,
         hy=hy,
         hz=hz / 2,
@@ -207,6 +207,7 @@ def setup_sim(builder, params):
 
 class Example:
     def __init__(self, viewer, args):
+        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.params = PARAMS
         self.sim_time = 0.0

--- a/newton/examples/vbd/example_vbd_soft_rigid_contact.py
+++ b/newton/examples/vbd/example_vbd_soft_rigid_contact.py
@@ -302,6 +302,7 @@ def setup_sim(builder, info, params):
 
 class Example:
     def __init__(self, viewer, args):
+        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.params = PARAMS
         self.sim_time = 0.0

--- a/newton/examples/vbd/example_vbd_soft_rigid_mix_contact.py
+++ b/newton/examples/vbd/example_vbd_soft_rigid_mix_contact.py
@@ -333,6 +333,7 @@ def setup_sim(builder, info, params):
 
 class Example:
     def __init__(self, viewer, args):
+        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.params = PARAMS
         self.sim_time = 0.0

--- a/newton/tests/test_example_runner.py
+++ b/newton/tests/test_example_runner.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import newton.examples
+
+
+class _RecordingViewer:
+    """Stub viewer recording observable calls, used by the lifecycle tests."""
+
+    def __init__(self):
+        self.calls = []
+
+    def show_loading_splash(self, text=None):
+        self.calls.append(("show_loading_splash", text))
+
+    def hide_loading_splash(self):
+        self.calls.append(("hide_loading_splash",))
+
+    def begin_frame(self, t):
+        self.calls.append(("begin_frame", t))
+
+    def end_frame(self):
+        self.calls.append(("end_frame",))
+
+    def is_running(self):
+        return False
+
+    def is_paused(self):
+        return False
+
+    def close(self):
+        self.calls.append(("close",))
+
+
+class TestExampleRunnerLifecycle(unittest.TestCase):
+    """Test example initialization and execution lifecycle behavior."""
+
+    def _args(self, **overrides):
+        defaults = {
+            "viewer": "gl",
+            "headless": False,
+            "paused": False,
+            "device": None,
+            "quiet": True,
+            "warp_config": [],
+            "benchmark": False,
+            "realtime": False,
+            "output_path": None,
+            "num_frames": 1,
+            "rerun_address": None,
+            "test": False,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _run_init(self, args):
+        stub = _RecordingViewer()
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = args
+        with (
+            mock.patch("newton.viewer.ViewerGL", return_value=stub),
+            mock.patch("newton.examples._apply_warp_config"),
+        ):
+            newton.examples.init(parser=parser)
+        return stub
+
+    def test_init_shows_splash_for_visible_gl(self):
+        """Verify initialization shows the loading splash for a visible GL viewer."""
+        viewer = self._run_init(self._args())
+        self.assertIn(("show_loading_splash", "Loading..."), viewer.calls)
+
+    def test_init_skips_splash_for_headless(self):
+        """Verify initialization skips the loading splash for a headless viewer."""
+        viewer = self._run_init(self._args(headless=True))
+        self.assertNotIn(("show_loading_splash", "Loading..."), viewer.calls)
+
+    def test_run_hides_splash(self):
+        """Verify the runner hides the loading splash before execution."""
+        viewer = _RecordingViewer()
+        example = SimpleNamespace(
+            viewer=viewer,
+            step=lambda: None,
+            render=lambda: None,
+        )
+        args = SimpleNamespace(test=False)
+        newton.examples.run(example, args)
+        self.assertIn(("hide_loading_splash",), viewer.calls)
+
+    def test_run_requires_test_final_in_test_mode(self):
+        """Ensure per-step checks cannot replace the required completion check."""
+        viewer = _RecordingViewer()
+        example = SimpleNamespace(
+            viewer=viewer,
+            step=lambda: None,
+            render=lambda: None,
+            test_post_step=lambda: None,
+        )
+        args = SimpleNamespace(test=True)
+
+        with self.assertRaisesRegex(NotImplementedError, "test_final"):
+            newton.examples.run(example, args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import warp as wp
 
+import newton.examples
 import newton.tests.unittest_utils
 from newton.tests.unittest_utils import (
     USD_AVAILABLE,
@@ -101,6 +102,14 @@ _EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_NEWTON_ASSET_DOWNLOAD_OUTPUT_RE, "stdout"),
 ]
 _OutputRegexSpec = str | tuple[str, str]
+_AUTO_DISCOVERED_ALLOW_DEPRECATION_WARNINGS = {
+    "basic.example_basic_heightfield",
+    "contacts.example_contacts_rj45_plug",
+    "vbd.example_vbd_rigid_rigid_contact",
+    "vbd.example_vbd_soft_rigid_contact",
+    "vbd.example_vbd_soft_rigid_mix_contact",
+}
+_registered_examples: set[str] = set()
 
 
 def _build_command_line_options(test_options: dict[str, Any]) -> list:
@@ -150,6 +159,8 @@ def add_example_test(
     _examples_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "examples")
     if not os.path.exists(os.path.join(_examples_dir, f"{name.replace('.', '/')}.py")):
         raise ValueError(f"Example {name} does not exist")
+
+    _registered_examples.add(name)
 
     if test_options is None:
         test_options = {}
@@ -1319,6 +1330,25 @@ add_example_test(
     test_options={"num-frames": 120},
     use_viewer=True,
 )
+
+
+class TestAutoDiscoveredExamples(unittest.TestCase):
+    pass
+
+
+for example_module in newton.examples.get_examples().values():
+    example_name = example_module.removeprefix("newton.examples.")
+    if example_name not in _registered_examples:
+        add_example_test(
+            TestAutoDiscoveredExamples,
+            name=example_name,
+            devices=cuda_test_devices,
+            # Keep newly covered examples in CI while their existing deprecations are migrated.
+            test_options={"allow_deprecation_warnings": True}
+            if example_name in _AUTO_DISCOVERED_ALLOW_DEPRECATION_WARNINGS
+            else None,
+            use_viewer=True,
+        )
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -102,13 +102,6 @@ _EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_NEWTON_ASSET_DOWNLOAD_OUTPUT_RE, "stdout"),
 ]
 _OutputRegexSpec = str | tuple[str, str]
-_AUTO_DISCOVERED_ALLOW_DEPRECATION_WARNINGS = {
-    "basic.example_basic_heightfield",
-    "contacts.example_contacts_rj45_plug",
-    "vbd.example_vbd_rigid_rigid_contact",
-    "vbd.example_vbd_soft_rigid_contact",
-    "vbd.example_vbd_soft_rigid_mix_contact",
-}
 _registered_examples: set[str] = set()
 
 
@@ -1343,10 +1336,6 @@ for example_module in newton.examples.get_examples().values():
             TestAutoDiscoveredExamples,
             name=example_name,
             devices=cuda_test_devices,
-            # Keep newly covered examples in CI while their existing deprecations are migrated.
-            test_options={"allow_deprecation_warnings": True}
-            if example_name in _AUTO_DISCOVERED_ALLOW_DEPRECATION_WARNINGS
-            else None,
             use_viewer=True,
         )
 

--- a/newton/tests/test_viewer_loading_splash.py
+++ b/newton/tests/test_viewer_loading_splash.py
@@ -3,9 +3,7 @@
 
 import unittest
 from types import SimpleNamespace
-from unittest import mock
 
-import newton.examples
 from newton._src.viewer.viewer_gl import ViewerGL
 
 
@@ -29,12 +27,14 @@ class TestViewerGLLoadingSplashState(unittest.TestCase):
         return viewer
 
     def test_show_sets_active_and_text(self):
+        """Verify showing the splash records its active state and text."""
         viewer = self._make_viewer()
         viewer.show_loading_splash("Loading...")
         self.assertTrue(viewer.gui._loading_splash_active)
         self.assertEqual(viewer.gui._loading_splash_text, "Loading...")
 
     def test_hide_clears_state(self):
+        """Verify hiding the splash clears its active state and text."""
         viewer = self._make_viewer()
         viewer.show_loading_splash("Loading...")
         viewer.hide_loading_splash()
@@ -42,91 +42,12 @@ class TestViewerGLLoadingSplashState(unittest.TestCase):
         self.assertIsNone(viewer.gui._loading_splash_text)
 
     def test_headless_no_gui_is_noop(self):
+        """Verify splash operations are no-ops when no GUI exists."""
         viewer = ViewerGL.__new__(ViewerGL)
         viewer.gui = None
         # Must not raise even though there is no GUI to drive.
         viewer.show_loading_splash("Loading...")
         viewer.hide_loading_splash()
-
-
-class _RecordingViewer:
-    """Stub viewer recording observable calls, used by the lifecycle tests."""
-
-    def __init__(self):
-        self.calls = []
-
-    def show_loading_splash(self, text=None):
-        self.calls.append(("show_loading_splash", text))
-
-    def hide_loading_splash(self):
-        self.calls.append(("hide_loading_splash",))
-
-    def begin_frame(self, t):
-        self.calls.append(("begin_frame", t))
-
-    def end_frame(self):
-        self.calls.append(("end_frame",))
-
-    def is_running(self):
-        return False
-
-    def is_paused(self):
-        return False
-
-    def close(self):
-        self.calls.append(("close",))
-
-
-class TestLoadingSplashLifecycle(unittest.TestCase):
-    """``init()`` shows the splash for visible GL viewers; ``run()`` hides it."""
-
-    def _args(self, **overrides):
-        defaults = {
-            "viewer": "gl",
-            "headless": False,
-            "paused": False,
-            "device": None,
-            "quiet": True,
-            "warp_config": [],
-            "benchmark": False,
-            "realtime": False,
-            "output_path": None,
-            "num_frames": 1,
-            "rerun_address": None,
-            "test": False,
-        }
-        defaults.update(overrides)
-        return SimpleNamespace(**defaults)
-
-    def _run_init(self, args):
-        stub = _RecordingViewer()
-        parser = mock.MagicMock()
-        parser.parse_args.return_value = args
-        with (
-            mock.patch("newton.viewer.ViewerGL", return_value=stub),
-            mock.patch("newton.examples._apply_warp_config"),
-        ):
-            newton.examples.init(parser=parser)
-        return stub
-
-    def test_init_shows_splash_for_visible_gl(self):
-        viewer = self._run_init(self._args())
-        self.assertIn(("show_loading_splash", "Loading..."), viewer.calls)
-
-    def test_init_skips_splash_for_headless(self):
-        viewer = self._run_init(self._args(headless=True))
-        self.assertNotIn(("show_loading_splash", "Loading..."), viewer.calls)
-
-    def test_run_hides_splash(self):
-        viewer = _RecordingViewer()
-        example = SimpleNamespace(
-            viewer=viewer,
-            step=lambda: None,
-            render=lambda: None,
-        )
-        args = SimpleNamespace(test=False)
-        newton.examples.run(example, args)
-        self.assertIn(("hide_loading_splash",), viewer.calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Follow-up to #3989. This PR must merge after #3989.

Migrate the five newly auto-discovered examples away from deprecated APIs and
remove their temporary strict-warning allowances. The examples now opt into
coordinate-layout joint targets where needed, the rigid-rigid VBD example uses
keyword arguments for `add_shape_box()`, and the RJ45 example no longer authors
the deprecated `vbd:joint_is_hard` attribute, which has no solver-mode effect
under its existing compliant ALM configuration.

This restores strict deprecation-warning enforcement for every auto-discovered
example.

GitHub's native stacked pull requests require all branches to live in the same
repository. Because #3989 is a cross-fork PR, this dependent PR temporarily
targets `main` and includes the parent changes in its comparison. The follow-up
change itself is commit `a64ae9aa`. After #3989 merges, this branch will be
rebased onto the updated `main` before this PR is marked ready.

## Checklist

- [x] New or existing tests cover these changes
- [x] No documentation update is required for this API-use migration
- [x] This maintenance-only change does not require a changelog fragment

## Test plan

```text
python -W error::DeprecationWarning -m newton.examples <each-offender> \
  --device cuda:0 --test --quiet --viewer null
# All five examples passed individually.

uv run --extra dev -m newton.tests -k TestAutoDiscoveredExamples \
  --strict-warnings --no-cache-clear
# 15 passed in 186.444s

uvx --python 3.12 pre-commit run -a
# passed
```

Before the migration, each of the five example commands failed with a
`DeprecationWarning` treated as an error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Example test mode now consistently requires a `test_final()` validation step.
  * Automatically discovered examples receive baseline CUDA test coverage.
  * Several examples now support coordinate-layout targets and updated contact configurations.

* **Bug Fixes**
  * Improved loading-screen behavior during example initialization and execution.
  * Added clearer validation when an example lacks the required final test.

* **Tests**
  * Expanded coverage for example lifecycle behavior, automatic discovery, and viewer loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->