### PR TITLE
Fix rigid contact friction exceeding the Coulomb cone

### DIFF
--- a/changelog/+rigid-friction-coulomb-cone-8f3a2c91.changed.md
+++ b/changelog/+rigid-friction-coulomb-cone-8f3a2c91.changed.md
@@ -1,0 +1,6 @@
+Change the `friction_smoothing` default on `SolverSemiImplicit` and `SolverFeatherstone`
+from 1.0 to 1.0e-3. It is a slip speed in m/s below which friction fades out, and friction
+is scaled by `|v_t| / sqrt(friction_smoothing^2 + |v_t|^2)`, so the old default left 2% of
+the Coulomb limit at 20 mm/s of slip. Scenes that set it explicitly should scale their
+value down by the same factor and keep it well under the slip speeds in the scene. Values
+<= 0 now raise `ValueError` instead of producing NaN forces.

--- a/changelog/+rigid-friction-coulomb-cone-8f3a2c91.fixed.md
+++ b/changelog/+rigid-friction-coulomb-cone-8f3a2c91.fixed.md
@@ -1,0 +1,5 @@
+Fix rigid contact friction exceeding the Coulomb cone in `SolverSemiImplicit` and
+`SolverFeatherstone`. The shared penalty kernel normalized the tangential velocity with
+`wp.norm_huber`, which returns `0.5 * |v_t|^2` below its delta and so scaled the friction
+bound by `2 / |v_t|`, reaching 100x the cone at 20 mm/s of slip. It now uses
+`wp.norm_pseudo_huber`, which is a real norm.

--- a/newton/_src/solvers/featherstone/solver_featherstone.py
+++ b/newton/_src/solvers/featherstone/solver_featherstone.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import numpy as np
 import warp as wp
 
@@ -139,7 +141,7 @@ class SolverFeatherstone(SolverBase, CouplingInterface):
         *,
         angular_damping: float = 0.05,
         update_mass_matrix_interval: int = 1,
-        friction_smoothing: float = 1.0,
+        friction_smoothing: float = 1.0e-3,
         use_tile_gemm: bool = False,
         fuse_cholesky: bool = True,
         deterministic: wp.DeterministicMode | None = None,
@@ -149,7 +151,7 @@ class SolverFeatherstone(SolverBase, CouplingInterface):
             model: The model to be simulated.
             angular_damping: Angular damping factor. Defaults to 0.05.
             update_mass_matrix_interval: How often to update the mass matrix (every n-th time the :meth:`step` function gets called). Defaults to 1.
-            friction_smoothing: The delta value for the Huber norm (see :func:`warp.norm_huber() <warp._src.lang.norm_huber>`) used for the friction velocity normalization. Defaults to 1.0.
+            friction_smoothing: Slip speed [m/s] below which friction fades out, passed as ``delta`` to :func:`warp.norm_pseudo_huber`. Friction is ``min(kf * |v_t|, mu * |f_n|)`` scaled by ``|v_t| / sqrt(delta^2 + |v_t|^2)``, so keep it well under the slip speeds in the scene. Must be positive. Defaults to 1.0e-3.
             use_tile_gemm: Whether to use operators from Warp's Tile API to solve for joint accelerations. Defaults to False.
             fuse_cholesky: Whether to fuse the Cholesky decomposition into the inertia matrix evaluation kernel when using the Tile API. Only used if `use_tile_gemm` is true. Defaults to True.
             deterministic: Opt-in determinism for this solver's atomic-emitting
@@ -157,6 +159,8 @@ class SolverFeatherstone(SolverBase, CouplingInterface):
                 ``None`` (default) to inherit the current
                 ``wp.config.deterministic`` mode.
         """
+        if not math.isfinite(friction_smoothing) or friction_smoothing <= 0.0:
+            raise ValueError(f"friction_smoothing must be finite and > 0 (got {friction_smoothing}).")
         super().__init__(model)
         effective_deterministic = deterministic if deterministic is not None else wp.config.deterministic
         if model.joint_count > 0:

--- a/newton/_src/solvers/semi_implicit/kernels_contact.py
+++ b/newton/_src/solvers/semi_implicit/kernels_contact.py
@@ -533,8 +533,10 @@ def eval_body_contact(
     # Coulomb friction (smooth, but gradients are numerically unstable around |vt| = 0)
     ft = wp.vec3(0.0)
     if d < 0.0:
-        # use a smooth vector norm to avoid gradient instability at/around zero velocity
-        vs = wp.norm_huber(vt, delta=friction_smoothing)
+        # vs has to be a real norm, otherwise fr is not a unit vector and the cone is
+        # scaled by whatever |fr| happens to be. wp.norm_huber returns 0.5 * |vt|^2
+        # below its delta, which scales it by 2 / |vt|. See particle_force above.
+        vs = wp.norm_pseudo_huber(vt, delta=friction_smoothing)
         if vs > 0.0:
             fr = vt / vs
             ft = fr * wp.min(kf * vs, -mu * (fn + fd))
@@ -602,7 +604,7 @@ def eval_body_contact_forces(
     model: Model,
     state: State,
     contacts: Contacts | None,
-    friction_smoothing: float = 1.0,
+    friction_smoothing: float = 1.0e-3,
     force_in_world_frame: bool = False,
     body_f_out: wp.array | None = None,
     body_q: wp.array | None = None,

--- a/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
+++ b/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import warp as wp
 
 from ...core.types import override
@@ -75,7 +77,7 @@ class SolverSemiImplicit(SolverBase, CouplingInterface):
         model: Model,
         *,
         angular_damping: float = 0.05,
-        friction_smoothing: float = 1.0,
+        friction_smoothing: float = 1.0e-3,
         joint_attach_ke: float = 1.0e4,
         joint_attach_kd: float = 1.0e2,
         enable_tri_contact: bool = True,
@@ -85,7 +87,7 @@ class SolverSemiImplicit(SolverBase, CouplingInterface):
         Args:
             model: The model to be simulated.
             angular_damping: Angular damping factor to be used in rigid body integration. Defaults to 0.05.
-            friction_smoothing: Huber norm delta used for friction velocity normalization (see :func:`warp.norm_huber() <warp._src.lang.norm_huber>`). Defaults to 1.0.
+            friction_smoothing: Slip speed [m/s] below which friction fades out, passed as ``delta`` to :func:`warp.norm_pseudo_huber`. Friction is ``min(kf * |v_t|, mu * |f_n|)`` scaled by ``|v_t| / sqrt(delta^2 + |v_t|^2)``, so keep it well under the slip speeds in the scene. Must be positive. Defaults to 1.0e-3.
             joint_attach_ke: Joint attachment spring stiffness. Defaults to 1.0e4.
             joint_attach_kd: Joint attachment spring damping. Defaults to 1.0e2.
             enable_tri_contact: Enable triangle contact. Defaults to True.
@@ -94,6 +96,8 @@ class SolverSemiImplicit(SolverBase, CouplingInterface):
                 ``None`` (default) to inherit the current
                 ``wp.config.deterministic`` mode.
         """
+        if not math.isfinite(friction_smoothing) or friction_smoothing <= 0.0:
+            raise ValueError(f"friction_smoothing must be finite and > 0 (got {friction_smoothing}).")
         super().__init__(model=model)
         effective_deterministic = deterministic if deterministic is not None else wp.config.deterministic
         deterministic_modules = []

--- a/newton/tests/test_rigid_contact.py
+++ b/newton/tests/test_rigid_contact.py
@@ -156,14 +156,12 @@ def test_shapes_on_plane(test, device, solver_fn):
         solver = newton.solvers.SolverFeatherstone(
             model,
             angular_damping=0.15,  # Increased for more rotational stability
-            friction_smoothing=2.0,  # Increased from default 1.0 for smoother friction
         )
     elif isinstance(temp_solver, newton.solvers.SolverSemiImplicit):
         # Recreate with stability parameters for SemiImplicit
         solver = newton.solvers.SolverSemiImplicit(
             model,
             angular_damping=0.15,  # Increased from default 0.05 for more rotational stability
-            friction_smoothing=2.0,  # Increased from default 1.0 for smoother friction
         )
     else:
         solver = temp_solver

--- a/newton/tests/test_rigid_contact_friction_cone.py
+++ b/newton/tests/test_rigid_contact_friction_cone.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Friction tests for the penalty contact kernel used by SemiImplicit and Featherstone.
+
+The kernel evaluates min(kf * |vt|, mu * |fn|) in the direction of vt, with the
+direction smoothed by wp.norm_pseudo_huber. That costs a factor
+|vt| / sqrt(delta^2 + |vt|^2), so friction_smoothing has to stay small.
+
+The kernel is launched on hand-built arrays instead of going through a solver,
+so a failure here is a failure of the force law and nothing else.
+"""
+
+import inspect
+import math
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton._src.solvers.semi_implicit.kernels_contact import eval_body_contact
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+PENETRATION = 1.0e-5  # m
+CONTACT_KE = 2.0e4  # N/m
+CONTACT_KD = 3.0  # N·s/m
+CONTACT_KF = 1.0e3  # N·s/m, the ShapeConfig default
+CONTACT_MU = 0.9
+CONTACT_OFFSET_X = 0.25  # m, lever arm for the spin case
+
+NORMAL_FORCE = CONTACT_KE * PENETRATION  # 0.2 N, exact while the normal velocity is zero
+CONE = CONTACT_MU * NORMAL_FORCE  # 0.18 N
+TRANSITION = CONE / CONTACT_KF  # 0.18 mm/s, where the stick branch gives way
+
+SLIP_SPEEDS = (0.5, 0.1, 0.05, 0.02, 0.005, 0.001, 0.0)
+SHARP_SMOOTHING = 1.0e-5  # small enough that the fade is not measurable
+
+
+def solver_default():
+    """Return the friction_smoothing default, which both solvers must agree on."""
+    solvers = (newton.solvers.SolverSemiImplicit, newton.solvers.SolverFeatherstone)
+    defaults = {s.__name__: inspect.signature(s.__init__).parameters["friction_smoothing"].default for s in solvers}
+    assert len(set(defaults.values())) == 1, defaults
+    return next(iter(defaults.values()))
+
+
+DEFAULT_SMOOTHING = solver_default()
+
+
+def expected_friction(slip, smoothing, cone=CONE):
+    """Return the friction magnitude the force law prescribes."""
+    vs = math.hypot(slip, smoothing)
+    return min(CONTACT_KF * vs, cone) * slip / vs
+
+
+def contact_force(device, v=(0.0, 0.0, 0.0), w=(0.0, 0.0, 0.0), smoothing=None, grad=False):
+    """Launch the kernel on one contact and return the force on body 0.
+
+    Returns the force plus the input and output arrays, so the gradient test can
+    replay the launch under a tape.
+    """
+
+    def arr(values, dtype):
+        return wp.array(np.array(values, dtype=np.float32), dtype=dtype, device=device, requires_grad=grad)
+
+    def iarr(values):
+        return wp.array(np.array(values, dtype=np.int32), dtype=int, device=device)
+
+    body_qd = arr([[*v, *w]], wp.spatial_vector)  # [linear at com; angular]
+    body_f = wp.zeros(1, dtype=wp.spatial_vector, device=device, requires_grad=grad)
+
+    # The contact sits off the origin so a spin about z has a lever arm. The
+    # penetration d = dot(n, point0 - point1) stays -PENETRATION either way.
+    wp.launch(
+        eval_body_contact,
+        dim=1,
+        device=device,
+        outputs=[body_f],
+        inputs=[
+            arr([wp.transform_identity()], wp.transform),
+            body_qd,
+            arr([[0.0, 0.0, 0.0]], wp.vec3),
+            arr([CONTACT_KE] * 2, float),
+            arr([CONTACT_KD] * 2, float),
+            arr([CONTACT_KF] * 2, float),
+            arr([0.0] * 2, float),  # ka, no adhesion
+            arr([CONTACT_MU] * 2, float),
+            iarr([0, -1]),  # shape 0 on body 0, shape 1 static
+            iarr([1]),  # contact count
+            arr([[CONTACT_OFFSET_X, 0.0, -PENETRATION]], wp.vec3),
+            arr([[CONTACT_OFFSET_X, 0.0, 0.0]], wp.vec3),
+            arr([[0.0, 0.0, -1.0]], wp.vec3),  # normal, A to B
+            iarr([0]),
+            iarr([1]),
+            arr([0.0], float),
+            arr([0.0], float),
+            None,  # no per-contact stiffness, damping or friction
+            None,
+            None,
+            False,  # force_in_world_frame
+            DEFAULT_SMOOTHING if smoothing is None else smoothing,
+        ],
+    )
+    return body_f.numpy()[0][:3].copy(), body_qd, body_f
+
+
+def sliding_force(device, slip, smoothing):
+    """Return the normal and friction magnitudes for a purely tangential slip."""
+    force, _, _ = contact_force(device, v=(slip, 0.0, 0.0), smoothing=smoothing)
+    return float(force[2]), float(np.linalg.norm(force[:2]))
+
+
+def test_friction_matches_the_force_law(test, device):
+    """Verify friction equals min(kf * |vt|, mu * |fn|) after the smoothing fade."""
+    for smoothing in (DEFAULT_SMOOTHING, SHARP_SMOOTHING):
+        for slip in SLIP_SPEEDS:
+            normal, friction = sliding_force(device, slip, smoothing)
+            test.assertAlmostEqual(normal, NORMAL_FORCE, delta=1.0e-6)
+            expected = expected_friction(slip, smoothing)
+            test.assertAlmostEqual(
+                friction,
+                expected,
+                delta=max(1.0e-4 * CONE, 1.0e-3 * expected),
+                msg=f"{friction:.6g} N, expected {expected:.6g} N at {slip * 1e3:g} mm/s, delta={smoothing:g}",
+            )
+
+
+def test_friction_stays_inside_the_cone(test, device):
+    """Verify friction never exceeds mu * |fn|, at any slip speed."""
+    for smoothing in (DEFAULT_SMOOTHING, SHARP_SMOOTHING, 1.0):
+        for slip in SLIP_SPEEDS:
+            _, friction = sliding_force(device, slip, smoothing)
+            test.assertLessEqual(
+                friction,
+                CONE * (1.0 + 1.0e-4),
+                msg=f"{friction:.4g} N over the {CONE:.4g} N cone at {slip * 1e3:g} mm/s, delta={smoothing:g}",
+            )
+
+
+def test_default_smoothing_reaches_the_cone(test, device):
+    """Verify the shipped default still lets friction saturate at realistic slip speeds."""
+    for slip, floor in ((0.02, 0.99), (0.001, 0.50)):
+        _, friction = sliding_force(device, slip, DEFAULT_SMOOTHING)
+        test.assertGreaterEqual(
+            friction,
+            floor * CONE,
+            msg=f"only {friction / CONE:.1%} of the cone at {slip * 1e3:g} mm/s, delta={DEFAULT_SMOOTHING:g}",
+        )
+
+
+def test_friction_is_linear_below_the_transition(test, device):
+    """Verify friction is kf * vt while the stick branch holds."""
+    for slip in (0.2 * TRANSITION, 0.5 * TRANSITION, 0.9 * TRANSITION):
+        _, friction = sliding_force(device, slip, SHARP_SMOOTHING)
+        test.assertAlmostEqual(friction, CONTACT_KF * slip, delta=1.0e-3 * CONTACT_KF * slip)
+
+
+def test_friction_opposes_the_slip(test, device):
+    """Verify friction is antiparallel to vt for an off-axis slip."""
+    slip = np.array([0.03, -0.04, 0.0])  # 50 mm/s, both tangential axes in play
+    force, _, _ = contact_force(device, v=tuple(slip))
+    expected = -slip[:2] / np.linalg.norm(slip) * expected_friction(float(np.linalg.norm(slip)), DEFAULT_SMOOTHING)
+    np.testing.assert_allclose(force[:2], expected, rtol=1.0e-3, atol=1.0e-6)
+    test.assertAlmostEqual(float(force[2]), NORMAL_FORCE, delta=1.0e-6)
+
+
+def test_damping_widens_the_cone(test, device):
+    """Verify the cone follows the damped normal force fn + fd, not ke * penetration."""
+    approach = 0.5  # m/s along -z
+    force, _, _ = contact_force(device, v=(0.02, 0.0, -approach))
+
+    normal = NORMAL_FORCE + CONTACT_KD * approach
+    test.assertAlmostEqual(float(force[2]), normal, delta=1.0e-5)
+
+    cone = CONTACT_MU * normal
+    friction = float(np.linalg.norm(force[:2]))
+    test.assertAlmostEqual(friction, expected_friction(0.02, DEFAULT_SMOOTHING, cone), delta=1.0e-3 * cone)
+    test.assertGreater(friction, CONE)
+
+
+def test_spin_produces_friction(test, device):
+    """Verify slip from an angular velocity at an offset contact is resisted."""
+    spin = 0.08  # rad/s about +z, so vt = (0, spin * offset, 0) = 20 mm/s
+    force, _, _ = contact_force(device, w=(0.0, 0.0, spin))
+    expected = expected_friction(spin * CONTACT_OFFSET_X, DEFAULT_SMOOTHING)
+    np.testing.assert_allclose(force[:2], [0.0, -expected], rtol=1.0e-3, atol=1.0e-6)
+
+
+def test_friction_falls_off_as_the_contact_slows(test, device):
+    """Verify friction shrinks towards zero as vt does, instead of growing."""
+    for smoothing in (DEFAULT_SMOOTHING, 1.0):
+        previous = float("inf")
+        for slip in SLIP_SPEEDS:  # descending
+            _, friction = sliding_force(device, slip, smoothing)
+            test.assertLessEqual(
+                friction,
+                previous + 1.0e-9,
+                msg=f"grew from {previous:.4g} to {friction:.4g} N at {slip * 1e3:g} mm/s, delta={smoothing:g}",
+            )
+            previous = friction
+        test.assertAlmostEqual(previous, 0.0, delta=1.0e-9)
+
+
+def test_friction_gradient_is_finite_at_zero_slip(test, device):
+    """Verify the friction gradient stays finite at and around vt = 0."""
+    seed = wp.array(
+        np.array([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype=np.float32), dtype=wp.spatial_vector, device=device
+    )
+    ceiling = 10.0 * max(CONTACT_KF, CONE / DEFAULT_SMOOTHING)
+    for slip in (0.0, 1.0e-9, SHARP_SMOOTHING, 0.01):
+        tape = wp.Tape()
+        with tape:
+            _, body_qd, body_f = contact_force(device, v=(slip, 0.0, 0.0), grad=True)
+        tape.backward(grads={body_f: seed})
+        grad = body_qd.grad.numpy()[0]
+        test.assertTrue(np.all(np.isfinite(grad)), f"{grad} at {slip:g} m/s")
+        test.assertLess(float(np.max(np.abs(grad))), ceiling, f"{grad} at {slip:g} m/s")
+        tape.zero()
+
+
+devices = get_test_devices()
+
+
+class TestRigidContactFrictionCone(unittest.TestCase):
+    pass
+
+
+for _test in (
+    test_friction_matches_the_force_law,
+    test_friction_stays_inside_the_cone,
+    test_default_smoothing_reaches_the_cone,
+    test_friction_is_linear_below_the_transition,
+    test_friction_opposes_the_slip,
+    test_damping_widens_the_cone,
+    test_spin_produces_friction,
+    test_friction_falls_off_as_the_contact_slows,
+    test_friction_gradient_is_finite_at_zero_slip,
+):
+    add_function_test(TestRigidContactFrictionCone, _test.__name__, _test, devices=devices)
+
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2)

--- a/newton/tests/test_rigid_friction_ramp.py
+++ b/newton/tests/test_rigid_friction_ramp.py
@@ -51,6 +51,12 @@ BOX_HY = 0.2
 BOX_HZ = 0.05
 BOX_GAP = 0.001  # initial offset above the ramp surface to avoid initial contact transient
 VBD_STOPPING_CONTACT_KE = 1.0e6  # Near-rigid normal for VBD kinetic-friction oracle
+# Stick stiffness [N·s/m] for SemiImplicit and Featherstone. Their stick branch is
+# viscous, so a box below the critical angle creeps at v = m g sin(theta) / kf
+# instead of stopping. The grid box is 16 kg, so at 40 deg that is 10 mm/s, or
+# 2.5 mm over the measurement window. The ShapeConfig default of 1e3 creeps 25 mm
+# and fails eps_pos.
+PENALTY_CONTACT_KF = 1.0e4
 
 SIM_DT = 1.0 / 60.0
 SIM_SUBSTEPS = 30
@@ -85,6 +91,9 @@ _DEFAULT_THRESHOLDS = _Thresholds(margin_deg=2.0, v_rest=0.10, eps_pos=0.02, min
 # VBD's min_slide is loose: finite-step / finite-iteration contact error can
 # creep borderline cells a few mm in 0.25 s rather than sliding fully.
 _VBD_THRESHOLDS = _Thresholds(margin_deg=5.0, v_rest=0.12, eps_pos=0.10, min_slide=0.005)
+# Creep is ~2.5 mm so eps_pos stays at the default, but v_rest is tightened:
+# creep speed is the clearest signal that the cone is binding.
+_PENALTY_THRESHOLDS = _Thresholds(margin_deg=2.0, v_rest=0.05, eps_pos=0.02, min_slide=0.02)
 
 # --- Stopping-distance config ---
 
@@ -373,8 +382,11 @@ def test_friction_stopping_distance(
 devices = get_test_devices()
 cuda_devices = get_selected_cuda_test_devices()
 
-# Featherstone and SemiImplicit use viscous (kf) friction rather than Coulomb,
-# so the critical-angle criterion does not apply; excluded here.
+# SemiImplicit and Featherstone evaluate min(kf * |v_t|, mu * |f_n|), which is a
+# Coulomb cone, so the critical-angle criterion applies to them too. They creep
+# rather than stick, so PENALTY_CONTACT_KF keeps the creep inside eps_pos. The
+# viscous tail rules out the stopping-distance oracle, same as
+# mujoco_warp_newton_contacts below.
 # stopping_distance_rel_tol: per-solver tolerance on d_measured/d_expected. Coulomb-cone
 # solvers (XPBD, MuJoCo) hit ~0.05-0.2% in practice. VBD still has finite-step and
 # finite-iteration error, so keep a small empirical margin above the precise
@@ -458,6 +470,22 @@ _SOLVERS = {
         "stopping_distance_contact_ke": VBD_STOPPING_CONTACT_KE,
         "stopping_distance_rel_tol": 0.02,
         "stopping_distance_rest_speed_max": STOPPING_REST_SPEED_MAX,
+    },
+    "semi_implicit": {
+        "factory": newton.solvers.SolverSemiImplicit,
+        "mus": _DEFAULT_MUS,
+        "angles_deg": _DEFAULT_ANGLES_DEG,
+        "thresholds": _PENALTY_THRESHOLDS,
+        "friction_ramp_contact_kf": PENALTY_CONTACT_KF,
+        "run_stopping_distance": False,
+    },
+    "featherstone": {
+        "factory": newton.solvers.SolverFeatherstone,
+        "mus": _DEFAULT_MUS,
+        "angles_deg": _DEFAULT_ANGLES_DEG,
+        "thresholds": _PENALTY_THRESHOLDS,
+        "friction_ramp_contact_kf": PENALTY_CONTACT_KF,
+        "run_stopping_distance": False,
     },
     "kamino": {
         "factory": newton.solvers.SolverKamino,


### PR DESCRIPTION
> **Draft, still in progress.** Opening it early for visibility so the approach can be
> discussed before I polish it. The fix and the tests are complete and passing, but I have
> only run them on Windows with an RTX 5080, not on the Linux CI, and I would like input on
> whether lowering the `friction_smoothing` default belongs in this PR or a separate one.

## Description

`eval_body_contact` is the penalty contact kernel behind `SolverSemiImplicit` and
`SolverFeatherstone`. It builds the friction direction like this:

```python
vs = wp.norm_huber(vt, delta=friction_smoothing)
fr = vt / vs
ft = fr * wp.min(kf * vs, -mu * (fn + fd))
```

`fr` is only a unit vector when `vs == |vt|`, and `norm_huber` is not a norm below its
delta. It returns `0.5*|vt|^2` there, which is a squared length, so `|fr|` becomes
`2/|vt|` and the cone is scaled by that. The slower the contact, the worse it gets. On one
contact with 0.2 N of normal force and `mu=0.9`, so a 0.18 N cone:

| slip | friction | vs cone |
|---|---|---|
| 500 mm/s | 0.72 N | 4x |
| 100 mm/s | 3.60 N | 20x |
| 20 mm/s | 18.0 N | 100x |

This uses `wp.norm_pseudo_huber` instead, which is `sqrt(delta^2 + |vt|^2)`. `particle_force`
in the same file already uses a plain `wp.length`. The bug comes from `warp.sim` and
predates the public API refactor (#519).

The norm on its own is not enough, which is why the default moves in the same commit.
`friction_smoothing` is a slip speed in m/s, and the law works out to
`min(kf*|vt|, mu*|fn|) * |vt| / sqrt(delta^2 + |vt|^2)`, so the old default of 1.0 leaves
2% of the cone at 20 mm/s. That trades far too much friction for far too little, and four
of the new tests still fail on it. Lowering it to 1.0e-3 tracks the ideal law to within
0.5% across the range. Splitting the two would leave a commit with failing tests.
`friction_smoothing <= 0` now raises instead of giving NaN forces, which
`norm_pseudo_huber` would.

`test_rigid_friction_ramp` excluded these two solvers for using *"viscous (kf) friction
rather than Coulomb"*. That was really this bug. The cone is in the kernel, it just never
bound. Both solvers are registered there now and pass the `(mu, theta)` grid.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

RTX 5080, CPU and CUDA, warp 1.17.0.dev20260807.

```
uv run --extra dev -m newton.tests -k test_rigid_contact_friction_cone   # 18 pass
uv run --extra dev -m newton.tests -k test_rigid_friction_ramp           # 29 pass
uv run --extra dev -m newton.tests -k test_rigid_contact                 # 64 pass
uv run --extra dev -m newton.tests -k diffsim                            # 12 pass
```

Running the new tests against unmodified source:

| source | force law tests | ramp, penalty solvers |
|---|---|---|
| main, `norm_huber` + delta 1.0 | 12 of 18 fail | both fail |
| norm fixed, delta still 1.0 | 4 of 18 fail | - |
| this PR | 18 pass | 29 pass |

The diffsim examples were the risk in lowering delta, since it sharpens the friction
derivative near zero slip, and `example_diffsim_ball` checks analytic gradients against
finite differences at `tol=5e-2`. They are unaffected.

This was run on Windows and Python 3.12, not the Linux CI. The ramp and `shapes_on_plane`
tests key off settling dynamics with tolerances, so treat it as strong evidence rather
than proof that CI agrees.

## Bug fix

**Steps to reproduce:**

1. Put a box with `mu = 0.1` on a 40 degree ramp under `SolverSemiImplicit` or
   `SolverFeatherstone`.
2. Run it for 0.75 s.
3. It does not slide. The critical angle for `mu = 0.1` is 5.7 degrees, so it should slide
   freely, but the friction holds it in place. On main it moves 1.2 mm.

That is how both solvers fail `test_friction_ramp` on main:

```
(mu=0.10, theta=40.0deg, crit=5.7deg): expected sliding but disp=0.0011 < 0.02
```

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

from newton._src.solvers.semi_implicit.kernels_contact import eval_body_contact

# One contact, 0.2 N of normal force, mu = 0.9, so the cone is 0.18 N.
# Slide it sideways at 20 mm/s and read back the friction.
device = wp.get_device("cpu")


def arr(values, dtype):
    return wp.array(np.array(values, dtype=np.float32), dtype=dtype, device=device)


def iarr(values):
    return wp.array(np.array(values, dtype=np.int32), dtype=int, device=device)


body_f = wp.zeros(1, dtype=wp.spatial_vector, device=device)
wp.launch(
    eval_body_contact,
    dim=1,
    device=device,
    outputs=[body_f],
    inputs=[
        arr([wp.transform_identity()], wp.transform),
        arr([[0.02, 0, 0, 0, 0, 0]], wp.spatial_vector),
        arr([[0, 0, 0]], wp.vec3),
        arr([2.0e4] * 2, float),
        arr([3.0] * 2, float),
        arr([1.0e3] * 2, float),
        arr([0.0] * 2, float),
        arr([0.9] * 2, float),
        iarr([0, -1]),
        iarr([1]),
        arr([[0, 0, -1.0e-5]], wp.vec3),
        arr([[0, 0, 0]], wp.vec3),
        arr([[0, 0, -1.0]], wp.vec3),
        iarr([0]),
        iarr([1]),
        arr([0.0], float),
        arr([0.0], float),
        None,
        None,
        None,
        False,
        1.0,  # friction_smoothing, the old default
    ],
)
print(np.linalg.norm(body_f.numpy()[0][:2]))

# main, delta=1.0       -> 17.999998   100x the 0.18 N cone
# this PR, delta=1.0    ->  0.0035993  2% of it, which is why the default moves too
# this PR, delta=1.0e-3 ->  0.1797754  the cone
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved rigid-body friction behavior for Semi-Implicit and Featherstone solvers using smoother tangential velocity handling.
  - Updated the default friction smoothing value for more accurate Coulomb-cone behavior.
  - Explicit friction smoothing values should be scaled proportionally when migrating.

- **Bug Fixes**
  - Prevented friction forces from exceeding the Coulomb friction limit.
  - Invalid smoothing values now raise a clear `ValueError` instead of producing invalid forces.
  - Improved friction behavior and gradients near zero slip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->