### PR TITLE
Color elements with one zero Lame parameter

### DIFF
--- a/changelog/3972.fixed.md
+++ b/changelog/3972.fixed.md
@@ -1,0 +1,1 @@
+Fix `ModelBuilder.color()` dropping triangles and tetrahedra whose Lame parameters multiply to zero. The colorer now marks an element active when either parameter is non-zero, matching the condition `SolverVBD` uses to evaluate it. Cloth imported from USD, which always sets `tri_ka` to 0, previously collapsed into a single color group.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -10370,13 +10370,23 @@ class ModelBuilder:
                 # Active if either stiffness or damping is non-zero
                 bending_edge_active_mask = (bending_edge_props[:, 0] != 0.0) | (bending_edge_props[:, 1] != 0.0)
 
+            # Active if either Lame parameter is non-zero, matching the condition SolverVBD uses to
+            # decide whether to evaluate an element. A product would deactivate elements the solver
+            # still integrates, leaving their vertices in the same color group.
+            tri_active_mask = (
+                (tri_materials[:, 0] != 0.0) | (tri_materials[:, 1] != 0.0) if len(tri_materials) else None
+            )
+            tet_active_mask = (
+                (tet_materials[:, 0] != 0.0) | (tet_materials[:, 1] != 0.0) if len(tet_materials) else None
+            )
+
             graph_edge_indices = construct_particle_graph(
                 tri_indices,
-                tri_materials[:, 0] * tri_materials[:, 1] if len(tri_materials) else None,
+                tri_active_mask,
                 bending_edge_indices,
                 bending_edge_active_mask,
                 tet_indices,
-                tet_materials[:, 0] * tet_materials[:, 1] if len(tet_materials) else None,
+                tet_active_mask,
             )
 
             if len(graph_edge_indices) > 0:

--- a/newton/tests/test_coloring.py
+++ b/newton/tests/test_coloring.py
@@ -482,7 +482,7 @@ def test_coloring_rigid_body_no_joints(test, device):
 
 
 def count_unseparated_elements(builder, element_indices, vertices_per_element):
-    """Count elements whose vertices were all placed in the same color group."""
+    """Count elements with two or more vertices sharing a color group."""
     element_colors = np.full(builder.particle_count, -1, dtype=np.int64)
     for color, group in enumerate(builder.particle_color_groups):
         element_colors[np.asarray(group)] = color
@@ -494,9 +494,10 @@ def count_unseparated_elements(builder, element_indices, vertices_per_element):
 def test_coloring_membrane_with_one_zero_lame_parameter(test, device):
     """Color every membrane triangle SolverVBD evaluates, including those with one zero Lame parameter."""
     with wp.ScopedDevice(device):
-        # SolverVBD evaluates a triangle when either k_mu or k_lambda is non-zero, so both of these
-        # meshes are simulated. The USD cloth importer always sets tri_ka to 0, so the first case is
-        # what every cloth imported from USD gets.
+        # SolverVBD evaluates a triangle when either Lame parameter is non-zero -- tri_ke and tri_ka
+        # here, columns 0 and 1 of Model.tri_materials -- so both of these meshes are simulated. The
+        # USD cloth importer always sets tri_ka to 0, so the first case is what every cloth imported
+        # from USD gets.
         for tri_ke, tri_ka in ((1.0e3, 0.0), (0.0, 1.0e3)):
             builder = ModelBuilder()
             builder.add_cloth_grid(
@@ -520,7 +521,7 @@ def test_coloring_membrane_with_one_zero_lame_parameter(test, device):
             test.assertEqual(
                 unseparated,
                 0,
-                f"tri_ke={tri_ke}, tri_ka={tri_ka}: {unseparated} triangles have all three vertices in one color group",
+                f"tri_ke={tri_ke}, tri_ka={tri_ka}: {unseparated} triangles have two vertices sharing a color group",
             )
 
 
@@ -550,7 +551,7 @@ def test_coloring_tets_with_one_zero_lame_parameter(test, device):
             test.assertEqual(
                 unseparated,
                 0,
-                f"k_mu={k_mu}, k_lambda={k_lambda}: {unseparated} tets have all four vertices in one color group",
+                f"k_mu={k_mu}, k_lambda={k_lambda}: {unseparated} tets have two vertices sharing a color group",
             )
 
 

--- a/newton/tests/test_coloring.py
+++ b/newton/tests/test_coloring.py
@@ -481,6 +481,79 @@ def test_coloring_rigid_body_no_joints(test, device):
         test.assertEqual(model.body_color_groups[0].size, 5, "All 5 bodies should be in same color group")
 
 
+def count_unseparated_elements(builder, element_indices, vertices_per_element):
+    """Count elements whose vertices were all placed in the same color group."""
+    element_colors = np.full(builder.particle_count, -1, dtype=np.int64)
+    for color, group in enumerate(builder.particle_color_groups):
+        element_colors[np.asarray(group)] = color
+
+    elements = np.array(element_indices).reshape(-1, vertices_per_element)
+    return sum(1 for element in elements if len({element_colors[int(v)] for v in element}) < vertices_per_element)
+
+
+def test_coloring_membrane_with_one_zero_lame_parameter(test, device):
+    """Color every membrane triangle SolverVBD evaluates, including those with one zero Lame parameter."""
+    with wp.ScopedDevice(device):
+        # SolverVBD evaluates a triangle when either k_mu or k_lambda is non-zero, so both of these
+        # meshes are simulated. The USD cloth importer always sets tri_ka to 0, so the first case is
+        # what every cloth imported from USD gets.
+        for tri_ke, tri_ka in ((1.0e3, 0.0), (0.0, 1.0e3)):
+            builder = ModelBuilder()
+            builder.add_cloth_grid(
+                pos=wp.vec3(0.0, 0.0, 0.0),
+                rot=wp.quat_identity(),
+                vel=wp.vec3(0.0, 0.0, 0.0),
+                dim_x=20,
+                dim_y=20,
+                cell_x=0.05,
+                cell_y=0.05,
+                mass=0.1,
+                tri_ke=tri_ke,
+                tri_ka=tri_ka,
+                tri_kd=0.0,
+                edge_ke=0.0,
+                edge_kd=0.0,
+            )
+            builder.color()
+
+            unseparated = count_unseparated_elements(builder, builder.tri_indices, 3)
+            test.assertEqual(
+                unseparated,
+                0,
+                f"tri_ke={tri_ke}, tri_ka={tri_ka}: {unseparated} triangles have all three vertices in one color group",
+            )
+
+
+def test_coloring_tets_with_one_zero_lame_parameter(test, device):
+    """Color every tetrahedron SolverVBD evaluates, including those with one zero Lame parameter."""
+    with wp.ScopedDevice(device):
+        for k_mu, k_lambda in ((1.0e3, 0.0), (0.0, 1.0e3)):
+            builder = ModelBuilder()
+            builder.add_soft_grid(
+                pos=wp.vec3(0.0, 0.0, 0.0),
+                rot=wp.quat_identity(),
+                vel=wp.vec3(0.0, 0.0, 0.0),
+                dim_x=4,
+                dim_y=4,
+                dim_z=4,
+                cell_x=0.1,
+                cell_y=0.1,
+                cell_z=0.1,
+                density=100.0,
+                k_mu=k_mu,
+                k_lambda=k_lambda,
+                k_damp=0.0,
+            )
+            builder.color()
+
+            unseparated = count_unseparated_elements(builder, builder.tet_indices, 4)
+            test.assertEqual(
+                unseparated,
+                0,
+                f"k_mu={k_mu}, k_lambda={k_lambda}: {unseparated} tets have all four vertices in one color group",
+            )
+
+
 devices = get_test_devices()
 
 
@@ -509,6 +582,20 @@ add_function_test(
 )
 add_function_test(
     TestColoring, "test_coloring_rigid_body_no_joints", test_coloring_rigid_body_no_joints, devices=devices
+)
+
+# Element activity coloring tests
+add_function_test(
+    TestColoring,
+    "test_coloring_membrane_with_one_zero_lame_parameter",
+    test_coloring_membrane_with_one_zero_lame_parameter,
+    devices=devices,
+)
+add_function_test(
+    TestColoring,
+    "test_coloring_tets_with_one_zero_lame_parameter",
+    test_coloring_tets_with_one_zero_lame_parameter,
+    devices=devices,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`ModelBuilder.color()` decided whether an element contributes edges to the coloring graph
from the **product** of its two Lame parameters, while `SolverVBD` decides whether to
evaluate that element from the **or** of the same two values. An element with exactly one
zero parameter was therefore removed from the graph while the solver still integrated it,
so its vertices could all land in one color group — which removes the Gauss-Seidel
ordering VBD's convergence rests on.

`import_usd_deformable_cloth.py` sets `tri_ka = 0.0` unconditionally, and `include_bending`
defaults to `False`, so every cloth imported from USD took this path unless the caller both
passed `include_bending=True` and had a non-zero `edge_ke`.

The fix uses the same "either is non-zero" predicate the solver uses, which is also the form
already used a few lines above for bending edges:

```python
bending_edge_active_mask = (bending_edge_props[:, 0] != 0.0) | (bending_edge_props[:, 1] != 0.0)
```

**The tet path had the identical mismatch** (`builder.py` used the product; the solver's tet
branch uses the same `or`). The issue flagged this as suspected but unverified — it
reproduces, so both are fixed here.

Closes #3972.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k lame_parameter
uv run -m unittest newton.tests.test_coloring
uv run -m unittest newton.tests.test_cloth
uv run -m unittest newton.tests.test_cable
uv run -m unittest newton.tests.test_softbody
uv run -m unittest newton.tests.test_import_usd_deformable_mixed
uv run -m unittest newton.tests.test_solver_vbd
uvx pre-commit run --files newton/_src/sim/builder.py newton/tests/test_coloring.py changelog/3972.fixed.md
```

All green on `cpu` and `cuda:0` (RTX 3050, sm_86). One `test_solver_vbd` failure,
`TestVBDFullSurfaceContact.test_edge_face_pushes_vertices_out_cuda_0`, reproduces
identically on unmodified `main` at `cd6a65c2` and is unrelated to this change.

Both halves of the fix were verified to be load-bearing by reverting each one alone:

| mutation | `..._membrane_...` | `..._tets_...` |
|---|---|---|
| tri mask back to the product | fails, 800/800 triangles unseparated | passes |
| tet mask back to the product | passes | fails, 320/320 tets unseparated |

## Bug fix

**Steps to reproduce:**

1. Build a cloth mesh with a non-zero `tri_ke` and `tri_ka = 0` — what the USD cloth
   importer produces.
2. Call `ModelBuilder.color()` with the default `include_bending=False`.
3. Observe a single color group, with all three vertices of every triangle sharing it.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton

builder = newton.ModelBuilder()
builder.add_cloth_grid(
    pos=wp.vec3(0.0, 0.0, 0.0),
    rot=wp.quat_identity(),
    vel=wp.vec3(0.0, 0.0, 0.0),
    dim_x=20,
    dim_y=20,
    cell_x=0.05,
    cell_y=0.05,
    mass=0.1,
    tri_ke=1.0e3,
    tri_ka=0.0,  # what import_usd_deformable_cloth.py always sets
    tri_kd=0.0,
)
builder.color()

colors = np.full(builder.particle_count, -1, dtype=np.int64)
for i, group in enumerate(builder.particle_color_groups):
    colors[np.asarray(group)] = i

tris = np.array(builder.tri_indices).reshape(-1, 3)
unseparated = sum(1 for t in tris if len({colors[int(v)] for v in t}) < 3)
print(f"{len(builder.particle_color_groups)} color groups, {unseparated}/{len(tris)} triangles unseparated")
# before: 1 color groups, 800/800 triangles unseparated
# after:  3 color groups, 0/800 triangles unseparated
```

The tet equivalent is `add_soft_grid(k_mu=1.0e3, k_lambda=0.0, ...)`, which gives
`1 color group, 320/320 tets unseparated` before and `4 color groups, 0/320` after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed material coloring for cloth and solid elements when only one material parameter is nonzero.
  - Prevented affected triangles and tetrahedra from collapsing into a single color group during USD-imported cloth simulations.
  - Aligned element activation and coloring behavior for more reliable simulation results.

- **Tests**
  - Added coverage for membrane triangles and tetrahedra with partially defined material parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->