### PR TITLE
Avoid pytorch imports during CI benchmark runs 

### DIFF
--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -508,16 +508,28 @@ class DRLegsBenchmarkWorkload:
         return builder
 
     @staticmethod
-    def create_solver(model, sim_dt):
-        # Reuse the Kamino RL example's solver settings to mirror the deployed workload.
-        from newton._src.solvers.kamino.examples.rl.simulation import RigidBodySim  # noqa: PLC0415
-
-        settings = RigidBodySim.default_settings(sim_dt)
-        settings.solver.collision_detector = settings.collision_detector
-        # Pin the linear solver so a change to default_settings cannot
-        # silently switch what this benchmark measures.
-        settings.solver.dynamics.linear_solver_type = "LLTBRCM"
-        return newton.solvers.SolverKamino(model, config=settings.solver)
+    def create_solver(model, _sim_dt):
+        # Pin the deployed RL settings without importing its PyTorch-dependent module.
+        config = newton.solvers.SolverKamino.Config(
+            sparse_jacobian=True,
+            use_collision_detector=True,
+            integrator="moreau",
+        )
+        config.collision_detector.pipeline = "unified"
+        config.collision_detector.max_contacts_per_pair = 8
+        config.constraints.alpha = 0.1
+        config.padmm.primal_tolerance = 1e-4
+        config.padmm.dual_tolerance = 1e-4
+        config.padmm.compl_tolerance = 1e-4
+        config.padmm.max_iterations = 200
+        config.padmm.eta = 1e-5
+        config.padmm.rho_0 = 0.05
+        config.padmm.use_acceleration = True
+        config.padmm.warmstart_mode = "containers"
+        config.padmm.contact_warmstart_method = "geom_pair_net_force"
+        config.padmm.use_graph_conditionals = False
+        config.dynamics.linear_solver_type = "LLTBRCM"
+        return newton.solvers.SolverKamino(model, config=config)
 
 
 if __name__ == "__main__":

--- a/asv/tests/test_benchmark_simulation.py
+++ b/asv/tests/test_benchmark_simulation.py
@@ -48,6 +48,7 @@ try:
 
     _DEFERRED_WORKLOAD_MODULES_AFTER_METRIC_IMPORT = {name: name in sys.modules for name in _DEFERRED_WORKLOAD_MODULES}
 
+    import benchmark_kamino
     from benchmark_kamino import DRLegsBenchmarkWorkload
     from benchmark_mujoco import Example as MuJoCoExample
 finally:
@@ -287,6 +288,18 @@ class TestSimulationBenchmarks(unittest.TestCase):
         """Give the DR Legs cache longer than ASV's default timeout."""
         config = json.loads((BENCHMARK_DIR.parents[1] / "asv.conf.json").read_text(encoding="utf-8"))
         self.assertGreater(bench_kamino.KpiDRLegs.setup_cache.timeout, config["default_benchmark_timeout"])
+
+    def test_fast_dr_legs_solver_does_not_import_torch(self):
+        """Construct the fast DR Legs solver without importing PyTorch."""
+        config_cls = benchmark_kamino.newton.solvers.SolverKamino.Config
+        with (
+            patch.dict(sys.modules, {"torch": None}),
+            patch.object(benchmark_kamino.newton.solvers, "SolverKamino") as solver_cls,
+        ):
+            solver_cls.Config = config_cls
+            DRLegsBenchmarkWorkload.create_solver(Mock(), 0.005)
+
+        solver_cls.assert_called_once()
 
     def test_aws_benchmark_comparison_gates_only_runtime_metrics(self):
         """Gate discovered PR runtimes while retaining dashboard-only metrics."""


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Fast benchmarks should not import pytorch since it is not needed and not available anymore.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for the fast DR Legs benchmark when PyTorch is unavailable.
  - Ensured the benchmark solver can initialize reliably with its configured simulation settings.

- **Tests**
  - Added regression coverage for solver creation without PyTorch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->