### PR TITLE
Fix Kamino model conversion with collision-group-based exclusion

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -12,6 +12,12 @@ import numpy as np
 import warp as wp
 
 from .....geometry import ShapeFlags
+from .....geometry.broad_phase_common import test_world_and_group_pair, write_pair
+from .....geometry.broad_phase_nxn import (
+    BroadPhaseAllPairs,
+    _find_world_and_local_id,
+    _get_lower_triangular_indices,
+)
 from .....sim.model import Model
 from ....coupled.model_view import ModelView
 from ..utils import logger as msg
@@ -1901,6 +1907,101 @@ def register_materials(model: Model, materials_manager: MaterialManager) -> np.n
     return geom_material
 
 
+@wp.kernel
+def _group_incompatible_pairs_kernel(
+    # Inputs
+    shape_collision_group: wp.array[wp.int32],
+    shape_world: wp.array[wp.int32],
+    world_cumsum_lower_tri: wp.array[wp.int32],  # Cumulative sum of lower tri elements per world
+    world_slice_ends: wp.array[wp.int32],  # End indices of each world slice
+    world_index_map: wp.array[wp.int32],  # Index map into source shapes
+    num_regular_worlds: int,  # Number of regular world segments (excluding dedicated -1 segment)
+    # Outputs
+    excluded_pair: wp.array[wp.vec2i],
+    excluded_pair_count: wp.array[wp.int32],
+    max_excluded_pairs: int,
+):
+    tid = wp.tid()
+
+    # Only shapes within the same world (or global, world -1) can ever collide, so restrict
+    # the thread space to per-world lower-triangular pairs instead of the full N^2 grid.
+    # Mirrors `_nxn_broadphase_kernel` in broad_phase_nxn.py.
+    world_id, local_id = _find_world_and_local_id(tid, world_cumsum_lower_tri)
+
+    world_slice_start = 0
+    if world_id > 0:
+        world_slice_start = world_slice_ends[world_id - 1]
+    world_slice_end = world_slice_ends[world_id]
+    num_shapes_in_world = world_slice_end - world_slice_start
+
+    local_shape_a, local_shape_b = _get_lower_triangular_indices(local_id, num_shapes_in_world)
+
+    shape_a_tmp = world_index_map[world_slice_start + local_shape_a]
+    shape_b_tmp = world_index_map[world_slice_start + local_shape_b]
+    shape_a = wp.min(shape_a_tmp, shape_b_tmp)
+    shape_b = wp.max(shape_a_tmp, shape_b_tmp)
+
+    world_a = shape_world[shape_a]
+    world_b = shape_world[shape_b]
+
+    # Skip pairs where both shapes are global (world -1), except in the dedicated
+    # -1 segment, to avoid counting global-vs-global pairs once per regular world.
+    is_dedicated_minus_one_segment = world_id >= num_regular_worlds
+    if world_a == -1 and world_b == -1 and not is_dedicated_minus_one_segment:
+        return
+
+    if not test_world_and_group_pair(world_a, world_b, shape_collision_group[shape_a], shape_collision_group[shape_b]):
+        write_pair(wp.vec2i(shape_a, shape_b), excluded_pair, excluded_pair_count, max_excluded_pairs)
+
+
+def compute_group_incompatible_pairs(
+    shape_collision_group: wp.array[wp.int32],
+    shape_world: wp.array[wp.int32],
+) -> np.ndarray:
+    """Find shape pairs that are incompatible under Newton's collision-group rule.
+    Used in Kamino's internal NXN/SAP broadphase, which does not check for
+    group-based exclusion, instead relying purely on the excluded-pairs list.
+
+    Args:
+        shape_collision_group: Per-shape collision group id, shape [num_shapes].
+        shape_world: Per-shape world index (-1 for global shapes), shape [num_shapes].
+
+    Returns:
+        Array of incompatible shape index pairs (each row canonical, i.e.
+        pair[0] < pair[1]), shape [pair_count, 2].
+    """
+    if shape_collision_group.shape[0] < 2:
+        return np.empty((0, 2), dtype=np.int32)
+
+    device = shape_collision_group.device
+    world_map = BroadPhaseAllPairs(shape_world, shape_flags=None, device=device)
+    num_threads = world_map.num_kernel_threads
+    if num_threads == 0:
+        return np.empty((0, 2), dtype=np.int32)
+
+    with wp.ScopedDevice(device):
+        excluded_pair = wp.zeros(num_threads, dtype=wp.vec2i)
+        excluded_pair_count = wp.zeros(1, dtype=wp.int32)
+
+    wp.launch(
+        kernel=_group_incompatible_pairs_kernel,
+        dim=num_threads,
+        inputs=[
+            shape_collision_group,
+            shape_world,
+            world_map.world_cumsum_lower_tri,
+            world_map.world_slice_ends,
+            world_map.world_index_map,
+            world_map.num_regular_worlds,
+        ],
+        outputs=[excluded_pair, excluded_pair_count, num_threads],
+        device=device,
+    )
+
+    count = int(excluded_pair_count.numpy()[0])
+    return excluded_pair.numpy()[:count]
+
+
 def convert_geometries(
     model: Model | ModelView,
     model_size: SizeKamino,
@@ -1956,8 +2057,20 @@ def convert_geometries(
         offset,
     )
 
-    # Create additional collision detection meta-data
-    sorted_excluded_pairs = model.shape_collision_filter_pairs_array()
+    # Create collision detection meta-data: Combine explicitly filtered
+    # pairs (e.g. same-body, user-specified exclusions) with pairs that are
+    # incompatible under Newton's collision-group rule. Kamino's NXN/SAP
+    # broadphase relies solely on this list for group-based filtering.
+    explicit_excluded_pairs = model.shape_collision_filter_pairs_array()
+    group_excluded_pairs = compute_group_incompatible_pairs(model.shape_collision_group, model.shape_world)
+    if explicit_excluded_pairs.size and group_excluded_pairs.size:
+        sorted_excluded_pairs = np.unique(
+            np.concatenate([explicit_excluded_pairs, group_excluded_pairs], axis=0), axis=0
+        )
+    elif group_excluded_pairs.size:
+        sorted_excluded_pairs = np.unique(group_excluded_pairs, axis=0)
+    else:
+        sorted_excluded_pairs = explicit_excluded_pairs
     excluded_pairs = wp.array(sorted_excluded_pairs, dtype=wp.vec2i, device=model.device)
 
     return GeometriesModel(

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -1912,6 +1912,7 @@ def _group_incompatible_pairs_kernel(
     # Inputs
     shape_collision_group: wp.array[wp.int32],
     shape_world: wp.array[wp.int32],
+    shape_flags: wp.array[wp.int32],
     world_cumsum_lower_tri: wp.array[wp.int32],  # Cumulative sum of lower tri elements per world
     world_slice_ends: wp.array[wp.int32],  # End indices of each world slice
     world_index_map: wp.array[wp.int32],  # Index map into source shapes
@@ -1950,21 +1951,30 @@ def _group_incompatible_pairs_kernel(
     if world_a == -1 and world_b == -1 and not is_dedicated_minus_one_segment:
         return
 
-    if not test_world_and_group_pair(world_a, world_b, shape_collision_group[shape_a], shape_collision_group[shape_b]):
+    groups_collide = test_world_and_group_pair(
+        world_a, world_b, shape_collision_group[shape_a], shape_collision_group[shape_b]
+    )
+    flags_collide = (shape_flags[shape_a] & ShapeFlags.COLLIDE_SHAPES) != 0 and (
+        shape_flags[shape_b] & ShapeFlags.COLLIDE_SHAPES
+    ) != 0
+    if not (groups_collide and flags_collide):
         write_pair(wp.vec2i(shape_a, shape_b), excluded_pair, excluded_pair_count, max_excluded_pairs)
 
 
 def compute_group_incompatible_pairs(
     shape_collision_group: wp.array[wp.int32],
     shape_world: wp.array[wp.int32],
+    shape_flags: wp.array[wp.int32],
 ) -> np.ndarray:
-    """Find shape pairs that are incompatible under Newton's collision-group rule.
-    Used in Kamino's internal NXN/SAP broadphase, which does not check for
-    group-based exclusion, instead relying purely on the excluded-pairs list.
+    """Find shape pairs that are incompatible under Newton's collision-group and
+    shape flag rules. Used in Kamino's internal NXN/SAP broadphase, which does
+    not check for group- or flag-based exclusion, instead relying purely on the
+    excluded-pairs list.
 
     Args:
         shape_collision_group: Per-shape collision group id, shape [num_shapes].
         shape_world: Per-shape world index (-1 for global shapes), shape [num_shapes].
+        shape_flags: Per-shape flags, shape [num_shapes].
 
     Returns:
         Array of incompatible shape index pairs (each row canonical, i.e.
@@ -1989,6 +1999,7 @@ def compute_group_incompatible_pairs(
         inputs=[
             shape_collision_group,
             shape_world,
+            shape_flags,
             world_map.world_cumsum_lower_tri,
             world_map.world_slice_ends,
             world_map.world_index_map,
@@ -2059,10 +2070,13 @@ def convert_geometries(
 
     # Create collision detection meta-data: Combine explicitly filtered
     # pairs (e.g. same-body, user-specified exclusions) with pairs that are
-    # incompatible under Newton's collision-group rule. Kamino's NXN/SAP
-    # broadphase relies solely on this list for group-based filtering.
+    # incompatible under Newton's collision-group and shape flag rules.
+    # Kamino's NXN/SAP broadphase relies solely on this list for collision
+    # filtering.
     explicit_excluded_pairs = model.shape_collision_filter_pairs_array()
-    group_excluded_pairs = compute_group_incompatible_pairs(model.shape_collision_group, model.shape_world)
+    group_excluded_pairs = compute_group_incompatible_pairs(
+        model.shape_collision_group, model.shape_world, model.shape_flags
+    )
     if explicit_excluded_pairs.size and group_excluded_pairs.size:
         sorted_excluded_pairs = np.unique(
             np.concatenate([explicit_excluded_pairs, group_excluded_pairs], axis=0), axis=0

--- a/newton/tests/kamino/test_kamino_core_model.py
+++ b/newton/tests/kamino/test_kamino_core_model.py
@@ -533,6 +533,129 @@ class TestModelConversions(unittest.TestCase):
             self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [-1])
             self.assertTrue(model_kamino.info.has_world_without_base_body)
 
+    def test_06a_model_conversions_group_incompatible_pairs_excluded(self):
+        """Newton's collision-group incompatibility must be baked into `geoms.excluded_pairs`,
+        since group membership is not checked during Kamino's broadphase.
+        """
+        builder: ModelBuilder = ModelBuilder()
+        builder.begin_world()
+        body_a = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        body_b = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        shape_a = builder.add_shape_sphere(body=body_a, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+        shape_b = builder.add_shape_sphere(body=body_b, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=2))
+        builder.end_world()
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        excluded = {tuple(sorted(pair)) for pair in model_kamino.geoms.excluded_pairs.numpy().tolist()}
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 1)
+        self.assertEqual(excluded, {tuple(sorted((shape_a, shape_b)))})
+
+    def test_06b_model_conversions_group_compatible_pairs_not_excluded(self):
+        """Shapes with compatible collision groups must not appear in `geoms.excluded_pairs`."""
+        builder: ModelBuilder = ModelBuilder()
+        builder.begin_world()
+        body_a = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        body_b = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        builder.add_shape_sphere(body=body_a, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+        builder.add_shape_sphere(body=body_b, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+        builder.end_world()
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 0)
+
+    def test_06c_model_conversions_group_exclusion_negative_group_self_pairs_excluded(self):
+        """Two shapes sharing the same negative collision-group id must be excluded."""
+        builder: ModelBuilder = ModelBuilder()
+        builder.begin_world()
+        body_a = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        body_b = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        shape_a = builder.add_shape_sphere(body=body_a, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=-1))
+        shape_b = builder.add_shape_sphere(body=body_b, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=-1))
+        builder.end_world()
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        excluded = {tuple(sorted(pair)) for pair in model_kamino.geoms.excluded_pairs.numpy().tolist()}
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 1)
+        self.assertEqual(excluded, {tuple(sorted((shape_a, shape_b)))})
+
+    def test_06d_model_conversions_group_exclusion_respects_world_boundaries(self):
+        """Group-incompatible shapes in different (non-global) worlds must never
+        be added to `geoms.excluded_pairs`.
+        """
+        builder: ModelBuilder = ModelBuilder()
+        builder.begin_world()
+        body_a = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        builder.add_shape_sphere(body=body_a, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+        builder.end_world()
+        builder.begin_world()
+        body_b = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        builder.add_shape_sphere(body=body_b, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=2))
+        builder.end_world()
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 0)
+
+    def test_06e_model_conversions_group_exclusion_global_shape_not_duplicated(self):
+        """A global (world -1) shape incompatible with per-world shapes must be
+        excluded against each world's shape exactly once."""
+        builder: ModelBuilder = ModelBuilder()
+        world_shapes = []
+        for _ in range(2):
+            builder.begin_world()
+            body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+            world_shapes.append(
+                builder.add_shape_sphere(body=body, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+            )
+            builder.end_world()
+        global_body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        global_shape = builder.add_shape_sphere(
+            body=global_body, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=2)
+        )
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        excluded = {tuple(sorted(pair)) for pair in model_kamino.geoms.excluded_pairs.numpy().tolist()}
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 2)
+        self.assertEqual(
+            excluded,
+            {tuple(sorted((world_shapes[0], global_shape))), tuple(sorted((world_shapes[1], global_shape)))},
+        )
+
+    def test_06f_model_conversions_group_exclusion_global_shape_not_duplicated(self):
+        """A global (world -1) shape incompatible with per-world shapes must be
+        excluded against each world's shape exactly once."""
+        builder: ModelBuilder = ModelBuilder()
+        world_shapes = []
+        global_shapes = []
+        global_body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        global_shapes.append(
+            builder.add_shape_sphere(body=global_body, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=2))
+        )
+        for _ in range(2):
+            builder.begin_world()
+            body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+            world_shapes.append(
+                builder.add_shape_sphere(body=body, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+            )
+            builder.end_world()
+        global_body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        global_shapes.append(
+            builder.add_shape_sphere(body=global_body, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=2))
+        )
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        excluded = [tuple(sorted(pair)) for pair in model_kamino.geoms.excluded_pairs.numpy().tolist()]
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 4)
+        self.assertEqual(
+            excluded,
+            sorted(
+                [
+                    tuple(sorted((world_shape, global_shape)))
+                    for world_shape in world_shapes
+                    for global_shape in global_shapes
+                ]
+            ),
+        )
+
     def test_10_model_conversions_arbitrary_axis(self):
         """
         Test that Newton→Kamino conversion succeeds for a revolute joint

--- a/newton/tests/kamino/test_kamino_core_model.py
+++ b/newton/tests/kamino/test_kamino_core_model.py
@@ -656,6 +656,26 @@ class TestModelConversions(unittest.TestCase):
             ),
         )
 
+    def test_06g_model_conversions_group_exclusion_non_colliding_shape_excluded(self):
+        """A shape without ShapeFlags.COLLIDE_SHAPES must be excluded from its
+        group-compatible pair."""
+        builder: ModelBuilder = ModelBuilder()
+        builder.begin_world()
+        body_a = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        body_b = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3, dtype=np.float32)))
+        shape_a = builder.add_shape_sphere(body=body_a, radius=0.5, cfg=ModelBuilder.ShapeConfig(collision_group=1))
+        shape_b = builder.add_shape_sphere(
+            body=body_b,
+            radius=0.5,
+            cfg=ModelBuilder.ShapeConfig(collision_group=1, has_shape_collision=False),
+        )
+        builder.end_world()
+
+        model_kamino: ModelKamino = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        excluded = {tuple(sorted(pair)) for pair in model_kamino.geoms.excluded_pairs.numpy().tolist()}
+        self.assertEqual(model_kamino.geoms.num_excluded_pairs, 1)
+        self.assertEqual(excluded, {tuple(sorted((shape_a, shape_b)))})
+
     def test_10_model_conversions_arbitrary_axis(self):
         """
         Test that Newton→Kamino conversion succeeds for a revolute joint


### PR DESCRIPTION
## Description

Kamino's internal collision pipeline relies on a list of excluded shape pairs in its broadphase, without explicitly checking the shape collision groups of a candidate pair. During model conversion, this list had been populated from Newton's excluded-pairs list, which does not include any group-based exclusions.

The group-based exclusions therefore have to be baked into Kamino's excluded-pairs list during conversion.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
python -m newton.tests -k model_conversions_group
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collision filtering now automatically excludes incompatible shape pairs based on collision groups and collision settings.
  * Collision exclusions respect world boundaries and correctly handle global shapes.
  * Compatible shape pairs remain collidable, while duplicate exclusions are removed.

* **Bug Fixes**
  * Improved handling of negative collision groups, self-pair exclusions, and shapes that cannot participate in collisions.

* **Tests**
  * Added coverage for group compatibility, collision settings, world boundaries, global shapes, and duplicate pair prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->