### PR TITLE
Heightfield prism refinement

### DIFF
--- a/changelog/+heightfield-deep-contacts-6d2f8a41.fixed.md
+++ b/changelog/+heightfield-deep-contacts-6d2f8a41.fixed.md
@@ -1,1 +1,1 @@
-Keep deeply penetrating heightfield contacts on the physical surface instead of the internal triangle-prism skirt.
+Keep deeply penetrating heightfield contact normals and depths on the physical surface instead of the internal triangle-prism skirt.

--- a/newton/_src/geometry/collision_convex.py
+++ b/newton/_src/geometry/collision_convex.py
@@ -109,6 +109,7 @@ def create_solve_convex_multi_contact(
     writer_func: Any,
     post_process_contact: Any,
     use_precomputed_center: bool = False,
+    penetration_refiner: Any = None,
 ):
     """Create a fused MPR/GJK multi-contact solver.
 
@@ -117,6 +118,7 @@ def create_solve_convex_multi_contact(
         writer_func: Function that writes generated contacts.
         post_process_contact: Function that post-processes generated contacts.
         use_precomputed_center: Whether the geometry data supplies a cached center.
+        penetration_refiner: Optional physical-proxy result refinement function.
 
     Returns:
         The specialized contact solver.
@@ -126,6 +128,7 @@ def create_solve_convex_multi_contact(
     support_funcs = create_support_map_function(support_func, use_precomputed_center)
     solve_mpr = create_solve_mpr(support_func, _support_funcs=support_funcs)
     solve_gjk = create_solve_closest_distance(support_func, _support_funcs=support_funcs)
+    has_penetration_refiner = penetration_refiner is not None
 
     @wp.func
     def solve_convex_multi_contact(
@@ -172,6 +175,19 @@ def create_solve_convex_multi_contact(
         )
 
         if collision:
+            if wp.static(has_penetration_refiner):
+                point_a, point_b, normal, penetration = penetration_refiner(
+                    geom_a,
+                    geom_b,
+                    relative_orientation_b,
+                    relative_position_b,
+                    enlarge,
+                    data_provider,
+                    point_a,
+                    point_b,
+                    normal,
+                    penetration,
+                )
             signed_distance = -penetration + enlarge
             # Undo the inflate on the witness points so downstream consumers
             # (manifold builder, contact writer) see true-surface positions.
@@ -236,6 +252,7 @@ def create_solve_convex_single_contact(
     writer_func: Any,
     post_process_contact: Any,
     use_precomputed_center: bool = False,
+    penetration_refiner: Any = None,
 ):
     """Create a fused MPR/GJK single-contact solver.
 
@@ -244,6 +261,7 @@ def create_solve_convex_single_contact(
         writer_func: Function that writes generated contacts.
         post_process_contact: Function that post-processes generated contacts.
         use_precomputed_center: Whether the geometry data supplies a cached center.
+        penetration_refiner: Optional physical-proxy result refinement function.
 
     Returns:
         The specialized contact solver.
@@ -253,6 +271,7 @@ def create_solve_convex_single_contact(
     support_funcs = create_support_map_function(support_func, use_precomputed_center)
     solve_mpr = create_solve_mpr(support_func, _support_funcs=support_funcs)
     solve_gjk = create_solve_closest_distance(support_func, _support_funcs=support_funcs)
+    has_penetration_refiner = penetration_refiner is not None
 
     @wp.func
     def solve_convex_single_contact(
@@ -293,6 +312,19 @@ def create_solve_convex_single_contact(
         )
 
         if collision:
+            if wp.static(has_penetration_refiner):
+                point_a, point_b, normal, penetration = penetration_refiner(
+                    geom_a,
+                    geom_b,
+                    relative_orientation_b,
+                    relative_position_b,
+                    enlarge,
+                    data_provider,
+                    point_a,
+                    point_b,
+                    normal,
+                    penetration,
+                )
             signed_distance = -penetration + enlarge
             half_enlarge = enlarge * 0.5
             point_a = point_a - normal * half_enlarge

--- a/newton/_src/geometry/collision_core.py
+++ b/newton/_src/geometry/collision_core.py
@@ -327,6 +327,7 @@ def create_compute_gjk_mpr_contacts(
     post_process_contact: Any = post_process_axial_on_discrete_contact,
     support_func: Any = None,
     use_precomputed_center: bool = False,
+    penetration_refiner: Any = None,
 ):
     """
     Factory function to create a compute_gjk_mpr_contacts function with a specific writer function.
@@ -336,6 +337,7 @@ def create_compute_gjk_mpr_contacts(
         post_process_contact: Function to post-process contact data
         support_func: Support mapping function (defaults to support_map)
         use_precomputed_center: Whether the geometry data supplies a cached center.
+        penetration_refiner: Optional physical-proxy result refinement function.
 
     Returns:
         A compute_gjk_mpr_contacts function with the writer function baked in
@@ -411,7 +413,11 @@ def create_compute_gjk_mpr_contacts(
         if wp.static(ENABLE_MULTI_CONTACT):
             wp.static(
                 create_solve_convex_multi_contact(
-                    support_func, writer_func, post_process_contact, use_precomputed_center
+                    support_func,
+                    writer_func,
+                    post_process_contact,
+                    use_precomputed_center,
+                    penetration_refiner,
                 )
             )(
                 shape_a_data,
@@ -432,7 +438,11 @@ def create_compute_gjk_mpr_contacts(
         else:
             wp.static(
                 create_solve_convex_single_contact(
-                    support_func, writer_func, post_process_contact, use_precomputed_center
+                    support_func,
+                    writer_func,
+                    post_process_contact,
+                    use_precomputed_center,
+                    penetration_refiner,
                 )
             )(
                 shape_a_data,

--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -36,7 +36,6 @@ from typing import Any
 import warp as wp
 
 from .support_function import (
-    create_penetration_refinement_function,
     create_shape_center_function,
     create_shape_support_function,
 )
@@ -184,7 +183,6 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
     shape_support = create_shape_support_function(support_func, center_ties=True)
     _, mpr_support, _ = create_support_map_function(shape_support)
-    refine_penetration = create_penetration_refinement_function(mpr_support)
 
     @wp.func
     def solve_mpr_core(
@@ -270,19 +268,6 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
             temp1 = v1.BtoA
             penetration = wp.dot(temp1, normal)
-
-            point_a, point_b, normal, penetration = refine_penetration(
-                geom_a,
-                geom_b,
-                orientation_b,
-                position_b,
-                extend,
-                data_provider,
-                point_a,
-                point_b,
-                normal,
-                penetration,
-            )
 
             return True, point_a, point_b, normal, penetration
 
@@ -395,19 +380,6 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
                     point_a = alpha * vert_a(v1) + beta * vert_a(v2) + gamma * vert_a(v3)
                     point_b = alpha * v1.B + beta * v2.B + gamma * v3.B
-
-                    point_a, point_b, normal, penetration = refine_penetration(
-                        geom_a,
-                        geom_b,
-                        orientation_b,
-                        position_b,
-                        extend,
-                        data_provider,
-                        point_a,
-                        point_b,
-                        normal,
-                        penetration,
-                    )
 
                 return hit, point_a, point_b, normal, penetration
 

--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -36,6 +36,7 @@ from typing import Any
 import warp as wp
 
 from .support_function import (
+    create_penetration_refinement_function,
     create_shape_center_function,
     create_shape_support_function,
 )
@@ -183,6 +184,7 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
     shape_support = create_shape_support_function(support_func, center_ties=True)
     _, mpr_support, _ = create_support_map_function(shape_support)
+    refine_penetration = create_penetration_refinement_function(mpr_support)
 
     @wp.func
     def solve_mpr_core(
@@ -268,6 +270,19 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
             temp1 = v1.BtoA
             penetration = wp.dot(temp1, normal)
+
+            point_a, point_b, normal, penetration = refine_penetration(
+                geom_a,
+                geom_b,
+                orientation_b,
+                position_b,
+                extend,
+                data_provider,
+                point_a,
+                point_b,
+                normal,
+                penetration,
+            )
 
             return True, point_a, point_b, normal, penetration
 
@@ -380,6 +395,19 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
                     point_a = alpha * vert_a(v1) + beta * vert_a(v2) + gamma * vert_a(v3)
                     point_b = alpha * v1.B + beta * v2.B + gamma * v3.B
+
+                    point_a, point_b, normal, penetration = refine_penetration(
+                        geom_a,
+                        geom_b,
+                        orientation_b,
+                        position_b,
+                        extend,
+                        data_provider,
+                        point_a,
+                        point_b,
+                        normal,
+                        penetration,
+                    )
 
                 return hit, point_a, point_b, normal, penetration
 

--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -70,6 +70,7 @@ from ..geometry.simplex_solver import create_solve_closest_distance
 from ..geometry.support_function import (
     GenericShapeData,
     SupportMapDataProvider,
+    create_triangle_prism_penetration_refiner,
     extract_shape_data,
     support_map,
     support_map_lean,
@@ -1646,7 +1647,13 @@ def create_narrow_phase_process_mesh_triangle_contacts_kernel(writer_func: Any):
             gap_b = shape_gap[shape_b]
             gap_sum = gap_a + gap_b
 
-            wp.static(create_compute_gjk_mpr_contacts(writer_func, post_process_contact=post_process_triangle_contact))(
+            wp.static(
+                create_compute_gjk_mpr_contacts(
+                    writer_func,
+                    post_process_contact=post_process_triangle_contact,
+                    penetration_refiner=create_triangle_prism_penetration_refiner(support_map),
+                )
+            )(
                 shape_data_a,
                 shape_data_b,
                 quat_a,

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -447,20 +447,21 @@ def create_shape_support_function(support_func: Any, center_ties: bool = False):
     return shape_support
 
 
-def create_penetration_refinement_function(minkowski_support: Any):
-    """Create the shape-policy hook applied to penetrating support-map results.
+def create_triangle_prism_penetration_refiner(support_func: Any):
+    """Create physical-surface refinement for triangle-prism collision proxies.
 
     MPR operates on closed convex proxies, but a proxy may contain artificial
     faces that are needed only to give it volume. The returned function maps a
-    proxy result back to its physical collision surface without coupling the
-    generic solver to any shape types.
+    triangle-prism result back to its physical face.
 
     Args:
-        minkowski_support: Support function for the Minkowski difference.
+        support_func: Support function for individual shapes.
 
     Returns:
         A function that refines MPR witness points, normal, and penetration.
     """
+
+    shape_support = create_shape_support_function(support_func, center_ties=True)
 
     @wp.func
     def refine_penetration(
@@ -483,21 +484,20 @@ def create_penetration_refinement_function(minkowski_support: Any):
                 if surface_normal[2] < 0.0:
                     surface_normal = -surface_normal
 
-                surface_support = minkowski_support(
-                    geom_a,
-                    geom_b,
-                    surface_normal,
-                    orientation_b,
-                    position_b,
-                    extend,
-                    data_provider,
-                )
-                surface_penetration = wp.dot(surface_support.BtoA, surface_normal)
+                surface_point_a = shape_support(geom_a, surface_normal, data_provider)
+                direction_b = wp.quat_rotate_inv(orientation_b, -surface_normal)
+                surface_point_b = shape_support(geom_b, direction_b, data_provider)
+                surface_point_b = wp.quat_rotate(orientation_b, surface_point_b) + position_b
+                if extend != 0.0:
+                    offset = surface_normal * extend * 0.5
+                    surface_point_a += offset
+                    surface_point_b -= offset
+                surface_penetration = wp.dot(surface_point_a - surface_point_b, surface_normal)
 
                 # A finite triangle must not use a support point beyond its
                 # footprint. A neighboring heightfield triangle may own that
                 # point, while at the outer boundary there may be no surface.
-                projected_b = surface_support.B - wp.dot(surface_support.B, surface_normal) * surface_normal
+                projected_b = surface_point_b - wp.dot(surface_point_b, surface_normal) * surface_normal
                 closest_b = closest_point_on_triangle(
                     projected_b,
                     wp.vec3(0.0),
@@ -509,7 +509,7 @@ def create_penetration_refinement_function(minkowski_support: Any):
                 if support_on_face and surface_penetration < penetration:
                     normal = surface_normal
                     penetration = surface_penetration
-                    point_b = surface_support.B
+                    point_b = surface_point_b
                     point_a = point_b + penetration * normal
 
         return point_a, point_b, normal, penetration

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -447,6 +447,76 @@ def create_shape_support_function(support_func: Any, center_ties: bool = False):
     return shape_support
 
 
+def create_penetration_refinement_function(minkowski_support: Any):
+    """Create the shape-policy hook applied to penetrating support-map results.
+
+    MPR operates on closed convex proxies, but a proxy may contain artificial
+    faces that are needed only to give it volume. The returned function maps a
+    proxy result back to its physical collision surface without coupling the
+    generic solver to any shape types.
+
+    Args:
+        minkowski_support: Support function for the Minkowski difference.
+
+    Returns:
+        A function that refines MPR witness points, normal, and penetration.
+    """
+
+    @wp.func
+    def refine_penetration(
+        geom_a: Any,
+        geom_b: Any,
+        orientation_b: wp.quat,
+        position_b: wp.vec3,
+        extend: float,
+        data_provider: Any,
+        point_a: wp.vec3,
+        point_b: wp.vec3,
+        normal: wp.vec3,
+        penetration: float,
+    ) -> tuple[wp.vec3, wp.vec3, wp.vec3, float]:
+        if geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
+            surface_normal = wp.cross(geom_a.scale, geom_a.auxiliary)
+            normal_length_sq = wp.length_sq(surface_normal)
+            if normal_length_sq >= 1.0e-24:
+                surface_normal /= wp.sqrt(normal_length_sq)
+                if surface_normal[2] < 0.0:
+                    surface_normal = -surface_normal
+
+                surface_support = minkowski_support(
+                    geom_a,
+                    geom_b,
+                    surface_normal,
+                    orientation_b,
+                    position_b,
+                    extend,
+                    data_provider,
+                )
+                surface_penetration = wp.dot(surface_support.BtoA, surface_normal)
+
+                # A finite triangle must not use a support point beyond its
+                # footprint. A neighboring heightfield triangle may own that
+                # point, while at the outer boundary there may be no surface.
+                projected_b = surface_support.B - wp.dot(surface_support.B, surface_normal) * surface_normal
+                closest_b = closest_point_on_triangle(
+                    projected_b,
+                    wp.vec3(0.0),
+                    geom_a.scale,
+                    geom_a.auxiliary,
+                )
+                support_on_face = wp.length_sq(projected_b - closest_b) < 1.0e-10
+
+                if support_on_face and surface_penetration < penetration:
+                    normal = surface_normal
+                    penetration = surface_penetration
+                    point_b = surface_support.B
+                    point_a = point_b + penetration * normal
+
+        return point_a, point_b, normal, penetration
+
+    return refine_penetration
+
+
 @wp.func
 def _shape_center(geom: Any) -> wp.vec3:
     """Return a local interior-point approximation for a supported shape."""

--- a/newton/tests/test_heightfield.py
+++ b/newton/tests/test_heightfield.py
@@ -356,9 +356,13 @@ class TestHeightfield(unittest.TestCase):
         contact_count = int(contacts.rigid_contact_count.numpy()[0])
         self.assertGreater(contact_count, 0, "No contacts detected between sphere and heightfield")
 
-    def _get_contact_kinematics(self, model, state, *, reduce_contacts=True):
+    def _get_contact_kinematics(self, model, state, *, reduce_contacts=True, requires_grad=False):
         """Return contact distances, normals, and heightfield points for a model state."""
-        pipeline = newton.CollisionPipeline(model, reduce_contacts=reduce_contacts)
+        pipeline = newton.CollisionPipeline(
+            model,
+            reduce_contacts=reduce_contacts,
+            requires_grad=requires_grad,
+        )
         contacts = pipeline.contacts()
         distance = wp.empty(contacts.rigid_contact_max, dtype=float, device=model.device)
         point0 = wp.empty(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
@@ -399,7 +403,11 @@ class TestHeightfield(unittest.TestCase):
                 builder.add_shape_box(body=body, hx=0.2, hy=0.065, hz=half_z)
 
                 model = builder.finalize()
-                distance, normal, point0 = self._get_contact_kinematics(model, model.state())
+                distance, normal, point0 = self._get_contact_kinematics(
+                    model,
+                    model.state(),
+                    requires_grad=True,
+                )
 
                 self.assertGreater(len(distance), 0, "no contacts between box and heightfield")
                 deepest = int(np.argmin(distance))

--- a/newton/tests/test_mpr.py
+++ b/newton/tests/test_mpr.py
@@ -23,6 +23,7 @@ from newton._src.geometry.support_function import (
 def _triangle_mpr_kernel(
     triangle_b: wp.array[wp.vec3],
     triangle_c: wp.array[wp.vec3],
+    triangle_type: int,
     shape_b_type: int,
     shape_b_scale: wp.vec3,
     shape_b_position: wp.array[wp.vec3],
@@ -37,7 +38,7 @@ def _triangle_mpr_kernel(
     i = wp.tid()
 
     shape_a = GenericShapeData()
-    shape_a.shape_type = int(GeoTypeEx.TRIANGLE)
+    shape_a.shape_type = triangle_type
     shape_a.scale = triangle_b[i]
     shape_a.auxiliary = triangle_c[i]
 
@@ -103,7 +104,15 @@ def _box_mpr_kernel(
     penetration_out[i] = penetration
 
 
-def _run_triangle_mpr(triangle_b, triangle_c, shape_type, shape_scale, shape_positions, shape_orientations):
+def _run_triangle_mpr(
+    triangle_b,
+    triangle_c,
+    shape_type,
+    shape_scale,
+    shape_positions,
+    shape_orientations,
+    triangle_type=GeoTypeEx.TRIANGLE,
+):
     """Run direct triangle-vs-convex MPR cases on CPU and return NumPy outputs."""
     device = "cpu"
     count = len(triangle_b)
@@ -125,6 +134,7 @@ def _run_triangle_mpr(triangle_b, triangle_c, shape_type, shape_scale, shape_pos
         inputs=[
             triangle_b_wp,
             triangle_c_wp,
+            int(triangle_type),
             int(shape_type),
             wp.vec3(*shape_scale),
             shape_positions_wp,
@@ -298,6 +308,30 @@ class TestMPRTriangleInitialization(unittest.TestCase):
         self.assertGreater(float(points_a[1, 1] - points_a[1, 0]), 1.0e-4)
         np.testing.assert_allclose(normals, [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], atol=1.0e-5)
         np.testing.assert_allclose(penetrations, [0.1, 0.1], atol=1.0e-5)
+
+
+class TestMPRTrianglePrismSurface(unittest.TestCase):
+    """Cover physical-surface refinement for volumetric triangle proxies."""
+
+    def test_deep_box_penetration_uses_top_face(self):
+        """Resolve a deeply embedded box through the prism's physical face."""
+        depth = 0.05
+        half_height = 0.02
+        collision, points_a, points_b, normals, penetrations = _run_triangle_mpr(
+            triangle_b=[[1.0, 0.0, 0.0]],
+            triangle_c=[[0.0, 1.0, 0.0]],
+            triangle_type=GeoTypeEx.TRIANGLE_PRISM,
+            shape_type=GeoType.BOX,
+            shape_scale=(0.1, 0.1, half_height),
+            shape_positions=[[0.25, 0.25, half_height - depth]],
+            shape_orientations=[[0.0, 0.0, 0.0, 1.0]],
+        )
+
+        np.testing.assert_array_equal(collision, [1])
+        np.testing.assert_allclose(normals, [[0.0, 0.0, 1.0]], atol=1.0e-6)
+        np.testing.assert_allclose(penetrations, [depth], atol=1.0e-6)
+        np.testing.assert_allclose(points_a[:, 2], [0.0], atol=1.0e-6)
+        np.testing.assert_allclose(points_b[:, 2], [-depth], atol=1.0e-6)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_mpr.py
+++ b/newton/tests/test_mpr.py
@@ -15,6 +15,7 @@ from newton._src.geometry.support_function import (
     GenericShapeData,
     GeoTypeEx,
     SupportMapDataProvider,
+    create_triangle_prism_penetration_refiner,
     support_map,
 )
 
@@ -24,6 +25,7 @@ def _triangle_mpr_kernel(
     triangle_b: wp.array[wp.vec3],
     triangle_c: wp.array[wp.vec3],
     triangle_type: int,
+    refine_proxy: bool,
     shape_b_type: int,
     shape_b_scale: wp.vec3,
     shape_b_position: wp.array[wp.vec3],
@@ -56,6 +58,19 @@ def _triangle_mpr_kernel(
         0.0,
         data_provider,
     )
+    if collision and refine_proxy:
+        point_a, point_b, normal, penetration = wp.static(create_triangle_prism_penetration_refiner(support_map))(
+            shape_a,
+            shape_b,
+            shape_b_orientation[i],
+            shape_b_position[i],
+            0.0,
+            data_provider,
+            point_a,
+            point_b,
+            normal,
+            penetration,
+        )
 
     collision_out[i] = int(collision)
     point_a_out[i] = point_a
@@ -112,6 +127,7 @@ def _run_triangle_mpr(
     shape_positions,
     shape_orientations,
     triangle_type=GeoTypeEx.TRIANGLE,
+    refine_proxy=False,
 ):
     """Run direct triangle-vs-convex MPR cases on CPU and return NumPy outputs."""
     device = "cpu"
@@ -135,6 +151,7 @@ def _run_triangle_mpr(
             triangle_b_wp,
             triangle_c_wp,
             int(triangle_type),
+            refine_proxy,
             int(shape_type),
             wp.vec3(*shape_scale),
             shape_positions_wp,
@@ -310,7 +327,7 @@ class TestMPRTriangleInitialization(unittest.TestCase):
         np.testing.assert_allclose(penetrations, [0.1, 0.1], atol=1.0e-5)
 
 
-class TestMPRTrianglePrismSurface(unittest.TestCase):
+class TestTrianglePrismSurfacePolicy(unittest.TestCase):
     """Cover physical-surface refinement for volumetric triangle proxies."""
 
     def test_deep_box_penetration_uses_top_face(self):
@@ -321,6 +338,7 @@ class TestMPRTrianglePrismSurface(unittest.TestCase):
             triangle_b=[[1.0, 0.0, 0.0]],
             triangle_c=[[0.0, 1.0, 0.0]],
             triangle_type=GeoTypeEx.TRIANGLE_PRISM,
+            refine_proxy=True,
             shape_type=GeoType.BOX,
             shape_scale=(0.1, 0.1, half_height),
             shape_positions=[[0.25, 0.25, half_height - depth]],


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Heightfield prism refinement

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional penetration refinement for convex collision detection.
  - Improved mesh and heightfield triangle contacts by refining deep penetrations against the physical triangle surface.
  - Added support for refined contact normals, penetration depths, and witness points.

- **Bug Fixes**
  - Corrected deep box–triangle penetration results to report the appropriate top-face contact geometry.

- **Tests**
  - Added regression coverage for refined triangle-prism contacts and gradient-enabled heightfield contact kinematics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->