### PR TITLE
Backport usd-exchange version bound for 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Reset masked `ControllerNeuralLSTM` hidden and cell state without in-place writes. Network outputs are produced under `torch.inference_mode()`, so a partial reset previously raised `RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.` ([#3923](https://github.com/newton-physics/newton/issues/3923))
 - Index Torch neural controller targets with the supplied `target_pos_indices`. `ControllerNeuralMLP` and `ControllerNeuralLSTM` previously selected between position and sequential indices by Python object identity, which produced wrong position errors whenever the target and position layouts differ, such as DOF-layout targets on a floating-base robot. ([#3923](https://github.com/newton-physics/newton/issues/3923))
+- Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems. (#3996)
 
 ## [1.5.0] - 2026-08-11
 

--- a/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
+++ b/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
@@ -1,1 +1,0 @@
-Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems.

--- a/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
+++ b/changelog/+limit-usd-exchange-2c6f1b8a.fixed.md
@@ -1,0 +1,1 @@
+Limit the `usd-exchange` dependency to versions below 3 for aarch64 systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ importers = [
 
     # USD core libraries
     "usd-core>=25.5,<26.5 ; platform_machine != 'aarch64' and python_version < '3.14'",
-    "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
+    "usd-exchange>=2.2.0,<3 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
     "newton-usd-schemas>=0.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3974,7 +3974,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'torch-cu13'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "newton", extra = "torch-cu13" } },
     { name = "trimesh", marker = "extra == 'importers'", specifier = ">=4.6.8" },
     { name = "usd-core", marker = "python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5,<26.5" },
-    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
+    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0,<3" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
     { name = "warp-lang", specifier = ">=1.16.0" },


### PR DESCRIPTION
## Description

Backport #3996 from `main` to `release-1.5` for the Newton 1.5.1 patch release.

Keep Newton's aarch64 importer extra on `usd-exchange` 2.x. This preserves the existing 2.2.0 minimum while preventing an unreviewed major-version upgrade. The lock file carries the same `<3` constraint and continues to select `usd-exchange==2.3.0`.

The source fix was cherry-picked from `ed5ef383` with `-x` as `4da8bf09`. Separate follow-up commit `2dc13a29` folds the orphan Towncrier fragment into the rolling 1.5.1 changelog and deletes the consumed fragment. This PR intentionally does not include a version bump or other final-release mechanics.

## Checklist

- [x] New or existing tests cover these changes (dependency metadata only)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

The exact pre-pick `release-1.5` requirement fails an assertion for the `<3` ceiling. On this branch:

- `pyproject.toml` requires `usd-exchange>=2.2.0,<3` on aarch64 with Python below 3.13.
- `uv.lock` carries the same `>=2.2.0,<3` constraint.
- The lock remains on `usd-exchange==2.3.0`.
- The consumed Towncrier fragment is absent from the committed tree.

```console
env UV_CACHE_DIR=/tmp/newton-uv-cache uv lock --check
env UV_CACHE_DIR=/tmp/newton-uv-cache \
  UV_TOOL_DIR=/tmp/newton-uv-tools \
  PRE_COMMIT_HOME=/tmp/newton-pre-commit-cache \
  uvx --python 3.12 pre-commit run -a
git diff --check upstream/release-1.5..HEAD
```

All checks pass.

## Bug fix

**Steps to reproduce:**

1. Resolve Newton's `importers` extra on aarch64 with Python below 3.13.
2. Observe that the previous requirement `usd-exchange>=2.2.0` permits a future 3.x major release without review.
3. With this backport, resolution is constrained to compatible 2.x releases.
