### PR TITLE
Limit usd-exchange below version 3

### DIFF
--- a/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
+++ b/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
@@ -1,0 +1,1 @@
+Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ importers = [
 
     # USD core libraries
     "usd-core>=25.5,<26.5 ; platform_machine != 'aarch64' and python_version < '3.14'",
-    "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
+    "usd-exchange>=2.2.0,<3 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
     "newton-usd-schemas>=0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3974,7 +3974,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'torch-cu13'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "newton", extra = "torch-cu13" } },
     { name = "trimesh", marker = "extra == 'importers'", specifier = ">=4.6.8" },
     { name = "usd-core", marker = "python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5,<26.5" },
-    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
+    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0,<3" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
     { name = "warp-lang", specifier = ">=1.16.0", index = "https://pypi.nvidia.com/" },


### PR DESCRIPTION
## Description

Keep Newton’s aarch64 importer extra on `usd-exchange` 2.x.

This avoids an unreviewed major-version upgrade while preserving the existing 2.2.0 minimum.

The lock file contains the same constraint and still selects `usd-exchange` 2.3.0.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- `uv lock --check`
- `git diff --check`
- Confirmed that both TOML files contain the `<3` bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for aarch64 systems running Python versions below 3.13 by constraining the USD exchange importer to supported releases.
* **Documentation**
  * Added a changelog entry describing the compatibility update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->