### PR TITLE
Preserve collision extension compatibility

### DIFF
--- a/changelog/+collision-extension-compatibility-5f8d2c1a.fixed.md
+++ b/changelog/+collision-extension-compatibility-5f8d2c1a.fixed.md
@@ -1,0 +1,1 @@
+Preserve the Newton 1.5 broad-phase and narrow-phase extension call contracts unless speculative contacts are enabled.

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1904,6 +1904,7 @@ class CollisionPipeline:
             )
 
         # Run broad phase (AABBs are already expanded by effective gaps, so pass None)
+        broad_phase_speculative_kwargs = {"shape_displacement": self._shape_displacement} if speculative_active else {}
         if isinstance(self.broad_phase, BroadPhaseAllPairs):
             self.broad_phase.launch(
                 self.narrow_phase.shape_aabb_lower,
@@ -1921,9 +1922,11 @@ class CollisionPipeline:
                 filter_pairs=self.shape_pairs_excluded,
                 num_filter_pairs=self.shape_pairs_excluded_count,
                 skip_count_zero=True,  # Already zeroed by compute_shape_aabbs
-                shape_displacement=self._shape_displacement if speculative_active else None,
+                **broad_phase_speculative_kwargs,
             )
         elif isinstance(self.broad_phase, BroadPhaseSAP):
+            if speculative_active:
+                broad_phase_speculative_kwargs["sort_axis_displacement_limit"] = max_speculative_extension
             self.broad_phase.launch(
                 self.narrow_phase.shape_aabb_lower,
                 self.narrow_phase.shape_aabb_upper,
@@ -1940,8 +1943,7 @@ class CollisionPipeline:
                 filter_pairs=self.shape_pairs_excluded,
                 num_filter_pairs=self.shape_pairs_excluded_count,
                 skip_count_zero=True,  # Already zeroed by compute_shape_aabbs
-                shape_displacement=self._shape_displacement if speculative_active else None,
-                sort_axis_displacement_limit=max_speculative_extension if speculative_active else None,
+                **broad_phase_speculative_kwargs,
             )
         else:  # BroadPhaseExplicit
             self.broad_phase.launch(
@@ -1957,7 +1959,7 @@ class CollisionPipeline:
                 include_static_kinematic_pairs=self.include_static_kinematic_pairs,
                 device=self.device,
                 skip_count_zero=True,  # Already zeroed by compute_shape_aabbs
-                shape_displacement=self._shape_displacement if speculative_active else None,
+                **broad_phase_speculative_kwargs,
             )
 
         # Create ContactWriterData struct for custom contact writing
@@ -1996,6 +1998,21 @@ class CollisionPipeline:
         writer_data.collision_update_dt = collision_update_dt
         writer_data.max_speculative_extension = max_speculative_extension
         # Run narrow phase with custom contact writer (writes directly to Contacts format)
+        narrow_phase_extension_kwargs = {}
+        if type(self.narrow_phase).launch_custom_write is NarrowPhase.launch_custom_write:
+            narrow_phase_extension_kwargs.update(
+                mesh_edge_centers=model.mesh_edge_centers,
+                mesh_edge_halves=model.mesh_edge_halves,
+                hydroelastic_shape_sdf_data_prepared=self._hydro_shape_sdf_data_prepared,
+            )
+        if self._speculative_enabled:
+            narrow_phase_extension_kwargs.update(
+                shape_base_gap=model.shape_gap,
+                shape_linear_velocity=self._shape_linear_velocity,
+                shape_angular_velocity=self._shape_angular_velocity,
+                collision_update_dt=collision_update_dt,
+                max_speculative_extension=max_speculative_extension,
+            )
         self.narrow_phase.launch_custom_write(
             candidate_pair=self.broad_phase_shape_pairs,
             candidate_pair_count=self.broad_phase_pair_count,
@@ -2007,7 +2024,6 @@ class CollisionPipeline:
             shape_sdf_index=model._shape_sdf_index,
             texture_sdf_data=model._texture_sdf_data,
             shape_gap=search_gap,
-            shape_base_gap=model.shape_gap,
             shape_collision_radius=model.shape_collision_radius,
             shape_flags=model.shape_flags,
             shape_collision_aabb_lower=model.shape_collision_aabb_lower,
@@ -2017,16 +2033,10 @@ class CollisionPipeline:
             heightfield_data=model.heightfield_data,
             heightfield_elevations=model.heightfield_elevations,
             mesh_edge_indices=model.mesh_edge_indices,
-            mesh_edge_centers=model.mesh_edge_centers,
-            mesh_edge_halves=model.mesh_edge_halves,
             shape_edge_range=model.shape_edge_range,
             writer_data=writer_data,
-            hydroelastic_shape_sdf_data_prepared=self._hydro_shape_sdf_data_prepared,
-            shape_linear_velocity=self._shape_linear_velocity,
-            shape_angular_velocity=self._shape_angular_velocity,
-            collision_update_dt=collision_update_dt,
-            max_speculative_extension=max_speculative_extension,
             device=self.device,
+            **narrow_phase_extension_kwargs,
         )
 
         # Match contacts against previous frame before sorting.

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -45,6 +45,7 @@ from newton._src.sim.collide import (
 )
 from newton._src.utils.heightfield import HeightfieldData
 from newton.examples import test_body_state
+from newton.geometry import BroadPhaseAllPairs, NarrowPhase
 from newton.tests.unittest_utils import (
     add_function_test,
     configure_sdf_for_collision_shapes,
@@ -250,6 +251,52 @@ devices = get_cuda_test_devices(mode="basic")
 
 
 class TestCollisionPipeline(unittest.TestCase):
+    def test_legacy_expert_components_ignore_unconfigured_extension_inputs(self):
+        """Preserve the Newton 1.5 expert-component call contract by default."""
+
+        class LegacyBroadPhase(BroadPhaseAllPairs):
+            def __init__(self, wrapped):
+                self.__dict__ = wrapped.__dict__
+
+            def launch(self, *args, **kwargs):
+                if "shape_displacement" in kwargs:
+                    raise TypeError("Newton 1.5 broad phases do not accept shape_displacement")
+                return super().launch(*args, **kwargs)
+
+        class LegacyNarrowPhase(NarrowPhase):
+            def __init__(self, wrapped):
+                self.__dict__ = wrapped.__dict__
+
+            def launch_custom_write(self, **kwargs):
+                new_parameters = {
+                    "collision_update_dt",
+                    "hydroelastic_shape_sdf_data_prepared",
+                    "max_speculative_extension",
+                    "mesh_edge_centers",
+                    "mesh_edge_halves",
+                    "shape_angular_velocity",
+                    "shape_base_gap",
+                    "shape_linear_velocity",
+                }
+                unexpected = new_parameters.intersection(kwargs)
+                if unexpected:
+                    raise TypeError(f"Newton 1.5 narrow phases do not accept {sorted(unexpected)}")
+                return super().launch_custom_write(**kwargs)
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+        pipeline = newton.CollisionPipeline(model, broad_phase="nxn")
+        pipeline.broad_phase = LegacyBroadPhase(pipeline.broad_phase)
+        pipeline.narrow_phase = LegacyNarrowPhase(pipeline.narrow_phase)
+        contacts = pipeline.contacts()
+
+        pipeline.collide(model.state(), contacts)
+
+        self.assertGreater(int(contacts.rigid_contact_count.numpy()[0]), 0)
+
     def test_model_collision_helpers_deprecated(self):
         builder = newton.ModelBuilder()
         builder.add_ground_plane()


### PR DESCRIPTION
## Description

Preserve the Newton 1.5 collision extension contract for custom broad- and narrow-phase implementations.

Speculative-contact support added optional inputs to the built-in `BroadPhase*.launch()` and `NarrowPhase.launch_custom_write()` methods. `CollisionPipeline` previously passed these new keywords even when speculative contacts were disabled. A custom implementation overriding the Newton 1.5 signature would therefore fail with an unexpected-keyword `TypeError`.

This change:

- Passes broad-phase motion inputs only when speculative contacts are active.
- Passes narrow-phase speculative inputs only when speculative contacts are configured.
- Continues passing preprocessing caches to the built-in `NarrowPhase`.
- Avoids passing post-1.5 preprocessing inputs to custom narrow-phase overrides.
- Adds regression coverage representing 1.5-compatible expert components.

### Questions for reviewers

1. **Should internal broad- and narrow-phase fields use `_` prefixes?**

   The release audit also identified runtime-owned preprocessing fields exposed without an underscore, including fields removed since 1.5. Should implementation buffers and counters on public expert classes consistently use `_` prefixes so they are not mistaken for supported API?

   This PR does not rename any fields.

2. **Should inward-edge filtering be opt-in or opt-out?**

   `Mesh.build_sdf()` now enables inward-edge filtering by default through `edge_inward_filter=True`. This is an opt-out design: users who need the Newton 1.5 contact set can pass `edge_inward_filter=False`.

   I prefer retaining this opt-out behavior: fully inward manifold edges should not contribute meaningful contacts, so filtering them by default avoids redundant work and contacts for most users. The compatibility tradeoff is that changing the default can alter the generated contact set for existing scenes. Do reviewers agree that opt-out is the right default for 1.6, given that `edge_inward_filter=False` preserves the earlier behavior, or should the filter initially require explicit opt-in?

   This PR does not change the inward-edge filtering default.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a changelog fragment has been added

## Test plan

```text
uv run --extra dev -m newton.tests -k test_legacy_expert_components_ignore_unconfigured_extension_inputs
uv run --extra dev -m newton.tests -k test_speculative_candidates_are_opt_in
uvx pre-commit run -a
```

The compatibility regression was verified to fail without the fix and pass with it. Speculative-contact tests pass on CPU and CUDA.

## Bug fix

**Steps to reproduce:**

1. Subclass a built-in broad or narrow phase.
2. Override `launch()` or `launch_custom_write()` using its Newton 1.5 signature.
3. Supply the expert component to a non-speculative `CollisionPipeline`.
4. Call `CollisionPipeline.collide()`.
5. Observe an unexpected-keyword `TypeError` for a post-1.5 input such as `shape_displacement`.

**Minimal reproduction:**

```python
class BroadPhase15(newton.geometry.BroadPhaseAllPairs):
    def launch(
        self,
        *args,
        device=None,
        filter_pairs=None,
        num_filter_pairs=None,
        skip_count_zero=False,
        shape_body=None,
        body_flags=None,
        include_static_kinematic_pairs=True,
    ):
        return super().launch(
            *args,
            device=device,
            filter_pairs=filter_pairs,
            num_filter_pairs=num_filter_pairs,
            skip_count_zero=skip_count_zero,
            shape_body=shape_body,
            body_flags=body_flags,
            include_static_kinematic_pairs=include_static_kinematic_pairs,
        )

# Before this PR, a non-speculative CollisionPipeline passes
# shape_displacement=None and the override raises TypeError.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved compatibility with Newton 1.5 broad-phase and narrow-phase extensions when speculative contacts are disabled.
  - Fixed collision processing for custom extension implementations that do not support newer optional arguments.
  - Ensured rigid contacts continue to be generated correctly with legacy-compatible collision components.

- **Documentation**
  - Added a changelog entry describing the extension compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->