### PR TITLE
Refit the MuJoCo midphase BVH after syncing inertial frames on CPU

### DIFF
--- a/changelog/3805.fixed.md
+++ b/changelog/3805.fixed.md
@@ -1,0 +1,1 @@
+Re-express a body's MuJoCo midphase BVH in its new inertial frame when `SolverMuJoCo(use_mujoco_cpu=True)` syncs inertias after compilation, so the midphase no longer culls geom pairs that genuinely overlap.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -4379,6 +4379,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         if not np.any(changed_bodies):
             return
 
+        old_body_iquat = self.mj_model.body_iquat.copy()
+
         self.mj_model.body_inertia[:] = mjw_body_inertia
         self.mj_model.body_iquat[:] = mjw_body_iquat
 
@@ -4388,6 +4390,40 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_model.body_sameframe[changed_bodies] = int(self._mujoco.mjtSameFrame.mjSAMEFRAME_NONE)
         self.mj_model.body_simple[changed_bodies] = 0
         self.mj_model.dof_simplenum[:] = 0
+
+        self._refit_body_bvh_to_inertial_frame(old_body_iquat, mjw_body_iquat, iquat_changed)
+
+    def _refit_body_bvh_to_inertial_frame(
+        self, old_body_iquat: np.ndarray, new_body_iquat: np.ndarray, iquat_changed: np.ndarray
+    ) -> None:
+        """Re-express each rotated body's midphase BVH boxes in its new inertial frame.
+
+        MuJoCo stores the body midphase BVH in the compile-time inertial frame and
+        ``mj_collideTree`` transforms it by ``ximat = xmat @ iquat`` at runtime. Overwriting
+        ``body_iquat`` after ``spec.compile()`` therefore leaves those boxes expressed in a frame
+        that no longer exists, and the midphase culls geom pairs that genuinely overlap.
+
+        Args:
+            old_body_iquat: Inertial frame orientations before the sync, shape ``(nbody, 4)``.
+            new_body_iquat: Inertial frame orientations after the sync, shape ``(nbody, 4)``.
+            iquat_changed: Boolean mask selecting the bodies whose orientation changed.
+        """
+        rot_old = np.empty(9)
+        rot_new = np.empty(9)
+        for body in np.flatnonzero(iquat_changed):
+            bvh_num = int(self.mj_model.body_bvhnum[body])
+            if bvh_num == 0:
+                continue
+            self._mujoco.mju_quat2Mat(rot_old, old_body_iquat[body])
+            self._mujoco.mju_quat2Mat(rot_new, new_body_iquat[body])
+            # Maps a point from the old inertial frame to the new one.
+            rot = rot_new.reshape(3, 3).T @ rot_old.reshape(3, 3)
+            bvh_adr = int(self.mj_model.body_bvhadr[body])
+            aabb = self.mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num]
+            # A rotated box is not axis-aligned, so its half-extents grow into the enclosing box.
+            self.mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num] = np.hstack(
+                (aabb[:, :3] @ rot.T, aabb[:, 3:] @ np.abs(rot).T)
+            )
 
     @override
     def notify_model_changed(self, flags: ModelFlags | int) -> None:

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3664,6 +3664,11 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         if disable_sensors:
             disableflags |= mujoco.mjtDisableBit.mjDSBL_SENSOR
         self.use_mujoco_cpu = use_mujoco_cpu
+        # Compiled midphase boxes and the inertial frame they are expressed in, captured
+        # before the first inertial sync so every refit starts from the same bounds.
+        self._canonical_bvh_aabb: np.ndarray | None = None
+        self._canonical_body_ipos: np.ndarray | None = None
+        self._canonical_body_iquat: np.ndarray | None = None
         if use_mujoco_contacts or use_mujoco_cpu:
             mujoco_attrs_for_warn = getattr(model, "mujoco", None)
             solref_mode_attr = (
@@ -4361,6 +4366,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         """Synchronize the complete MJWarp inertial representation to MuJoCo CPU."""
         mjw_body_inertia = self.mjw_model.body_inertia.numpy()[0]
         mjw_body_iquat = self.mjw_model.body_iquat.numpy()[0]
+        mjw_body_ipos = self.mjw_model.body_ipos.numpy()[0]
 
         inertia_changed = ~np.isclose(
             self.mj_model.body_inertia,
@@ -4374,15 +4380,25 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             rtol=1.0e-6,
             atol=1.0e-8,
         ).all(axis=1)
-        changed_bodies = inertia_changed | iquat_changed
+        ipos_changed = ~np.isclose(
+            self.mj_model.body_ipos,
+            mjw_body_ipos,
+            rtol=1.0e-6,
+            atol=1.0e-8,
+        ).all(axis=1)
+        # The inertial frame is the pair (ipos, iquat); either one moving invalidates the
+        # compiled metadata and the midphase boxes expressed in that frame.
+        frame_changed = iquat_changed | ipos_changed
+        changed_bodies = inertia_changed | frame_changed
 
         if not np.any(changed_bodies):
             return
 
-        old_body_iquat = self.mj_model.body_iquat.copy()
+        self._cache_canonical_body_bvh()
 
         self.mj_model.body_inertia[:] = mjw_body_inertia
         self.mj_model.body_iquat[:] = mjw_body_iquat
+        self.mj_model.body_ipos[:] = mjw_body_ipos
 
         # ``body_inertia`` and ``body_iquat`` are coupled. Once the inertial
         # frame changes, MuJoCo CPU's compiled simple-path metadata may still
@@ -4391,39 +4407,55 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_model.body_simple[changed_bodies] = 0
         self.mj_model.dof_simplenum[:] = 0
 
-        self._refit_body_bvh_to_inertial_frame(old_body_iquat, mjw_body_iquat, iquat_changed)
+        self._refit_body_bvh_to_inertial_frame(frame_changed)
 
-    def _refit_body_bvh_to_inertial_frame(
-        self, old_body_iquat: np.ndarray, new_body_iquat: np.ndarray, iquat_changed: np.ndarray
-    ) -> None:
-        """Re-express each rotated body's midphase BVH boxes in its new inertial frame.
+    def _cache_canonical_body_bvh(self) -> None:
+        """Snapshot the compiled midphase boxes and the frame they are expressed in.
+
+        Every refit is computed from this snapshot rather than from the previous result. The
+        enclosing-box growth applied when a box is rotated is not reversible, so transforming
+        an already-expanded box on each update would let the bounds grow without limit.
+        """
+        if self._canonical_bvh_aabb is not None:
+            return
+        self._canonical_bvh_aabb = self.mj_model.bvh_aabb.copy()
+        self._canonical_body_ipos = self.mj_model.body_ipos.copy()
+        self._canonical_body_iquat = self.mj_model.body_iquat.copy()
+
+    def _refit_body_bvh_to_inertial_frame(self, frame_changed: np.ndarray) -> None:
+        """Re-express each moved body's midphase BVH boxes in its new inertial frame.
 
         MuJoCo stores the body midphase BVH in the compile-time inertial frame and
         ``mj_collideTree`` transforms it by ``ximat = xmat @ iquat`` at runtime. Overwriting
-        ``body_iquat`` after ``spec.compile()`` therefore leaves those boxes expressed in a frame
-        that no longer exists, and the midphase culls geom pairs that genuinely overlap.
+        ``body_ipos`` or ``body_iquat`` after ``spec.compile()`` therefore leaves those boxes
+        expressed in a frame that no longer exists, and the midphase culls geom pairs that
+        genuinely overlap.
 
         Args:
-            old_body_iquat: Inertial frame orientations before the sync, shape ``(nbody, 4)``.
-            new_body_iquat: Inertial frame orientations after the sync, shape ``(nbody, 4)``.
-            iquat_changed: Boolean mask selecting the bodies whose orientation changed.
+            frame_changed: Boolean mask selecting the bodies whose inertial frame moved.
         """
-        rot_old = np.empty(9)
+        rot_canonical = np.empty(9)
         rot_new = np.empty(9)
-        for body in np.flatnonzero(iquat_changed):
+        for body in np.flatnonzero(frame_changed):
             bvh_num = int(self.mj_model.body_bvhnum[body])
             if bvh_num == 0:
                 continue
-            self._mujoco.mju_quat2Mat(rot_old, old_body_iquat[body])
-            self._mujoco.mju_quat2Mat(rot_new, new_body_iquat[body])
-            # Maps a point from the old inertial frame to the new one.
-            rot = rot_new.reshape(3, 3).T @ rot_old.reshape(3, 3)
+            self._mujoco.mju_quat2Mat(rot_canonical, self._canonical_body_iquat[body])
+            self._mujoco.mju_quat2Mat(rot_new, self.mj_model.body_iquat[body])
+            rot_canonical = rot_canonical.reshape(3, 3)
+            rot_new = rot_new.reshape(3, 3)
+            # A point p in the canonical frame sits at ipos_c + R_c @ p in body coordinates, so
+            # in the new frame it is R_n.T @ (R_c @ p + ipos_c - ipos_n).
+            rot = rot_new.T @ rot_canonical
+            offset = rot_new.T @ (self._canonical_body_ipos[body] - self.mj_model.body_ipos[body])
             bvh_adr = int(self.mj_model.body_bvhadr[body])
-            aabb = self.mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num]
+            aabb = self._canonical_bvh_aabb[bvh_adr : bvh_adr + bvh_num]
             # A rotated box is not axis-aligned, so its half-extents grow into the enclosing box.
             self.mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num] = np.hstack(
-                (aabb[:, :3] @ rot.T, aabb[:, 3:] @ np.abs(rot).T)
+                (aabb[:, :3] @ rot.T + offset, aabb[:, 3:] @ np.abs(rot).T)
             )
+            rot_canonical = rot_canonical.reshape(9)
+            rot_new = rot_new.reshape(9)
 
     @override
     def notify_model_changed(self, flags: ModelFlags | int) -> None:
@@ -4497,7 +4529,6 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
         if self.use_mujoco_cpu:
             if flags & ModelFlags.BODY_INERTIAL_PROPERTIES:
-                self.mj_model.body_ipos[:] = self.mjw_model.body_ipos.numpy()[0]
                 self.mj_model.body_mass[:] = self.mjw_model.body_mass.numpy()[0]
                 self.mj_model.body_gravcomp[:] = self.mjw_model.body_gravcomp.numpy()[0]
                 self._sync_mjw_inertias_to_mjc_cpu()

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -677,8 +677,9 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         builder.rigid_gap = 0.0
         builder.add_shape_mesh(body=-1, mesh=box(0.01, 0.01, 0.01))
         # Two shapes far apart in the body frame, so the principal axes differ from the compiled ones.
+        # add_body already yields a free-floating body; an explicit free joint would be a
+        # second root and is reported as an unsupported loop closure.
         obj = builder.add_body(xform=wp.transform(wp.vec3(0.049, 0.0, 0.0), wp.quat_identity()))
-        builder.add_joint_free(obj)
         builder.add_shape_mesh(body=obj, mesh=box(0.04, 0.01, 0.005))
         builder.add_shape_mesh(
             body=obj,
@@ -722,8 +723,9 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         builder = newton.ModelBuilder()
         builder.rigid_gap = 0.0
         builder.add_shape_mesh(body=-1, mesh=box(0.01, 0.01, 0.01))
+        # add_body already yields a free-floating body; an explicit free joint would be a
+        # second root and is reported as an unsupported loop closure.
         obj = builder.add_body(xform=wp.transform(wp.vec3(0.049, 0.0, 0.0), wp.quat_identity()))
-        builder.add_joint_free(obj)
         builder.add_shape_mesh(body=obj, mesh=box(0.04, 0.01, 0.005))
         builder.add_shape_mesh(
             body=obj,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -704,6 +704,60 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         self.assertGreater(contact_counts[False], 0)
         self.assertEqual(contact_counts[True], contact_counts[False])
 
+    def test_mujoco_cpu_midphase_survives_runtime_com_update(self):
+        """Verify the CPU midphase follows the inertial frame when only the centre of mass moves.
+
+        A runtime ``body_com`` update moves ``body_ipos`` while leaving ``body_iquat`` alone, so a
+        refit keyed on orientation alone would leave the midphase boxes centred on the old frame.
+        """
+        cube_faces = [
+            0, 1, 3, 0, 3, 2, 4, 7, 5, 4, 6, 7, 0, 4, 1, 1, 4, 5,
+            2, 3, 7, 2, 7, 6, 0, 2, 6, 0, 6, 4, 1, 5, 7, 1, 7, 3,
+        ]  # fmt: skip
+
+        def box(hx, hy, hz):
+            vertices = [[sx * hx, sy * hy, sz * hz] for sx in (-1.0, 1.0) for sy in (-1.0, 1.0) for sz in (-1.0, 1.0)]
+            return Mesh(np.array(vertices, dtype=np.float32).flatten().tolist(), cube_faces)
+
+        builder = newton.ModelBuilder()
+        builder.rigid_gap = 0.0
+        builder.add_shape_mesh(body=-1, mesh=box(0.01, 0.01, 0.01))
+        obj = builder.add_body(xform=wp.transform(wp.vec3(0.049, 0.0, 0.0), wp.quat_identity()))
+        builder.add_joint_free(obj)
+        builder.add_shape_mesh(body=obj, mesh=box(0.04, 0.01, 0.005))
+        builder.add_shape_mesh(
+            body=obj,
+            mesh=box(0.005, 0.005, 0.005),
+            xform=wp.transform(wp.vec3(0.02, 0.02, 0.0), wp.quat_identity()),
+        )
+
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model, use_mujoco_cpu=True, use_mujoco_contacts=True)
+        mj_model = solver.mj_model
+
+        body = 1
+        bvh_adr = int(mj_model.body_bvhadr[body])
+        bvh_num = int(mj_model.body_bvhnum[body])
+        centers_before = mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, :3].copy()
+        ipos_before = mj_model.body_ipos[body].copy()
+
+        body_com = model.body_com.numpy().copy()
+        body_com[0] = body_com[0] + np.array([0.02, 0.02, 0.0], dtype=body_com.dtype)
+        model.body_com.assign(body_com)
+        solver.notify_model_changed(ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+        # The origin moved, so the boxes must move with it.
+        self.assertGreater(float(np.max(np.abs(mj_model.body_ipos[body] - ipos_before))), 1e-4)
+        centers_after = mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, :3]
+        self.assertGreater(float(np.max(np.abs(centers_after - centers_before))), 1e-4)
+
+        # Repeating the same update must not drift the bounds, since the refit is computed
+        # from the compiled boxes rather than from the previous result.
+        extents = mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, 3:].copy()
+        for _ in range(4):
+            solver.notify_model_changed(ModelFlags.BODY_INERTIAL_PROPERTIES)
+        assert_np_equal(mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, 3:], extents, tol=1e-6)
+
     def test_body_gravcomp(self):
         """
         Tests if the body gravity compensation is updated properly.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -751,10 +751,25 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         centers_after = mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, :3]
         self.assertGreater(float(np.max(np.abs(centers_after - centers_before))), 1e-4)
 
-        # Repeating the same update must not drift the bounds, since the refit is computed
-        # from the compiled boxes rather than from the previous result.
+        # Returning to a frame must reproduce that frame's bounds. Rotating a box into a new
+        # frame grows it into the enclosing box, which is not reversible, so a refit computed
+        # from the previous result would accumulate on every round trip.
         extents = mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, 3:].copy()
+        body_inertia = model.body_inertia.numpy().copy()
+        rotated = body_inertia.copy()
+        angle = math.radians(30.0)
+        rot = np.array(
+            [
+                [math.cos(angle), -math.sin(angle), 0.0],
+                [math.sin(angle), math.cos(angle), 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        rotated[0] = (rot @ body_inertia[0].astype(np.float64) @ rot.T).astype(body_inertia.dtype)
         for _ in range(4):
+            model.body_inertia.assign(rotated)
+            solver.notify_model_changed(ModelFlags.BODY_INERTIAL_PROPERTIES)
+            model.body_inertia.assign(body_inertia)
             solver.notify_model_changed(ModelFlags.BODY_INERTIAL_PROPERTIES)
         assert_np_equal(mj_model.bvh_aabb[bvh_adr : bvh_adr + bvh_num, 3:], extents, tol=1e-6)
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -654,6 +654,56 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         np.testing.assert_allclose(solver.mj_data.qfrc_actuator[0], native_data.qfrc_actuator[0], rtol=1e-7)
         np.testing.assert_allclose(solver.mj_data.qvel[0], native_data.qvel[0], rtol=1e-6, atol=1e-7)
 
+    def test_mujoco_cpu_midphase_keeps_contacts_after_inertia_frame_sync(self):
+        """Verify the CPU midphase still reports overlapping geom pairs after the inertia frame sync.
+
+        MuJoCo stores the body midphase BVH in the compile-time inertial frame, so overwriting
+        ``body_iquat`` after ``spec.compile()`` invalidates it unless the boxes are re-expressed in
+        the new frame. A stale BVH culls pairs the narrowphase can prove are penetrating.
+        """
+        mujoco, _ = SolverMuJoCo.import_mujoco()
+
+        cube_faces = [
+            0, 1, 3, 0, 3, 2, 4, 7, 5, 4, 6, 7, 0, 4, 1, 1, 4, 5,
+            2, 3, 7, 2, 7, 6, 0, 2, 6, 0, 6, 4, 1, 5, 7, 1, 7, 3,
+        ]  # fmt: skip
+
+        def box(hx, hy, hz):
+            vertices = [[sx * hx, sy * hy, sz * hz] for sx in (-1.0, 1.0) for sy in (-1.0, 1.0) for sz in (-1.0, 1.0)]
+            return Mesh(np.array(vertices, dtype=np.float32).flatten().tolist(), cube_faces)
+
+        builder = newton.ModelBuilder()
+        # A non-zero gap is exported as a geom margin, which would hide a midphase miss.
+        builder.rigid_gap = 0.0
+        builder.add_shape_mesh(body=-1, mesh=box(0.01, 0.01, 0.01))
+        # Two shapes far apart in the body frame, so the principal axes differ from the compiled ones.
+        obj = builder.add_body(xform=wp.transform(wp.vec3(0.049, 0.0, 0.0), wp.quat_identity()))
+        builder.add_joint_free(obj)
+        builder.add_shape_mesh(body=obj, mesh=box(0.04, 0.01, 0.005))
+        builder.add_shape_mesh(
+            body=obj,
+            mesh=box(0.005, 0.005, 0.005),
+            xform=wp.transform(wp.vec3(0.02, 0.02, 0.0), wp.quat_identity()),
+        )
+
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model, use_mujoco_cpu=True, use_mujoco_contacts=True)
+        mj_model, mj_data = solver.mj_model, solver.mj_data
+
+        midphase_bit = int(mujoco.mjtDisableBit.mjDSBL_MIDPHASE)
+        contact_counts = {}
+        for midphase_enabled in (True, False):
+            if midphase_enabled:
+                mj_model.opt.disableflags &= ~midphase_bit
+            else:
+                mj_model.opt.disableflags |= midphase_bit
+            mujoco.mj_forward(mj_model, mj_data)
+            contact_counts[midphase_enabled] = mj_data.ncon
+
+        # The pair genuinely penetrates, so the narrowphase alone must find it.
+        self.assertGreater(contact_counts[False], 0)
+        self.assertEqual(contact_counts[True], contact_counts[False])
+
     def test_body_gravcomp(self):
         """
         Tests if the body gravity compensation is updated properly.


### PR DESCRIPTION
## Description

MuJoCo stores each body's midphase BVH boxes in the **compile-time** inertial frame, and `mj_collideTree` transforms them at runtime by `ximat = xmat @ iquat`. `_sync_mjw_inertias_to_mjc_cpu()` overwrites `body_iquat` after `spec.compile()`, so those boxes were left describing a frame that no longer exists and the midphase culled geom pairs that genuinely overlap — while `mj_geomDistance` (no midphase) still reported penetration for the same pair.

This re-expresses each rotated body's BVH boxes in its new inertial frame using `R = R_new.T @ R_old`. A rotated box is not axis-aligned, so the half-extents are grown into the enclosing box via `|R|`; that is conservative and can never cull a real overlap.

The sync runs during solver construction via `notify_model_changed(ModelFlags.ALL)`, so every `use_mujoco_cpu=True` model whose Newton-computed inertial frame differs from the compiled one was affected from step 0. Near-symmetric single-hull bodies lose little; multi-shape bodies (for example CoACD convex decompositions) can lose every contact.

Closes #3805

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

New regression test, which fails on `main` and passes with this change:

```
uv run --extra dev -m newton.tests -k test_mujoco_cpu_midphase_keeps_contacts_after_inertia_frame_sync
```

It builds a body carrying two shapes far apart in the body frame, so its principal axes diverge from the compiled ones, and asserts the midphase reports the same contact count as the narrowphase alone. Without the fix it fails with `AssertionError: 0 != 1`.

Full solver suite on this branch:

```
python -m unittest newton.tests.test_mujoco_solver
```

274 tests, 19 skipped, 1 error — the error is `test_mjc_damping_from_usd_via_schema_resolver` failing with `ModuleNotFoundError: No module named 'pxr'`, which fails identically on pristine `main` here (no USD installed). `ruff check` and `ruff format` are clean.

Environment: Linux x86_64, Python 3.12, CPU device, mujoco 3.11.0 / mujoco-warp 3.11.0 / warp-lang 1.16.0.

## Bug fix

To reproduce **without** this PR applied:

```python
import mujoco
import numpy as np
import warp as wp

import newton

CUBE_FACES = [
    0, 1, 3, 0, 3, 2, 4, 7, 5, 4, 6, 7, 0, 4, 1, 1, 4, 5,
    2, 3, 7, 2, 7, 6, 0, 2, 6, 0, 6, 4, 1, 5, 7, 1, 7, 3,
]

def box(hx, hy, hz):
    v = np.array([[sx * hx, sy * hy, sz * hz] for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)], dtype=np.float32)
    return newton.Mesh(v.flatten().tolist(), CUBE_FACES)

builder = newton.ModelBuilder()
builder.rigid_gap = 0.0  # a non-zero gap is exported as a geom margin and masks the miss
builder.add_shape_mesh(body=-1, mesh=box(0.01, 0.01, 0.01))
obj = builder.add_body(xform=wp.transform(wp.vec3(0.049, 0.0, 0.0), wp.quat_identity()))
builder.add_joint_free(obj)
builder.add_shape_mesh(body=obj, mesh=box(0.04, 0.01, 0.005))
builder.add_shape_mesh(body=obj, mesh=box(0.005, 0.005, 0.005),
                       xform=wp.transform(wp.vec3(0.02, 0.02, 0.0), wp.quat_identity()))

model = builder.finalize(device="cpu")
solver = newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=True, use_mujoco_contacts=True)
m, d = solver.mj_model, solver.mj_data

for label, disable in (("midphase ON ", False), ("midphase OFF", True)):
    m.opt.disableflags &= ~int(mujoco.mjtDisableBit.mjDSBL_MIDPHASE)
    if disable:
        m.opt.disableflags |= int(mujoco.mjtDisableBit.mjDSBL_MIDPHASE)
    mujoco.mj_forward(m, d)
    dist = mujoco.mj_geomDistance(m, d, 0, 1, 10.0, np.zeros(6))
    print(f"{label}: ncon={d.ncon}  mj_geomDistance={dist * 1000:7.3f} mm")
```

On `main`:

```
midphase ON : ncon=0  mj_geomDistance= -1.000 mm
midphase OFF: ncon=1  mj_geomDistance= -1.000 mm
```

With this change both report `ncon=1`. Credit to @lenroe, whose report isolated the invariant precisely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU collision detection after inertial frame updates, preventing valid overlapping geometry from being incorrectly culled.
  * Improved collision-bound updates when body positions, center-of-mass locations, or orientations change.
  * Prevented collision bounds from drifting during repeated inertial-frame updates or switches between configurations.

* **Tests**
  * Added regression coverage for penetrating geometry and collision bounds following runtime center-of-mass and orientation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->