### PR TITLE
Accept `label_prefixes` in `ModelBuilder.replicate()`

### DIFF
--- a/changelog/+replicate-label-prefixes-3b7f0c14.added.md
+++ b/changelog/+replicate-label-prefixes-3b7f0c14.added.md
@@ -1,1 +1,1 @@
-`ModelBuilder.replicate` accepts `label_prefixes`, applying a per-world label prefix the way `add_builder` and `add_world` already do. Pass `None` for a given world to leave its labels unchanged; omit the argument to leave all worlds unchanged, matching prior behavior.
+Add `label_prefixes` to `ModelBuilder.replicate`, applying a per-world label prefix the way `add_builder` and `add_world` already do. Pass `None` for a given world to leave its labels unchanged; omit the argument to leave all worlds unchanged, matching prior behavior.

--- a/changelog/+replicate-label-prefixes-3b7f0c14.added.md
+++ b/changelog/+replicate-label-prefixes-3b7f0c14.added.md
@@ -1,0 +1,1 @@
+`ModelBuilder.replicate` accepts `label_prefixes`, applying a per-world label prefix the way `add_builder` and `add_world` already do. Pass `None` for a given world to leave its labels unchanged; omit the argument to leave all worlds unchanged, matching prior behavior.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2603,6 +2603,7 @@ class ModelBuilder:
         spacing: tuple[float, float, float] = (0.0, 0.0, 0.0),
         *,
         xforms: Sequence[Transform] | None = None,
+        label_prefixes: Sequence[str | None] | None = None,
     ):
         """
         Replicates the given builder multiple times, offsetting each copy according to the supplied spacing.
@@ -2637,6 +2638,11 @@ class ModelBuilder:
                 Defaults to (0.0, 0.0, 0.0).
             xforms: Optional sequence of transforms, one per replicated world.
                 When provided, its length must equal ``world_count``.
+            label_prefixes: Optional prefix prepended to all labels from the source builder,
+                one per replicated world, applied as :meth:`add_builder` applies its
+                ``label_prefix``. Labels are joined with ``/``. A ``None`` entry leaves that
+                world's labels as they are in ``builder``; an empty source label remains
+                unlabeled.
         """
         if world_count <= 0:
             return
@@ -2650,10 +2656,14 @@ class ModelBuilder:
             xforms = [wp.transform(offset, wp.quat_identity()) for offset in offsets]
         elif len(xforms) != world_count:
             raise ValueError(f"xforms must contain {world_count} entries, got {len(xforms)}")
+        if label_prefixes is None:
+            label_prefixes = [None] * world_count
+        elif len(label_prefixes) != world_count:
+            raise ValueError(f"label_prefixes must contain {world_count} entries, got {len(label_prefixes)}")
 
         base_world = self.world_count
         worlds = list(range(base_world, base_world + world_count))
-        self._merge_builder_copies(builder, worlds, xforms, [None] * world_count)
+        self._merge_builder_copies(builder, worlds, xforms, label_prefixes)
 
         self.world_gravity.extend(builder._gravity_as_vector() for _ in range(world_count))
         self.world_count += world_count
@@ -2872,7 +2882,8 @@ class ModelBuilder:
             elif attr.endswith("_label"):
                 for label_prefix in label_prefixes:
                     if label_prefix:
-                        destination.extend(f"{label_prefix}/{label}" if label else label for label in source)
+                        rooted = label_prefix + "/"
+                        destination.extend([rooted + label if label else label for label in source])
                     else:
                         destination.extend(source)
             elif spec.references in {Model.AttributeFrequency.WORLD, "world"}:

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -623,6 +623,7 @@ class TestModelBuilderReplicateLabelPrefixes(unittest.TestCase):
         return builder
 
     def test_each_world_gets_its_own_prefix(self):
+        """Each replicated world's labels are prefixed with its own entry from label_prefixes."""
         scene = ModelBuilder()
         prefixes = [f"/World/envs/env_{index}/Robot" for index in range(3)]
         scene.replicate(self._source(), 3, label_prefixes=prefixes)
@@ -630,11 +631,13 @@ class TestModelBuilderReplicateLabelPrefixes(unittest.TestCase):
         self.assertEqual(scene.shape_label, [f"{prefix}/box" for prefix in prefixes])
 
     def test_a_none_prefix_leaves_that_world_alone(self):
+        """A None entry in label_prefixes copies that world's labels unprefixed."""
         scene = ModelBuilder()
         scene.replicate(self._source("root"), 2, label_prefixes=["left", None])
 
         self.assertEqual(scene.shape_label, ["left/root/box", "root/box"])
 
     def test_prefix_count_must_match_world_count(self):
+        """label_prefixes must have exactly one entry per replicated world."""
         with self.assertRaises(ValueError):
             ModelBuilder().replicate(self._source("root"), 2, label_prefixes=["only-one"])

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -609,3 +609,32 @@ add_function_test(
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestModelBuilderReplicateLabelPrefixes(unittest.TestCase):
+    """Per-world label prefixes on the batched replication path."""
+
+    @staticmethod
+    def _source(root: str = "") -> ModelBuilder:
+        """A two-link prototype whose labels are relative to ``root`` (empty names the root)."""
+        builder = ModelBuilder()
+        body = builder.add_link(xform=wp.transform(), label=root)
+        builder.add_shape_box(body=body, label=f"{root}/box" if root else "box")
+        return builder
+
+    def test_each_world_gets_its_own_prefix(self):
+        scene = ModelBuilder()
+        prefixes = [f"/World/envs/env_{index}/Robot" for index in range(3)]
+        scene.replicate(self._source(), 3, label_prefixes=prefixes)
+
+        self.assertEqual(scene.shape_label, [f"{prefix}/box" for prefix in prefixes])
+
+    def test_a_none_prefix_leaves_that_world_alone(self):
+        scene = ModelBuilder()
+        scene.replicate(self._source("root"), 2, label_prefixes=["left", None])
+
+        self.assertEqual(scene.shape_label, ["left/root/box", "root/box"])
+
+    def test_prefix_count_must_match_world_count(self):
+        with self.assertRaises(ValueError):
+            ModelBuilder().replicate(self._source("root"), 2, label_prefixes=["only-one"])


### PR DESCRIPTION
## Description
`ModelBuilder.add_world()` accepts `label_prefix` as a prefix for all labels in the child builder. This PR exposes the analogous `label_prefixes` for the batched `ModelBuilder.replicate()` function, ensuring that objects can be disambiguated by world also when using the batched path.

Without this, the batched replicate path requires callers to rewrite labels themselves, unlike the single-world `add_builder` path.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan
```
uv run --extra dev -m newton.tests -k test_builder_replicate
```

## New feature / API change
```python
import newton

robot = newton.ModelBuilder()
robot.add_body(...)

main = newton.ModelBuilder()
main.add_world(robot, label_prefix="/World_0")  # All robot entities -> world 0
main.replicate(robot, world_count=2, label_prefixes=["/World_1", "/World_2"])  # Add more worlds from the same source
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-world label prefixes when replicating models.
  * Supports leaving individual worlds unchanged with `None`.
  * Existing behavior is preserved when prefixes are omitted.
  * Validates that the number of prefixes matches the number of replicated worlds.
  * Applies prefixes consistently to entities created in each world.

* **Tests**
  * Added coverage for per-world prefixes, unchanged worlds, and invalid prefix counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->