### PR TITLE
[asv] NotifyDRLegs: bump benchmark version to "2" (sampling change in #3859)

### DIFF
--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -157,6 +157,7 @@ class KpiDRLegs(_KpiBenchmark):
 class NotifyDRLegs:
     """Benchmark Kamino model notifications for 2048 DR Legs worlds."""
 
+    version = "2"  # sampling/methodology changed in #3859 -> new ASV series
     number = 1
     repeat = 5
     rounds = 1


### PR DESCRIPTION
Adds an explicit `version = "2"` to `NotifyDRLegs` so ASV splits the series at the #3859 sampling change. ASV's per-benchmark version hashes only benchmark/setup source, never timing attrs, so #3859 (`number` 10→1) continued the old series and the ~2–7x step read as an in-series regression.

Fixes #3992. Cause: #3859; #3780 is exonerated (A/B: the step follows the sampling config, not the Warp version) — no action needed there.

Not retroactive: old rows keep the old hash; the new series starts at the bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Started a new benchmark series for the NotifyDRLegs simulation to reflect updated sampling and methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->