### PR TITLE
Optimize BVH construction with tiled AABB computation

### DIFF
--- a/changelog/+tiled-shape-bounds-6f3a2c1d.changed.md
+++ b/changelog/+tiled-shape-bounds-6f3a2c1d.changed.md
@@ -1,0 +1,1 @@
+Accelerate shape BVH construction by reducing mesh and Gaussian local bounds cooperatively on the device; computed bounds are unchanged and no migration is required.

--- a/newton/_src/geometry/bvh.py
+++ b/newton/_src/geometry/bvh.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ..sim import Model, State
 
 
+SHAPE_BOUNDS_BLOCK_DIM = 256
+
+
 @wp.func
 def compute_shape_bounds(
     transform: wp.transformf, scale: wp.vec3f, shape_min_bounds: wp.vec3f, shape_max_bounds: wp.vec3f
@@ -210,31 +213,35 @@ def compute_shape_local_bounds(
     in_gaussians: wp.array[Gaussian.Data],
     out_bounds: wp.array2d[wp.vec3f],
 ):
-    tid = wp.tid()
+    shape_index, lane = wp.tid()
 
     min_point = wp.vec3(MAXVAL)
     max_point = wp.vec3(-MAXVAL)
 
     if (
-        in_shape_type[tid] == GeoType.MESH
-        or in_shape_type[tid] == GeoType.CONVEX_MESH
-        or in_shape_type[tid] == GeoType.HFIELD
+        in_shape_type[shape_index] == GeoType.MESH
+        or in_shape_type[shape_index] == GeoType.CONVEX_MESH
+        or in_shape_type[shape_index] == GeoType.HFIELD
     ):
         # Heightfields and convex meshes store mesh-backed geometry in shape_source_ptr.
-        mesh = wp.mesh_get(in_shape_ptr[tid])
-        for i in range(mesh.points.shape[0]):
+        mesh = wp.mesh_get(in_shape_ptr[shape_index])
+        for i in range(lane, mesh.points.shape[0], wp.block_dim()):
             min_point = wp.min(min_point, mesh.points[i])
             max_point = wp.max(max_point, mesh.points[i])
 
-    elif in_shape_type[tid] == GeoType.GAUSSIAN:
-        gaussian_id = in_shape_ptr[tid]
-        for i in range(in_gaussians[gaussian_id].num_points):
+    elif in_shape_type[shape_index] == GeoType.GAUSSIAN:
+        gaussian_id = in_shape_ptr[shape_index]
+        for i in range(lane, in_gaussians[gaussian_id].num_points, wp.block_dim()):
             lower, upper = compute_gaussian_bounds(in_gaussians[gaussian_id], i)
             min_point = wp.min(min_point, lower)
             max_point = wp.max(max_point, upper)
 
-    out_bounds[tid, 0] = min_point
-    out_bounds[tid, 1] = max_point
+    min_point = wp.tile_reduce(wp.min, wp.tile(min_point, preserve_type=True))[0]
+    max_point = wp.tile_reduce(wp.max, wp.tile(max_point, preserve_type=True))[0]
+
+    if lane == 0:
+        out_bounds[shape_index, 0] = min_point
+        out_bounds[shape_index, 1] = max_point
 
 
 @wp.kernel(enable_backward=False)

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -1615,6 +1615,7 @@ class Model:
                 included in the BVH if any of its flags are set in the mask.
         """
         from ..geometry.bvh import (  # noqa: PLC0415
+            SHAPE_BOUNDS_BLOCK_DIM,
             compute_bvh_group_roots,
             compute_enabled_shapes,
             compute_shape_bvh_bounds_launch,
@@ -1630,9 +1631,10 @@ class Model:
         world_count_total = self.world_count + 1
 
         self.bvh_shape_bounds = wp.empty((shape_count, 2), dtype=wp.vec3f, ndim=2, device=device)
-        wp.launch(
+        wp.launch_tiled(
             kernel=compute_shape_local_bounds,
             dim=shape_count,
+            block_dim=SHAPE_BOUNDS_BLOCK_DIM,
             inputs=[
                 self.shape_type,
                 self.shape_source_ptr,

--- a/newton/tests/test_bvh.py
+++ b/newton/tests/test_bvh.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cooperative shape BVH local-bounds reduction."""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton._src.geometry.bvh import SHAPE_BOUNDS_BLOCK_DIM, compute_shape_local_bounds
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+# Straddle the reduction block size: fewer points than lanes (idle lanes reduce only the
+# sentinel), one lane short of full, exactly one iteration per lane, a single strided tail
+# element, and several iterations per lane.
+POINT_COUNTS = (
+    3,
+    SHAPE_BOUNDS_BLOCK_DIM - 1,
+    SHAPE_BOUNDS_BLOCK_DIM,
+    SHAPE_BOUNDS_BLOCK_DIM + 1,
+    4 * SHAPE_BOUNDS_BLOCK_DIM + 1,
+)
+
+
+class TestShapeBvhBounds(unittest.TestCase):
+    pass
+
+
+def _make_points(rng: np.random.Generator, num_points: int, extent: float) -> np.ndarray:
+    """Sample points in a cube, planting the extremes at the strided-tail and midpoint indices."""
+    points = rng.uniform(-extent, extent, size=(num_points, 3)).astype(np.float32)
+    # Index num_points - 1 is the final iteration of the last active lane, so a dropped tail
+    # moves the bounds no matter how num_points relates to the block size.
+    points[num_points - 1] = (2.0 * extent, 4.0 * extent, -6.0 * extent)
+    points[num_points // 2] = (-4.0 * extent, 2.0 * extent, 1.0 * extent)
+    return points
+
+
+def _make_mesh(vertices: np.ndarray) -> newton.Mesh:
+    """Wrap vertices in a Mesh; only the point set matters for bounds, so one triangle suffices."""
+    return newton.Mesh(vertices, np.array([0, 1, 2], dtype=np.int32), compute_inertia=False)
+
+
+def _gaussian_bounds(gaussian: newton.Gaussian, positions: np.ndarray, scales: np.ndarray) -> tuple[np.ndarray, ...]:
+    """Reference AABB over Gaussian ellipsoids, given default identity rotations and unit opacities."""
+    response_scale = np.sqrt(np.log(gaussian.min_response) / -0.5)
+    return (
+        np.min(positions - scales * response_scale, axis=0),
+        np.max(positions + scales * response_scale, axis=0),
+    )
+
+
+def test_tiled_local_bounds(test: TestShapeBvhBounds, device: str):
+    """Verify tiled local bounds match exact mesh and Gaussian AABBs across reduction block boundaries."""
+    rng = np.random.default_rng(1234)
+
+    for num_points in POINT_COUNTS:
+        with test.subTest(num_points=num_points):
+            vertices = _make_points(rng, num_points, 1.0)
+            mesh = _make_mesh(vertices)
+
+            positions = _make_points(rng, num_points, 2.0)
+            scales = rng.uniform(0.05, 0.5, size=(num_points, 3)).astype(np.float32)
+            gaussian = newton.Gaussian(positions=positions, scales=scales, min_response=0.1)
+
+            builder = newton.ModelBuilder()
+            mesh_shape = builder.add_shape_mesh(body=-1, mesh=mesh)
+            convex_shape = builder.add_shape_convex_hull(body=-1, mesh=mesh)
+            gaussian_shape = builder.add_shape_gaussian(body=-1, gaussian=gaussian)
+            model = builder.finalize(device=device)
+
+            bounds = model.bvh_shape_bounds.numpy()
+            mesh_bounds = (vertices.min(axis=0), vertices.max(axis=0))
+            np.testing.assert_allclose(bounds[mesh_shape], mesh_bounds, rtol=0.0, atol=0.0)
+            np.testing.assert_allclose(bounds[convex_shape], mesh_bounds, rtol=0.0, atol=0.0)
+            np.testing.assert_allclose(
+                bounds[gaussian_shape], _gaussian_bounds(gaussian, positions, scales), rtol=1.0e-6, atol=1.0e-6
+            )
+
+
+def test_tiled_local_bounds_rebuild(test: TestShapeBvhBounds, device: str):
+    """Verify a tiled bounds rebuild re-reads mutated mesh points rather than reusing the first result."""
+    rng = np.random.default_rng(1234)
+    num_points = POINT_COUNTS[-1]
+    vertices = _make_points(rng, num_points, 1.0)
+    mesh = _make_mesh(vertices)
+
+    builder = newton.ModelBuilder()
+    mesh_shape = builder.add_shape_mesh(body=-1, mesh=mesh)
+    # All vertices are distinct, so finalize's convex dedup returns this same Mesh and both
+    # shapes share one wp.Mesh; that is what lets the assign() below reach the convex shape too.
+    convex_shape = builder.add_shape_convex_hull(body=-1, mesh=mesh)
+
+    with mock.patch.object(wp, "launch_tiled", wraps=wp.launch_tiled) as launch_tiled:
+        model = builder.finalize(device=device)
+
+    local_bounds_launches = [
+        call for call in launch_tiled.call_args_list if call.kwargs.get("kernel") is compute_shape_local_bounds
+    ]
+    test.assertEqual(len(local_bounds_launches), 1)
+    test.assertEqual(local_bounds_launches[0].kwargs["block_dim"], SHAPE_BOUNDS_BLOCK_DIM)
+
+    changed_vertices = vertices.copy()
+    changed_vertices[num_points // 3] = (-8.0, 9.0, -10.0)
+    mesh.mesh.points.assign(changed_vertices)
+    model.bvh_build_shapes(model.state())
+
+    rebuilt_bounds = model.bvh_shape_bounds.numpy()
+    changed_bounds = (changed_vertices.min(axis=0), changed_vertices.max(axis=0))
+    for shape, label in ((mesh_shape, "mesh"), (convex_shape, "convex")):
+        with test.subTest(shape=label):
+            np.testing.assert_allclose(rebuilt_bounds[shape], changed_bounds, rtol=0.0, atol=0.0)
+
+
+add_function_test(TestShapeBvhBounds, "test_tiled_local_bounds", test_tiled_local_bounds, devices=get_test_devices())
+add_function_test(
+    TestShapeBvhBounds, "test_tiled_local_bounds_rebuild", test_tiled_local_bounds_rebuild, devices=get_test_devices()
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

`ModelBuilder.finalize()` constructs a bvh for the model's shapes. The shape-local AABB computation is sequential over vertices, which can lead to unnecessarily high startup costs for meshes. This PR speeds up AABB computation by using tiled reductions on CUDA devices.

part of #4000

### Performance impact

Measurement of `Model.bvh_build_shapes` within Isaac Lab, go2 robot on flat/rough terrain in 4096 envs shows a mild regression for simple geometry and a large improvement for large meshes.

| task | terrain | base (ms) | PR (ms) | Δ (ms) | Δ% | speedup |
|---|---|---:|---:|---:|---:|---:|
| go2-rough | generated trimesh | 902.6 | 16.7 | -885.7 | -98.1% | **54.0×** |
| go2-flat | plane | 2.1 | 2.4 | +0.3 | +13.1% | 0.88× |

Δ is the median of the paired differences across 9 runs.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k test_bvh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved shape BVH construction by parallelizing local-bound calculations across mesh and Gaussian geometry.
  * Bounds are now computed cooperatively on supported devices while preserving existing results.

* **Bug Fixes**
  * Rebuilding shape bounds now correctly reflects updated mesh vertices.

* **Tests**
  * Added coverage for mesh, convex-hull, and Gaussian bounds across varying geometry sizes and available devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->