### PR TITLE
Add scene attributes for Kamino assets

### DIFF
--- a/newton/tests/assets/kamino/basics/box_on_plane.usda
+++ b/newton/tests/assets/kamino/basics/box_on_plane.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "box_on_plane"

--- a/newton/tests/assets/kamino/basics/box_pendulum.usda
+++ b/newton/tests/assets/kamino/basics/box_pendulum.usda
@@ -12,7 +12,7 @@ def PhysicsScene "World" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    float physics:gravityMagnitude = 9.8067
+    float physics:gravityMagnitude = 9.81
     vector3f physics:gravityDirection = (0, 0, -1)
     uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
     uniform float newton:kamino:padmm:dualTolerance = 0.0001

--- a/newton/tests/assets/kamino/basics/box_pendulum.usda
+++ b/newton/tests/assets/kamino/basics/box_pendulum.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "box_pendulum"

--- a/newton/tests/assets/kamino/basics/boxes_fourbar.usda
+++ b/newton/tests/assets/kamino/basics/boxes_fourbar.usda
@@ -12,7 +12,7 @@ def PhysicsScene "World" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    float physics:gravityMagnitude = 9.8067
+    float physics:gravityMagnitude = 9.81
     vector3f physics:gravityDirection = (0, 0, -1)
     uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
     uniform float newton:kamino:padmm:dualTolerance = 0.0001

--- a/newton/tests/assets/kamino/basics/boxes_fourbar.usda
+++ b/newton/tests/assets/kamino/basics/boxes_fourbar.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "boxes_fourbar"

--- a/newton/tests/assets/kamino/basics/boxes_hinged.usda
+++ b/newton/tests/assets/kamino/basics/boxes_hinged.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "boxes_hinged"

--- a/newton/tests/assets/kamino/basics/boxes_hinged.usda
+++ b/newton/tests/assets/kamino/basics/boxes_hinged.usda
@@ -12,7 +12,7 @@ def PhysicsScene "World" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    float physics:gravityMagnitude = 9.8067
+    float physics:gravityMagnitude = 9.81
     vector3f physics:gravityDirection = (0, 0, -1)
     uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
     uniform float newton:kamino:padmm:dualTolerance = 0.0001

--- a/newton/tests/assets/kamino/basics/boxes_nunchaku.usda
+++ b/newton/tests/assets/kamino/basics/boxes_nunchaku.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "boxes_nunchaku"

--- a/newton/tests/assets/kamino/basics/boxes_nunchaku.usda
+++ b/newton/tests/assets/kamino/basics/boxes_nunchaku.usda
@@ -12,7 +12,7 @@ def PhysicsScene "World" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    float physics:gravityMagnitude = 9.8067
+    float physics:gravityMagnitude = 9.81
     vector3f physics:gravityDirection = (0, 0, -1)
     uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
     uniform float newton:kamino:padmm:dualTolerance = 0.0001

--- a/newton/tests/assets/kamino/basics/cartpole.usda
+++ b/newton/tests/assets/kamino/basics/cartpole.usda
@@ -8,10 +8,15 @@
     upAxis = "Z"
 )
 
-def PhysicsScene "World"
+def PhysicsScene "World" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
 {
     float physics:gravityMagnitude = 9.8067
     vector3f physics:gravityDirection = (0, 0, -1)
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "cartpole"

--- a/newton/tests/assets/kamino/basics/cartpole.usda
+++ b/newton/tests/assets/kamino/basics/cartpole.usda
@@ -12,7 +12,7 @@ def PhysicsScene "World" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    float physics:gravityMagnitude = 9.8067
+    float physics:gravityMagnitude = 9.81
     vector3f physics:gravityDirection = (0, 0, -1)
     uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
     uniform float newton:kamino:padmm:dualTolerance = 0.0001


### PR DESCRIPTION
## Description

This adds basic scene attributes to the Kamino USD files used in the examples that didn't have them yet, based on the config parameters of the examples. Config setup has been left unchanged to still serve as a reference for users.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Standardized Kamino physics scene configuration across foundational simulation examples.
  * Added consistent solver tolerance settings for improved simulation behavior.
  * Updated gravity magnitude to the standard value of 9.81 where applicable, while preserving gravity direction and overall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->