### PR TITLE
Fix AWS benchmark Python launcher

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -155,7 +155,7 @@ jobs:
           # Keep representative camera output modes and teleop tail latency;
           # full ASV collection retains every metric. Interleave rounds across
           # revisions to control cold-start and ordering bias.
-          python asv/run_pr_benchmarks.py ${{ inputs.base_ref }} ${{ inputs.ref }}
+          uv run --no-project asv/run_pr_benchmarks.py ${{ inputs.base_ref }} ${{ inputs.ref }}
         continue-on-error: true
         id: benchmark
 

--- a/asv/tests/test_benchmark_simulation.py
+++ b/asv/tests/test_benchmark_simulation.py
@@ -292,7 +292,7 @@ class TestSimulationBenchmarks(unittest.TestCase):
         """Gate discovered PR runtimes while retaining dashboard-only metrics."""
         workflow_path = ROOT / ".github" / "workflows" / "aws_gpu_benchmarks.yml"
         workflow = workflow_path.read_text(encoding="utf-8")
-        self.assertIn("python asv/run_pr_benchmarks.py", workflow)
+        self.assertIn("uv run --no-project asv/run_pr_benchmarks.py", workflow)
         patterns = tuple(re.compile(selection) for selection in load_benchmark_patterns())
         inventory = {benchmark["name"]: benchmark for benchmark in self._discover_benchmarks(pr_gate=False)}
 


### PR DESCRIPTION
## Description

Launch the PR ASV helper through `uv` instead of relying on an unversioned
`python` command.

The AWS benchmark runner successfully installs managed CPython with
`uv python install`, but that does not place `python` on `PATH`. The benchmark
therefore exits with status 127 before ASV runs, blocking unrelated pull
requests without producing a comparison.

Using `uv run --no-project` selects an available interpreter while avoiding a
sync of Newton's project dependencies. The checked-in helper continues to
launch ASV through its existing `uvx` command, preserving the benchmark setup
introduced in #4015.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (not applicable;
      workflow-only change)
- [x] No changelog fragment is required because this is not user-facing

## Test plan

- Reproduced the failure under a runner-like `PATH`: the existing
  `python asv/run_pr_benchmarks.py --help` command exits 127 with
  `python: command not found`.
- Verified `uv run --no-project asv/run_pr_benchmarks.py --help` successfully
  launches the helper under the same `PATH`.
- `uv run --extra dev asv/tests/test_benchmark_simulation.py`
- `uvx pre-commit run -a`

## CI validation limitation

This PR's own AWS benchmark check is expected to reproduce the failure until
the fix lands on `main`. The workflow is triggered through
`pull_request_target`, so its reusable workflow definition is loaded from the
base branch rather than from this PR.

[Run 32861036227](https://github.com/newton-physics/newton/actions/runs/32861036227)
loaded `aws_gpu_benchmarks.yml` from `refs/heads/main` at `c28e928f`, executed
the old `python asv/run_pr_benchmarks.py ...` command, and exited 127. It did
not execute this PR's `uv run --no-project ...` change. A fresh pull-request
event after the fix is present on `main` will provide the end-to-end
validation.

## Bug fix

**Steps to reproduce:**

1. On an Ubuntu runner without an unversioned `python` executable, run
   `uv python install`.
2. Run `python asv/run_pr_benchmarks.py BASE_REF PR_REF`.
3. Observe `python: command not found` and exit status 127 before any benchmark
   executes.

**Minimal reproduction:**

```bash
uv python install
python asv/run_pr_benchmarks.py BASE_REF PR_REF
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GPU benchmark workflow to run benchmarks through the project's managed execution environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
