### PR TITLE
Experimental newton viewer extension support

### DIFF
--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -140,17 +140,18 @@ through the ``newton.viewers`` entry-point group. For example, its
    [project.entry-points."newton.viewers"]
    custom = "my_package.newton_viewer:create_viewer"
 
-The entry point must load a factory that accepts the parsed example arguments
-and returns a :class:`~newton.viewer.ViewerBase` instance:
+The entry point must load a zero-argument factory that returns a
+:class:`~newton.viewer.ViewerBase` instance:
 
 .. code-block:: python
 
-   def create_viewer(args):
-       return MyViewer(headless=args.headless, num_frames=args.num_frames)
+   def create_viewer():
+       return MyViewer()
 
 Newton reads installed entry-point metadata when constructing the example
 parser and imports only the selected viewer package. Third-party viewers cannot
-override built-in viewer names.
+override built-in viewer names. Conflicting entry points are ignored so they do
+not prevent other viewers from being used.
 
 Real-time Viewers
 -----------------

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -128,6 +128,30 @@ All viewers support ``set_visible_worlds()`` to limit visualization to a subset 
     viewer.set_model(model)
     viewer.set_visible_worlds(range(4))
 
+Third-party viewers
+-------------------
+
+An installed package can add a viewer to the examples' ``--viewer`` choices
+through the ``newton.viewers`` entry-point group. For example, its
+``pyproject.toml`` can contain:
+
+.. code-block:: toml
+
+   [project.entry-points."newton.viewers"]
+   custom = "my_package.newton_viewer:create_viewer"
+
+The entry point must load a factory that accepts the parsed example arguments
+and returns a :class:`~newton.viewer.ViewerBase` instance:
+
+.. code-block:: python
+
+   def create_viewer(args):
+       return MyViewer(headless=args.headless, num_frames=args.num_frames)
+
+Newton reads installed entry-point metadata when constructing the example
+parser and imports only the selected viewer package. Third-party viewers cannot
+override built-in viewer names.
+
 Real-time Viewers
 -----------------
 

--- a/newton/_src/viewer/__init__.py
+++ b/newton/_src/viewer/__init__.py
@@ -39,6 +39,9 @@ Layers:
     activated layer's model.
 """
 
+import importlib.metadata
+import logging
+
 from .viewer import Layer, ViewerBase
 from .viewer_file import ViewerFile
 from .viewer_gl import ViewerGL
@@ -47,6 +50,26 @@ from .viewer_rerun import ViewerRerun
 from .viewer_rtx import ViewerRTX
 from .viewer_usd import ViewerUSD
 from .viewer_viser import ViewerViser
+
+_BUILTIN_VIEWER_NAMES = ("gl", "usd", "rtx", "rerun", "null", "viser")
+_VIEWER_ENTRY_POINT_GROUP = "newton.viewers"
+_logger = logging.getLogger(__name__)
+
+
+def _get_viewer_entry_points() -> dict[str, importlib.metadata.EntryPoint]:
+    """Return installed third-party viewer entry points keyed by viewer name."""
+    viewer_entry_points = {}
+    for entry_point in importlib.metadata.entry_points(group=_VIEWER_ENTRY_POINT_GROUP):
+        if entry_point.name in _BUILTIN_VIEWER_NAMES:
+            _logger.warning(
+                "Ignoring viewer entry point '%s' because it conflicts with a built-in viewer", entry_point.name
+            )
+        elif entry_point.name in viewer_entry_points:
+            _logger.warning("Ignoring duplicate viewer entry point '%s'", entry_point.name)
+        else:
+            viewer_entry_points[entry_point.name] = entry_point
+    return viewer_entry_points
+
 
 __all__ = [
     "Layer",

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -5,7 +5,6 @@ import ast
 import copy
 import gc
 import importlib
-import importlib.metadata
 import math
 import os
 import sys
@@ -21,8 +20,6 @@ import newton
 from newton.tests.unittest_utils import find_nan_members
 
 _DEPRECATED_WARP_CONFIG_KEYS = {"quiet", "verbose"}
-_BUILTIN_VIEWER_NAMES = ("gl", "usd", "rtx", "rerun", "null", "viser")
-_VIEWER_ENTRY_POINT_GROUP = "newton.viewers"
 
 
 def get_source_directory() -> str:
@@ -632,18 +629,6 @@ def _print_examples(examples: dict[str, str]) -> None:
         print(f"  {name}")
 
 
-def _get_viewer_entry_points() -> dict[str, importlib.metadata.EntryPoint]:
-    """Return installed third-party viewer entry points keyed by viewer name."""
-    viewer_entry_points = {}
-    for entry_point in importlib.metadata.entry_points(group=_VIEWER_ENTRY_POINT_GROUP):
-        if entry_point.name in _BUILTIN_VIEWER_NAMES:
-            raise ValueError(f"Viewer entry point cannot override built-in viewer name '{entry_point.name}'")
-        if entry_point.name in viewer_entry_points:
-            raise ValueError(f"Duplicate viewer entry point '{entry_point.name}'")
-        viewer_entry_points[entry_point.name] = entry_point
-    return viewer_entry_points
-
-
 def create_parser():
     """Create a base argument parser with common parameters for Newton examples.
 
@@ -661,7 +646,7 @@ def create_parser():
         "--viewer",
         type=str,
         default="gl",
-        choices=[*_BUILTIN_VIEWER_NAMES, *sorted(_get_viewer_entry_points())],
+        choices=[*newton.viewer._BUILTIN_VIEWER_NAMES, *sorted(newton.viewer._get_viewer_entry_points())],
         help="Viewer to use.",
     )
     parser.add_argument(
@@ -943,7 +928,7 @@ def init(parser=None):
     elif args.viewer == "viser":
         viewer = newton.viewer.ViewerViser()
     else:
-        viewer = _get_viewer_entry_points()[args.viewer].load()(args)
+        viewer = newton.viewer._get_viewer_entry_points()[args.viewer].load()()
 
     if visible_gl:
         viewer.show_loading_splash("Loading...")

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -5,6 +5,7 @@ import ast
 import copy
 import gc
 import importlib
+import importlib.metadata
 import math
 import os
 import sys
@@ -20,6 +21,8 @@ import newton
 from newton.tests.unittest_utils import find_nan_members
 
 _DEPRECATED_WARP_CONFIG_KEYS = {"quiet", "verbose"}
+_BUILTIN_VIEWER_NAMES = ("gl", "usd", "rtx", "rerun", "null", "viser")
+_VIEWER_ENTRY_POINT_GROUP = "newton.viewers"
 
 
 def get_source_directory() -> str:
@@ -629,6 +632,18 @@ def _print_examples(examples: dict[str, str]) -> None:
         print(f"  {name}")
 
 
+def _get_viewer_entry_points() -> dict[str, importlib.metadata.EntryPoint]:
+    """Return installed third-party viewer entry points keyed by viewer name."""
+    viewer_entry_points = {}
+    for entry_point in importlib.metadata.entry_points(group=_VIEWER_ENTRY_POINT_GROUP):
+        if entry_point.name in _BUILTIN_VIEWER_NAMES:
+            raise ValueError(f"Viewer entry point cannot override built-in viewer name '{entry_point.name}'")
+        if entry_point.name in viewer_entry_points:
+            raise ValueError(f"Duplicate viewer entry point '{entry_point.name}'")
+        viewer_entry_points[entry_point.name] = entry_point
+    return viewer_entry_points
+
+
 def create_parser():
     """Create a base argument parser with common parameters for Newton examples.
 
@@ -646,8 +661,8 @@ def create_parser():
         "--viewer",
         type=str,
         default="gl",
-        choices=["gl", "usd", "rtx", "rerun", "null", "viser"],
-        help="Viewer to use (gl, usd, rtx, rerun, null, or viser).",
+        choices=[*_BUILTIN_VIEWER_NAMES, *sorted(_get_viewer_entry_points())],
+        help="Viewer to use.",
     )
     parser.add_argument(
         "--rerun-address",
@@ -928,7 +943,7 @@ def init(parser=None):
     elif args.viewer == "viser":
         viewer = newton.viewer.ViewerViser()
     else:
-        raise ValueError(f"Invalid viewer: {args.viewer}")
+        viewer = _get_viewer_entry_points()[args.viewer].load()(args)
 
     if visible_gl:
         viewer.show_loading_splash("Loading...")

--- a/newton/viewer.py
+++ b/newton/viewer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
+from ._src import viewer as _viewer
 from ._src.viewer import (
     Layer,
     ViewerBase,
@@ -13,6 +14,9 @@ from ._src.viewer import (
     ViewerUSD,
     ViewerViser,
 )
+
+_BUILTIN_VIEWER_NAMES = _viewer._BUILTIN_VIEWER_NAMES
+_get_viewer_entry_points = _viewer._get_viewer_entry_points
 
 __all__ = [
     "Layer",


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Experimental newton viewer extension support

Allows to have viewers in other pip packages that can then be used directly inside newton if they are in the same venv. E. g. viewers that visualize more data through ImGui etc.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for third-party visualization viewer plugins.
  - Viewer plugins can be discovered and selected alongside built-in viewers.
  - Plugin factories are called without command-line arguments.
  - Conflicting or duplicate viewer names are safely ignored, allowing other valid viewers to remain available.

- **Documentation**
  - Added guidance for developing and registering third-party viewer plugins, including the required factory format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->