### PR TITLE
Introduce `ModelBuilder.replicate_and_finalize()`

### DIFF
--- a/changelog/+replicate-finalize-8c1f2a4d.added.md
+++ b/changelog/+replicate-finalize-8c1f2a4d.added.md
@@ -1,1 +1,1 @@
-Add `ModelBuilder.replicate_and_finalize()` to accelerate finalization after batched replication.
+Add `ModelBuilder.replicate_and_finalize()` to accelerate finalization after batched replication and defer cyclic garbage collection until construction is complete.

--- a/changelog/+replicate-finalize-8c1f2a4d.added.md
+++ b/changelog/+replicate-finalize-8c1f2a4d.added.md
@@ -1,0 +1,1 @@
+Add `ModelBuilder.replicate_and_finalize()` to accelerate finalization after batched replication.

--- a/changelog/+replicate-finalize-8c1f2a4d.added.md
+++ b/changelog/+replicate-finalize-8c1f2a4d.added.md
@@ -1,1 +1,1 @@
-Add `ModelBuilder.replicate_and_finalize()` to accelerate finalization after batched replication and defer cyclic garbage collection until construction is complete.
+Add `ModelBuilder.replicate_and_finalize()`, which replicates a builder and finalizes the model in one faster step.

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -265,9 +265,9 @@ While :meth:`~newton.ModelBuilder.begin_world` and :meth:`~newton.ModelBuilder.e
    world_count: 4
    body_count: 8
 
-If the replicated builder needs no further modification, :meth:`~newton.ModelBuilder.replicate_and_finalize`
-performs both steps in one call and finalizes faster. The destination builder is left unmodified; use separate
-:meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize` calls when the replicated data
+If the replicated builder needs no further modification, :meth:`~newton.ModelBuilder.replicate_and_finalize` performs
+both steps in one call and is faster than calling them separately. The destination builder is left unmodified; use
+separate :meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize` calls when the replicated data
 must be changed in between.
 
 .. important::

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -269,8 +269,10 @@ If the replicated builder does not need further modification, use
 :meth:`~newton.ModelBuilder.replicate_and_finalize` to perform the two operations
 atomically. It produces the same model while forwarding the contiguous arrays
 created during replication directly to finalization through a private,
-single-use builder. The destination builder is not modified. Add global entities
-and configure the destination builder before calling it; use separate
+single-use builder. It also defers cyclic garbage collection until that builder
+has been discarded, replacing collections during construction with one final
+collection. The destination builder is not modified. Add global entities and
+configure the destination builder before calling it; use separate
 :meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize`
 calls when the replicated data must be changed in between.
 

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -265,16 +265,10 @@ While :meth:`~newton.ModelBuilder.begin_world` and :meth:`~newton.ModelBuilder.e
    world_count: 4
    body_count: 8
 
-If the replicated builder does not need further modification, use
-:meth:`~newton.ModelBuilder.replicate_and_finalize` to perform the two operations
-atomically. It produces the same model while forwarding the contiguous arrays
-created during replication directly to finalization through a private,
-single-use builder. It also defers cyclic garbage collection until that builder
-has been discarded, replacing collections during construction with one final
-collection. The destination builder is not modified. Add global entities and
-configure the destination builder before calling it; use separate
-:meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize`
-calls when the replicated data must be changed in between.
+If the replicated builder needs no further modification, :meth:`~newton.ModelBuilder.replicate_and_finalize`
+performs both steps in one call and finalizes faster. The destination builder is left unmodified; use separate
+:meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize` calls when the replicated data
+must be changed in between.
 
 .. important::
    Call :meth:`~newton.ModelBuilder.approximate_meshes` on the sub-builder

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -265,6 +265,15 @@ While :meth:`~newton.ModelBuilder.begin_world` and :meth:`~newton.ModelBuilder.e
    world_count: 4
    body_count: 8
 
+If the replicated builder does not need further modification, use
+:meth:`~newton.ModelBuilder.replicate_and_finalize` to perform the two operations
+atomically. It produces the same model while forwarding the contiguous arrays
+created during replication directly to finalization through a private,
+single-use builder. The destination builder is not modified. Add global entities
+and configure the destination builder before calling it; use separate
+:meth:`~newton.ModelBuilder.replicate` and :meth:`~newton.ModelBuilder.finalize`
+calls when the replicated data must be changed in between.
+
 .. important::
    Call :meth:`~newton.ModelBuilder.approximate_meshes` on the sub-builder
    **before** passing it to :meth:`~newton.ModelBuilder.replicate`.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -3317,7 +3317,10 @@ class ModelBuilder:
 
         world_range = np.arange(world_count, dtype=np.int64)
         start_arrays = {kind: base + world_range * counts[kind] for kind, base in bases.items()}
-        start_arrays["muscle_point"] = len(self.muscle_bodies) + world_range * len(builder.muscle_bodies)
+        # muscle_point has no count attribute, so its base is the waypoint count. Read it from array_starts
+        # when muscle_bodies is array-backed: it was already resized above to hold the replicated worlds.
+        muscle_point_base = array_starts.get("muscle_bodies", len(self.muscle_bodies))
+        start_arrays["muscle_point"] = muscle_point_base + world_range * len(builder.muscle_bodies)
 
         def starts(kind: str) -> np.ndarray:
             return start_arrays[kind]
@@ -12815,7 +12818,7 @@ class ModelBuilder:
                                 warnings.warn(
                                     f"Texture SDF construction failed for shape {i} "
                                     f"(type={shape_type}): {e}. Falling back to BVH.",
-                                    stacklevel=2,
+                                    stacklevel=3,
                                 )
                                 tex_data = create_empty_texture_sdf_data()
                                 c_tex = None
@@ -12895,7 +12898,7 @@ class ModelBuilder:
                         warnings.warn(
                             f"Full-surface SDF construction failed for mesh shape {i} ({e}); it falls "
                             "back to the legacy per-particle soft-contact path.",
-                            stacklevel=2,
+                            stacklevel=3,
                         )
                         continue
                     wt_idx = len(compact_texture_sdf_data)
@@ -12926,7 +12929,7 @@ class ModelBuilder:
                 warnings.warn(
                     "Heightfield-vs-heightfield collision is not supported; "
                     "contacts between heightfield pairs will be skipped.",
-                    stacklevel=2,
+                    stacklevel=3,
                 )
             from ..utils.heightfield import HeightfieldData, create_empty_heightfield_data  # noqa: PLC0415
 
@@ -13220,7 +13223,7 @@ class ModelBuilder:
                         warnings.warn(
                             f"Inertia validation corrected {num_corrections} bodies. "
                             f"Set validate_inertia_detailed=True for detailed per-body warnings.",
-                            stacklevel=2,
+                            stacklevel=3,
                         )
 
                     # Use the corrected arrays directly on the Model.
@@ -13295,7 +13298,7 @@ class ModelBuilder:
                         "will be removed. Set newton.use_coord_layout_targets = True before "
                         "building models and index targets via Model.joint_target_q_start.",
                         DeprecationWarning,
-                        stacklevel=2,
+                        stacklevel=3,
                     )
                 target_q_values = self._project_target_q_to_dof()
             m.joint_target_q = wp.array(target_q_values, dtype=wp.float32, requires_grad=requires_grad)
@@ -13509,7 +13512,7 @@ class ModelBuilder:
                             f"Custom attribute '{full_key}' has {attr_count} values but frequency '{freq_key}' "
                             f"expects {expected_count}. Missing values will be filled with defaults.",
                             UserWarning,
-                            stacklevel=2,
+                            stacklevel=3,
                         )
 
             # Store custom frequency counts on the model for selection.py and other consumers

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -148,10 +148,9 @@ _IDENTITY_ROTATION = np.asarray(wp.quatf(0.0, 0.0, 0.0, 1.0), dtype=np.float32)
 
 @functools.cache
 def _model_array_dtypes() -> dict[str, Any]:
-    """Warp dtypes from the instance annotations in ``Model.__init__``.
+    """Warp dtypes for the ``Model`` array attributes, read from the annotations in ``Model.__init__``.
 
-    Read on first use rather than at import: only replication into contiguous arrays needs
-    them, and reading them requires the source of ``Model.__init__`` to be available.
+    Deferred to first use: only array-backed replication needs them, and reading them requires source access.
     """
     import ast  # noqa: PLC0415
     import textwrap  # noqa: PLC0415
@@ -189,8 +188,7 @@ def _model_array_dtypes() -> dict[str, Any]:
     return result
 
 
-# These numeric fields drive large Python loops during finalization. Keeping
-# them as lists avoids boxing a NumPy scalar on every iteration.
+# Excluded from array backing: finalization loops over these in Python, where NumPy elements box a scalar per access.
 _FINALIZE_LIST_CONTROL_FLOW_FIELDS = frozenset({"shape_flags", "shape_type", "joint_type", "joint_dof_dim"})
 
 
@@ -2968,13 +2966,12 @@ class ModelBuilder:
     joint_target_vel = RemovedAttribute("joint_target_qd", removed_in="1.5")
 
     def _project_target_q_to_dof(self) -> list[float] | np.ndarray:
-        """Drop the quat-w padding slot for FREE/BALL/DISTANCE joints to turn
-        the coord-sized :attr:`joint_target_q` buffer into a DOF-shaped list.
+        """Drop the quat-w padding slot for FREE/BALL/DISTANCE joints to turn the coord-sized
+        :attr:`joint_target_q` buffer into a DOF-shaped one.
 
-        Under :data:`newton.use_coord_layout_targets` ``False`` the builder
-        stores raw per-axis angles (extrinsic ZYX) in the first 3 quat slots
-        and a placeholder ``1.0`` in the 4th — this method just slices the
-        placeholder off to produce the legacy DOF-shaped ``Model.joint_target_q``.
+        Under :data:`newton.use_coord_layout_targets` ``False`` the builder stores raw per-axis angles (extrinsic
+        ZYX) in the first 3 quat slots and a placeholder ``1.0`` in the 4th — this method just slices the placeholder
+        off to produce the legacy DOF-shaped ``Model.joint_target_q``.
         """
         if isinstance(self.joint_target_q, np.ndarray):
             joint_types = np.asarray(self.joint_type, dtype=np.int32)
@@ -3101,30 +3098,25 @@ class ModelBuilder:
     ) -> Model:
         """Replicate a builder and immediately finalize the resulting model.
 
-        This is equivalent to calling :meth:`replicate` followed by :meth:`finalize`,
-        but performs the replication on a private, single-use copy of this builder.
-        Dense numeric attributes on that copy are stored directly as contiguous arrays
-        and the copy is discarded after finalization. This builder is not modified. Use
-        the separate calls when the replicated builder must be modified before
-        finalization. When cyclic garbage collection is enabled, it is deferred until
-        the single-use builder has been discarded, then run once before this method
-        returns. An already-disabled collector remains disabled.
+        Equivalent to :meth:`replicate` followed by :meth:`finalize`, but faster, and leaves this builder unmodified.
+        Use the separate calls when the replicated data must be changed in between. Cyclic garbage collection is
+        suspended for the duration.
 
         Args:
             builder: The builder to replicate.
             world_count: The number of worlds to create.
             spacing: The spacing between replicated worlds. Ignored when ``xforms`` is provided.
             xforms: Optional sequence of transforms, one per replicated world.
-            label_prefixes: Optional prefix prepended to all labels from ``builder``, one per
-                replicated world. See :meth:`replicate`.
-            device: Device on which to allocate the model.
+            label_prefixes: Optional prefix prepended to all labels from ``builder``, one per replicated world.
+                See :meth:`replicate`.
+            device: Device on which to allocate the model. If None, uses the current Warp device.
             requires_grad: Whether model arrays require gradients.
             skip_all_validations: Whether to skip all validation checks.
-            skip_validation_worlds: Whether to skip world-ordering validation.
-            skip_validation_joints: Whether to skip joint-membership validation.
-            skip_validation_shapes: Whether to skip shape-margin validation.
-            skip_validation_structure: Whether to skip structural validation.
-            skip_validation_joint_ordering: Whether to skip joint-ordering validation.
+            skip_validation_worlds: Whether to skip world ordering and contiguity validation.
+            skip_validation_joints: Whether to skip articulation-membership validation.
+            skip_validation_shapes: Whether to skip contact-margin validation.
+            skip_validation_structure: Whether to skip structural-invariant validation.
+            skip_validation_joint_ordering: Whether to skip DFS joint-ordering validation.
 
         Returns:
             The finalized replicated model.
@@ -3311,8 +3303,7 @@ class ModelBuilder:
                 prefix = np.asarray(prefix_values, dtype=numpy_dtype)
                 source = np.asarray(source_values, dtype=numpy_dtype)
                 if not element_shape:
-                    # Scalar Warp arrays can still be assembled from rows (for example,
-                    # triangle indices). Infer that builder-only layout from the data.
+                    # Scalar arrays may still be built row-wise (tri_indices); take the row width from the data.
                     shaped = source if source.ndim > 1 else prefix
                     if shaped.ndim > 1:
                         element_shape = shaped.shape[1:]

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -16,7 +16,7 @@ import warnings
 import weakref
 from collections import Counter, deque
 from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import numpy as np
@@ -3157,29 +3157,18 @@ class ModelBuilder:
                 setattr(scratch, name, set(value))
 
         scratch.body_shapes = {body: list(shapes) for body, shapes in self.body_shapes.items()}
-        scratch.joint_parents = {body: list(joints) for body, joints in self.joint_parents.items()}
         scratch.joint_children = {body: list(joints) for body, joints in self.joint_children.items()}
 
-        scratch.custom_attributes = {}
-        for key, attribute in self.custom_attributes.items():
-            values = attribute.values
-            if isinstance(values, list):
-                values = list(values)
-            elif isinstance(values, dict):
-                values = dict(values)
-            scratch.custom_attributes[key] = replace(attribute, values=values)
+        def fork_record(record: Any) -> Any:
+            copies = {}
+            for field in fields(record):
+                value = getattr(record, field.name)
+                if isinstance(value, (list, dict)):
+                    copies[field.name] = copy.copy(value)
+            return replace(record, **copies)
 
-        scratch.actuator_entries = {
-            key: replace(
-                entry,
-                indices=list(entry.indices),
-                pos_indices=list(entry.pos_indices),
-                controller_args=list(entry.controller_args),
-                delay_args=list(entry.delay_args),
-                clamping_args=list(entry.clamping_args),
-            )
-            for key, entry in self.actuator_entries.items()
-        }
+        scratch.custom_attributes = {key: fork_record(value) for key, value in self.custom_attributes.items()}
+        scratch.actuator_entries = {key: fork_record(value) for key, value in self.actuator_entries.items()}
 
         filter_pairs = self._shape_collision_filter_pairs
         if isinstance(filter_pairs, _BuilderShapeCollisionFilterPairs):

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import copy
 import ctypes
 import functools
+import gc
 import inspect
 import math
 import os
@@ -3105,7 +3106,9 @@ class ModelBuilder:
         Dense numeric attributes on that copy are stored directly as contiguous arrays
         and the copy is discarded after finalization. This builder is not modified. Use
         the separate calls when the replicated builder must be modified before
-        finalization.
+        finalization. When cyclic garbage collection is enabled, it is deferred until
+        the single-use builder has been discarded, then run once before this method
+        returns. An already-disabled collector remains disabled.
 
         Args:
             builder: The builder to replicate.
@@ -3126,20 +3129,31 @@ class ModelBuilder:
         Returns:
             The finalized replicated model.
         """
-        scratch = self._fork_for_finalize()
-        scratch._replicate(
-            builder, world_count, spacing, xforms=xforms, label_prefixes=label_prefixes, array_backed=True
-        )
-        return scratch._finalize(
-            device,
-            requires_grad=requires_grad,
-            skip_all_validations=skip_all_validations,
-            skip_validation_worlds=skip_validation_worlds,
-            skip_validation_joints=skip_validation_joints,
-            skip_validation_shapes=skip_validation_shapes,
-            skip_validation_structure=skip_validation_structure,
-            skip_validation_joint_ordering=skip_validation_joint_ordering,
-        )
+        collect_garbage = gc.isenabled()
+        if collect_garbage:
+            gc.disable()
+        scratch = None
+        try:
+            scratch = self._fork_for_finalize()
+            scratch._replicate(
+                builder, world_count, spacing, xforms=xforms, label_prefixes=label_prefixes, array_backed=True
+            )
+            model = scratch._finalize(
+                device,
+                requires_grad=requires_grad,
+                skip_all_validations=skip_all_validations,
+                skip_validation_worlds=skip_validation_worlds,
+                skip_validation_joints=skip_validation_joints,
+                skip_validation_shapes=skip_validation_shapes,
+                skip_validation_structure=skip_validation_structure,
+                skip_validation_joint_ordering=skip_validation_joint_ordering,
+            )
+        finally:
+            del scratch
+            if collect_garbage:
+                gc.enable()
+                gc.collect()
+        return model
 
     def _fork_for_finalize(self) -> ModelBuilder:
         """Create a single-use builder with independent mutable containers."""

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -144,6 +144,55 @@ _SCALAR_GRAVITY_DEPRECATION_MSG = (
 _IDENTITY_TRANSFORM = np.asarray(wp.transformf((0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0)), dtype=np.float32)
 _IDENTITY_ROTATION = np.asarray(wp.quatf(0.0, 0.0, 0.0, 1.0), dtype=np.float32)
 
+
+@functools.cache
+def _model_array_dtypes() -> dict[str, Any]:
+    """Warp dtypes from the instance annotations in ``Model.__init__``.
+
+    Read on first use rather than at import: only replication into contiguous arrays needs
+    them, and reading them requires the source of ``Model.__init__`` to be available.
+    """
+    import ast  # noqa: PLC0415
+    import textwrap  # noqa: PLC0415
+
+    init_source = textwrap.dedent(inspect.getsource(Model.__init__))
+    init_node = ast.parse(init_source).body[0]
+    result = {}
+    for node in ast.walk(init_node):
+        if not (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Attribute)
+            and isinstance(node.target.value, ast.Name)
+            and node.target.value.id == "self"
+        ):
+            continue
+        array_annotation = next(
+            (
+                candidate
+                for candidate in ast.walk(node.annotation)
+                if isinstance(candidate, ast.Subscript)
+                and isinstance(candidate.value, ast.Attribute)
+                and isinstance(candidate.value.value, ast.Name)
+                and candidate.value.value.id == "wp"
+                and candidate.value.attr.startswith("array")
+            ),
+            None,
+        )
+        if (
+            array_annotation is not None
+            and isinstance(array_annotation.slice, ast.Attribute)
+            and isinstance(array_annotation.slice.value, ast.Name)
+            and array_annotation.slice.value.id == "wp"
+        ):
+            result[node.target.attr] = getattr(wp, array_annotation.slice.attr)
+    return result
+
+
+# These numeric fields drive large Python loops during finalization. Keeping
+# them as lists avoids boxing a NumPy scalar on every iteration.
+_FINALIZE_LIST_CONTROL_FLOW_FIELDS = frozenset({"shape_flags", "shape_type", "joint_type", "joint_dof_dim"})
+
+
 _MERGE_VALIDATION_CACHE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 """Memoizes :meth:`ModelBuilder._validate_builder_merge` as ``dest -> {source: schema epochs}``.
 
@@ -2917,7 +2966,7 @@ class ModelBuilder:
     joint_target_pos = RemovedAttribute("joint_target_q", removed_in="1.5")
     joint_target_vel = RemovedAttribute("joint_target_qd", removed_in="1.5")
 
-    def _project_target_q_to_dof(self) -> list[float]:
+    def _project_target_q_to_dof(self) -> list[float] | np.ndarray:
         """Drop the quat-w padding slot for FREE/BALL/DISTANCE joints to turn
         the coord-sized :attr:`joint_target_q` buffer into a DOF-shaped list.
 
@@ -2926,6 +2975,16 @@ class ModelBuilder:
         and a placeholder ``1.0`` in the 4th — this method just slices the
         placeholder off to produce the legacy DOF-shaped ``Model.joint_target_q``.
         """
+        if isinstance(self.joint_target_q, np.ndarray):
+            joint_types = np.asarray(self.joint_type, dtype=np.int32)
+            ball_mask = joint_types == int(JointType.BALL)
+            padding_mask = ball_mask | (joint_types == int(JointType.FREE)) | (joint_types == int(JointType.DISTANCE))
+            padding_indices = np.asarray(self.joint_q_start, dtype=np.int64)[padding_mask]
+            padding_indices += np.where(ball_mask[padding_mask], 3, 6)
+            keep = np.ones(len(self.joint_target_q), dtype=np.bool_)
+            keep[padding_indices] = False
+            return self.joint_target_q[keep]
+
         result: list[float] = []
         for j, jtype in enumerate(self.joint_type):
             q_start = self.joint_q_start[j]
@@ -3020,6 +3079,124 @@ class ModelBuilder:
                 world's labels as they are in ``builder``; an empty source label remains
                 unlabeled.
         """
+        self._replicate(builder, world_count, spacing, xforms=xforms, label_prefixes=label_prefixes)
+
+    def replicate_and_finalize(
+        self,
+        builder: ModelBuilder,
+        world_count: int,
+        spacing: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        *,
+        xforms: Sequence[Transform] | None = None,
+        label_prefixes: Sequence[str | None] | None = None,
+        device: Devicelike | None = None,
+        requires_grad: bool = False,
+        skip_all_validations: bool = False,
+        skip_validation_worlds: bool = False,
+        skip_validation_joints: bool = False,
+        skip_validation_shapes: bool = False,
+        skip_validation_structure: bool = False,
+        skip_validation_joint_ordering: bool = True,
+    ) -> Model:
+        """Replicate a builder and immediately finalize the resulting model.
+
+        This is equivalent to calling :meth:`replicate` followed by :meth:`finalize`,
+        but performs the replication on a private, single-use copy of this builder.
+        Dense numeric attributes on that copy are stored directly as contiguous arrays
+        and the copy is discarded after finalization. This builder is not modified. Use
+        the separate calls when the replicated builder must be modified before
+        finalization.
+
+        Args:
+            builder: The builder to replicate.
+            world_count: The number of worlds to create.
+            spacing: The spacing between replicated worlds. Ignored when ``xforms`` is provided.
+            xforms: Optional sequence of transforms, one per replicated world.
+            label_prefixes: Optional prefix prepended to all labels from ``builder``, one per
+                replicated world. See :meth:`replicate`.
+            device: Device on which to allocate the model.
+            requires_grad: Whether model arrays require gradients.
+            skip_all_validations: Whether to skip all validation checks.
+            skip_validation_worlds: Whether to skip world-ordering validation.
+            skip_validation_joints: Whether to skip joint-membership validation.
+            skip_validation_shapes: Whether to skip shape-margin validation.
+            skip_validation_structure: Whether to skip structural validation.
+            skip_validation_joint_ordering: Whether to skip joint-ordering validation.
+
+        Returns:
+            The finalized replicated model.
+        """
+        scratch = self._fork_for_finalize()
+        scratch._replicate(
+            builder, world_count, spacing, xforms=xforms, label_prefixes=label_prefixes, array_backed=True
+        )
+        return scratch._finalize(
+            device,
+            requires_grad=requires_grad,
+            skip_all_validations=skip_all_validations,
+            skip_validation_worlds=skip_validation_worlds,
+            skip_validation_joints=skip_validation_joints,
+            skip_validation_shapes=skip_validation_shapes,
+            skip_validation_structure=skip_validation_structure,
+            skip_validation_joint_ordering=skip_validation_joint_ordering,
+        )
+
+    def _fork_for_finalize(self) -> ModelBuilder:
+        """Create a single-use builder with independent mutable containers."""
+        scratch = copy.copy(self)
+        for name, value in vars(self).items():
+            if isinstance(value, list):
+                setattr(scratch, name, list(value))
+            elif isinstance(value, dict):
+                setattr(scratch, name, dict(value))
+            elif isinstance(value, set):
+                setattr(scratch, name, set(value))
+
+        scratch.body_shapes = {body: list(shapes) for body, shapes in self.body_shapes.items()}
+        scratch.joint_parents = {body: list(joints) for body, joints in self.joint_parents.items()}
+        scratch.joint_children = {body: list(joints) for body, joints in self.joint_children.items()}
+
+        scratch.custom_attributes = {}
+        for key, attribute in self.custom_attributes.items():
+            values = attribute.values
+            if isinstance(values, list):
+                values = list(values)
+            elif isinstance(values, dict):
+                values = dict(values)
+            scratch.custom_attributes[key] = replace(attribute, values=values)
+
+        scratch.actuator_entries = {
+            key: replace(
+                entry,
+                indices=list(entry.indices),
+                pos_indices=list(entry.pos_indices),
+                controller_args=list(entry.controller_args),
+                delay_args=list(entry.delay_args),
+                clamping_args=list(entry.clamping_args),
+            )
+            for key, entry in self.actuator_entries.items()
+        }
+
+        filter_pairs = self._shape_collision_filter_pairs
+        if isinstance(filter_pairs, _BuilderShapeCollisionFilterPairs):
+            scratch_filter_pairs = copy.copy(filter_pairs)
+            scratch_filter_pairs._entries = list(filter_pairs._entries)
+            scratch._shape_collision_filter_pairs = scratch_filter_pairs
+        else:
+            scratch._shape_collision_filter_pairs = list(filter_pairs)
+        scratch._merge_filter_template = None
+        return scratch
+
+    def _replicate(
+        self,
+        builder: ModelBuilder,
+        world_count: int,
+        spacing: tuple[float, float, float],
+        *,
+        xforms: Sequence[Transform] | None,
+        label_prefixes: Sequence[str | None] | None = None,
+        array_backed: bool = False,
+    ) -> None:
         if world_count <= 0:
             return
         if self.current_world != -1:
@@ -3039,7 +3216,13 @@ class ModelBuilder:
 
         base_world = self.world_count
         worlds = list(range(base_world, base_world + world_count))
-        self._merge_builder_copies(builder, worlds, xforms, label_prefixes)
+        self._merge_builder_copies(
+            builder,
+            worlds,
+            xforms,
+            label_prefixes,
+            array_backed=array_backed,
+        )
 
         self.world_gravity.extend(builder._gravity_as_vector() for _ in range(world_count))
         self.world_count += world_count
@@ -3050,6 +3233,8 @@ class ModelBuilder:
         worlds: Sequence[int],
         xforms: Sequence[Transform | None],
         label_prefixes: Sequence[str | None],
+        *,
+        array_backed: bool = False,
     ) -> None:
         if builder.up_axis != self.up_axis:
             raise ValueError("Cannot add a builder with a different up axis.")
@@ -3094,6 +3279,37 @@ class ModelBuilder:
         attribute_specs = self._builder_merge_attribute_specs()
         bases = self._builder_merge_counts(self)
 
+        array_starts = {}
+        if array_backed:
+            for attr, warp_dtype in _model_array_dtypes().items():
+                spec = attribute_specs.get(attr)
+                if spec is None or attr in _FINALIZE_LIST_CONTROL_FLOW_FIELDS or spec.compaction_policy != "generic":
+                    continue
+                prefix_values = getattr(self, attr)
+                source_values = getattr(builder, attr)
+                if len(prefix_values) == 0 and len(source_values) == 0:
+                    continue
+
+                scalar_dtype = getattr(warp_dtype, "_wp_scalar_type_", warp_dtype)
+                numpy_dtype = wp.dtype_to_numpy(scalar_dtype)
+                element_shape = tuple(getattr(warp_dtype, "_shape_", ()))
+
+                prefix = np.asarray(prefix_values, dtype=numpy_dtype)
+                source = np.asarray(source_values, dtype=numpy_dtype)
+                if not element_shape:
+                    # Scalar Warp arrays can still be assembled from rows (for example,
+                    # triangle indices). Infer that builder-only layout from the data.
+                    shaped = source if source.ndim > 1 else prefix
+                    if shaped.ndim > 1:
+                        element_shape = shaped.shape[1:]
+                prefix = prefix.reshape((-1, *element_shape))
+                source = source.reshape((-1, *element_shape))
+                values = np.empty((len(prefix) + world_count * len(source), *element_shape), dtype=numpy_dtype)
+                values[: len(prefix)] = prefix
+                values[len(prefix) :].reshape((world_count, len(source), *element_shape))[:] = source
+                setattr(self, attr, values)
+                array_starts[attr] = len(prefix)
+
         world_range = np.arange(world_count, dtype=np.int64)
         start_arrays = {kind: base + world_range * counts[kind] for kind, base in bases.items()}
         start_arrays["muscle_point"] = len(self.muscle_bodies) + world_range * len(builder.muscle_bodies)
@@ -3101,10 +3317,18 @@ class ModelBuilder:
         def starts(kind: str) -> np.ndarray:
             return start_arrays[kind]
 
-        def extend_referenced(dst: list, values: Sequence[Any], kind: str) -> None:
-            if not values:
+        def extend_referenced(attr: str, dst: list | np.ndarray, values: Sequence[Any], kind: str) -> None:
+            if len(values) == 0:
                 return
             source = np.asarray(values, dtype=np.int64)
+            if isinstance(dst, np.ndarray):
+                target = dst[array_starts[attr] :].reshape((world_count, *source.shape))
+                target[:] = source
+                reference_starts = np.asarray(starts(kind), dtype=dst.dtype).reshape(
+                    (world_count,) + (1,) * source.ndim
+                )
+                np.add(target, reference_starts, out=target, where=target >= 0)
+                return
             if world_count == 1:
                 start = int(start_arrays[kind][0])
                 dst.extend(np.where(source >= 0, source + start, source).tolist())
@@ -3123,14 +3347,18 @@ class ModelBuilder:
             self.particle_max_velocity = builder.particle_max_velocity
             particle_q = np.tile(np.asarray(builder.particle_q, dtype=np.float32), (world_count, 1))
             particle_q += np.repeat(offsets, counts["particle"], axis=0)
-            self.particle_q.extend(particle_q.tolist())
+            if "particle_q" in array_starts:
+                self.particle_q[array_starts["particle_q"] :] = particle_q
+            else:
+                self.particle_q.extend(particle_q.tolist())
 
         shape_starts = starts("shape")
         body_starts = starts("body")
 
-        attribute_specs.pop("shape_transform")
-        shape_transform_start = len(self.shape_transform)
-        self.shape_transform.extend(source_list("shape_transform") * world_count)
+        attribute_specs.pop("shape_transform", None)
+        shape_transform_start = array_starts.get("shape_transform", int(bases["shape"]))
+        if "shape_transform" not in array_starts:
+            self.shape_transform.extend(source_list("shape_transform") * world_count)
         if counts["shape"]:
             static_shapes = np.flatnonzero(np.asarray(builder.shape_body, dtype=np.int64) == -1)
             for world_index, xform in enumerate(xforms):
@@ -3139,7 +3367,8 @@ class ModelBuilder:
                 for shape in static_shapes.tolist():
                     source = wp.transform(*builder.shape_transform[shape])
                     target = shape_transform_start + world_index * counts["shape"] + shape
-                    self.shape_transform[target] = transform_mul(xform, source)
+                    transformed = transform_mul(xform, source)
+                    self.shape_transform[target] = transformed
 
         for body_start, shape_start in zip(body_starts, shape_starts, strict=True):
             for body, shapes in builder.body_shapes.items():
@@ -3153,10 +3382,11 @@ class ModelBuilder:
         joint_coord_starts = starts("joint_coord")
         joint_dof_starts = starts("joint_dof")
 
-        attribute_specs.pop("joint_X_p")
+        attribute_specs.pop("joint_X_p", None)
         attribute_specs.pop("joint_q")
-        joint_X_p_start = len(self.joint_X_p)
-        self.joint_X_p.extend(source_list("joint_X_p") * world_count)
+        joint_X_p_start = array_starts.get("joint_X_p", int(bases["joint"]))
+        if "joint_X_p" not in array_starts:
+            self.joint_X_p.extend(source_list("joint_X_p") * world_count)
         joint_q = np.tile(np.asarray(builder.joint_q, dtype=np.float32), world_count)
         if counts["joint"]:
             joint_types = np.asarray(builder.joint_type, dtype=np.int64)
@@ -3168,7 +3398,8 @@ class ModelBuilder:
                 for joint in nonfree_roots.tolist():
                     source = wp.transform(*builder.joint_X_p[joint])
                     target = joint_X_p_start + world_index * counts["joint"] + joint
-                    self.joint_X_p[target] = transform_mul(xform, source)
+                    transformed = transform_mul(xform, source)
+                    self.joint_X_p[target] = transformed
 
             free_roots = np.flatnonzero((joint_parents == -1) & (joint_types == int(JointType.FREE)))
             if len(free_roots) and any(xform is not None for xform in xforms):
@@ -3189,7 +3420,10 @@ class ModelBuilder:
                         target_q = coord_base + source_q
                         joint_q[target_q : target_q + 7] = np.asarray(transformed, dtype=np.float32)
 
-        self.joint_q.extend(joint_q.tolist())
+        if "joint_q" in array_starts:
+            self.joint_q[array_starts["joint_q"] :] = joint_q
+        else:
+            self.joint_q.extend(joint_q.tolist())
 
         for world_index, joint_start in enumerate(joint_starts.tolist()):
             body_start = int(body_starts[world_index])
@@ -3201,20 +3435,34 @@ class ModelBuilder:
                 self.joint_parents.setdefault(new_child, []).append((new_parent, joint))
                 self.joint_children.setdefault(new_parent, []).append((new_child, joint))
 
-        attribute_specs.pop("body_q")
+        attribute_specs.pop("body_q", None)
         if counts["body"]:
             if translations_only:
                 body_q = np.tile(np.asarray(builder.body_q, dtype=np.float32).reshape((-1, 7)), (world_count, 1))
                 if np.any(offsets):
                     body_q[:, :3] += np.repeat(offsets, counts["body"], axis=0)
-                # Own each transform without retaining per-row views into the tiled array.
-                self.body_q.extend(wp.transform.from_buffer_copy(row) for row in body_q)
+                if "body_q" in array_starts:
+                    self.body_q[array_starts["body_q"] :] = body_q
+                else:
+                    # Own each transform without retaining per-row views into the tiled array.
+                    self.body_q.extend(wp.transform.from_buffer_copy(row) for row in body_q)
             else:
+                body_q_target = array_starts.get("body_q", int(bases["body"]))
                 for xform in xforms:
                     if xform is None:
-                        self.body_q.extend(wp.transform(*body_q) for body_q in builder.body_q)
+                        if "body_q" not in array_starts:
+                            self.body_q.extend(wp.transform(*source_body_q) for source_body_q in builder.body_q)
+                        body_q_target += counts["body"]
+                        continue
+                    if "body_q" in array_starts:
+                        for body, source_body_q in enumerate(builder.body_q):
+                            transformed = transform_mul(xform, wp.transform(*source_body_q))
+                            self.body_q[body_q_target + body] = transformed
                     else:
-                        self.body_q.extend(transform_mul(xform, wp.transform(*body_q)) for body_q in builder.body_q)
+                        self.body_q.extend(
+                            transform_mul(xform, wp.transform(*source_body_q)) for source_body_q in builder.body_q
+                        )
+                    body_q_target += counts["body"]
 
         source_filter_pairs = builder._shape_collision_filter_pairs
         if source_filter_pairs:
@@ -3235,10 +3483,24 @@ class ModelBuilder:
         for attr, spec in attribute_specs.items():
             if spec.compaction_policy in {"world_start", "passthrough"}:
                 continue
-            source = source_list(attr)
-            if not source:
+            source_values = getattr(builder, attr)
+            if len(source_values) == 0:
                 continue
             destination = getattr(self, attr)
+            if attr in array_starts:
+                if spec.references in {Model.AttributeFrequency.WORLD, "world"}:
+                    source_count = counts.get(self._builder_frequency_key(spec.frequency), len(source_values))
+                    destination[array_starts[attr] :] = np.repeat(worlds, source_count)
+                elif spec.references is not None:
+                    extend_referenced(
+                        attr,
+                        destination,
+                        source_values,
+                        self._builder_frequency_key(spec.references),
+                    )
+                continue
+
+            source = source_list(attr)
             if spec.compaction_policy == "color_groups":
                 kind = self._builder_frequency_key(spec.frequency)
                 source_groups = [np.asarray(group, dtype=np.int64) for group in source]
@@ -3266,7 +3528,7 @@ class ModelBuilder:
                 source_count = counts.get(self._builder_frequency_key(spec.frequency), len(source))
                 destination.extend(np.repeat(worlds, source_count).tolist())
             elif spec.references is not None:
-                extend_referenced(destination, source, self._builder_frequency_key(spec.references))
+                extend_referenced(attr, destination, source, self._builder_frequency_key(spec.references))
             else:
                 destination.extend(source * world_count)
 
@@ -11001,7 +11263,7 @@ class ModelBuilder:
         all_world_indices = set()
 
         for array_name, world_array in world_arrays:
-            if not world_array:
+            if len(world_array) == 0:
                 continue
 
             arr = np.array(world_array, dtype=np.int32)
@@ -11842,7 +12104,29 @@ class ModelBuilder:
             - Sets up all arrays and properties required for simulation, including particles, bodies, shapes,
               joints, springs, muscles, constraints, and collision/contact data.
         """
+        return self._finalize(
+            device,
+            requires_grad=requires_grad,
+            skip_all_validations=skip_all_validations,
+            skip_validation_worlds=skip_validation_worlds,
+            skip_validation_joints=skip_validation_joints,
+            skip_validation_shapes=skip_validation_shapes,
+            skip_validation_structure=skip_validation_structure,
+            skip_validation_joint_ordering=skip_validation_joint_ordering,
+        )
 
+    def _finalize(
+        self,
+        device: Devicelike | None = None,
+        *,
+        requires_grad: bool = False,
+        skip_all_validations: bool = False,
+        skip_validation_worlds: bool = False,
+        skip_validation_joints: bool = False,
+        skip_validation_shapes: bool = False,
+        skip_validation_structure: bool = False,
+        skip_validation_joint_ordering: bool = True,
+    ) -> Model:
         # ensure the world count is set correctly
         self.world_count = max(1, self.world_count)
 
@@ -11900,7 +12184,12 @@ class ModelBuilder:
             m.particle_mass = wp.array(self.particle_mass, dtype=wp.float32, requires_grad=requires_grad)
             m.particle_inv_mass = wp.array(particle_inv_mass, dtype=wp.float32, requires_grad=requires_grad)
             m.particle_radius = wp.array(self.particle_radius, dtype=wp.float32, requires_grad=requires_grad)
-            m.particle_flags = wp.array([flag_to_int(f) for f in self.particle_flags], dtype=wp.int32)
+            particle_flags = (
+                self.particle_flags
+                if isinstance(self.particle_flags, np.ndarray)
+                else [flag_to_int(f) for f in self.particle_flags]
+            )
+            m.particle_flags = wp.array(particle_flags, dtype=wp.int32)
             m.particle_world = wp.array(self.particle_world, dtype=wp.int32)
             m.particle_max_radius = np.max(self.particle_radius) if len(self.particle_radius) > 0 else 0.0
             m.particle_max_velocity = self.particle_max_velocity
@@ -12810,7 +13099,7 @@ class ModelBuilder:
             # derive the edge/triangle maps against the final triangles.
             edge_indices = (
                 np.array(self.edge_indices, dtype=np.int32).reshape(-1, 4)
-                if self.edge_indices
+                if len(self.edge_indices) > 0
                 else np.empty((0, 4), dtype=np.int32)
             )
             m.soft_mesh_adjacency = MeshAdjacency(
@@ -12965,7 +13254,7 @@ class ModelBuilder:
             m.joint_child = wp.array(self.joint_child, dtype=wp.int32)
             m.joint_X_p = wp.array(self.joint_X_p, dtype=wp.transform, requires_grad=requires_grad)
             m.joint_X_c = wp.array(self.joint_X_c, dtype=wp.transform, requires_grad=requires_grad)
-            m.joint_dof_dim = wp.array(np.array(self.joint_dof_dim), dtype=wp.int32, ndim=2)
+            m.joint_dof_dim = wp.array(np.asarray(self.joint_dof_dim, dtype=np.int32), dtype=wp.int32, ndim=2)
             m.joint_axis = wp.array(self.joint_axis, dtype=wp.vec3, requires_grad=requires_grad)
             m.joint_q = wp.array(self.joint_q, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_qd = wp.array(self.joint_qd, dtype=wp.float32, requires_grad=requires_grad)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -188,7 +188,7 @@ def _model_array_dtypes() -> dict[str, Any]:
     return result
 
 
-# Excluded from array backing: finalization loops over these in Python, where NumPy elements box a scalar per access.
+# Kept as lists because finalize() reads them in Python loops; other looped fields measured too small to add.
 _FINALIZE_LIST_CONTROL_FLOW_FIELDS = frozenset({"shape_flags", "shape_type", "joint_type", "joint_dof_dim"})
 
 
@@ -2966,12 +2966,13 @@ class ModelBuilder:
     joint_target_vel = RemovedAttribute("joint_target_qd", removed_in="1.5")
 
     def _project_target_q_to_dof(self) -> list[float] | np.ndarray:
-        """Drop the quat-w padding slot for FREE/BALL/DISTANCE joints to turn the coord-sized
-        :attr:`joint_target_q` buffer into a DOF-shaped one.
+        """Drop the quat-w padding slot for FREE/BALL/DISTANCE joints to turn
+        the coord-sized :attr:`joint_target_q` buffer into a DOF-shaped one.
 
-        Under :data:`newton.use_coord_layout_targets` ``False`` the builder stores raw per-axis angles (extrinsic
-        ZYX) in the first 3 quat slots and a placeholder ``1.0`` in the 4th — this method just slices the placeholder
-        off to produce the legacy DOF-shaped ``Model.joint_target_q``.
+        Under :data:`newton.use_coord_layout_targets` ``False`` the builder
+        stores raw per-axis angles (extrinsic ZYX) in the first 3 quat slots
+        and a placeholder ``1.0`` in the 4th — this method just slices the
+        placeholder off to produce the legacy DOF-shaped ``Model.joint_target_q``.
         """
         if isinstance(self.joint_target_q, np.ndarray):
             joint_types = np.asarray(self.joint_type, dtype=np.int32)
@@ -3099,8 +3100,8 @@ class ModelBuilder:
         """Replicate a builder and immediately finalize the resulting model.
 
         Equivalent to :meth:`replicate` followed by :meth:`finalize`, but faster, and leaves this builder unmodified.
-        Use the separate calls when the replicated data must be changed in between. Cyclic garbage collection is
-        suspended for the duration.
+        Use the separate calls when the replicated data must be changed in between. Replication and finalization
+        run in a single batched pass; subclass overrides of :meth:`replicate` or :meth:`finalize` are not invoked.
 
         Args:
             builder: The builder to replicate.
@@ -3121,15 +3122,13 @@ class ModelBuilder:
         Returns:
             The finalized replicated model.
         """
-        collect_garbage = gc.isenabled()
-        if collect_garbage:
+        restore_garbage_collection = gc.isenabled()
+        if restore_garbage_collection:
             gc.disable()
         scratch = None
         try:
             scratch = self._fork_for_finalize()
-            scratch._replicate(
-                builder, world_count, spacing, xforms=xforms, label_prefixes=label_prefixes, array_backed=True
-            )
+            scratch._replicate(builder, world_count, spacing, True, xforms=xforms, label_prefixes=label_prefixes)
             model = scratch._finalize(
                 device,
                 requires_grad=requires_grad,
@@ -3142,13 +3141,12 @@ class ModelBuilder:
             )
         finally:
             del scratch
-            if collect_garbage:
+            if restore_garbage_collection:
                 gc.enable()
-                gc.collect()
         return model
 
     def _fork_for_finalize(self) -> ModelBuilder:
-        """Create a single-use builder with independent mutable containers."""
+        """Create a single-use builder whose mutable containers are copies; their elements stay shared."""
         scratch = copy.copy(self)
         for name, value in vars(self).items():
             if isinstance(value, list):
@@ -3198,10 +3196,10 @@ class ModelBuilder:
         builder: ModelBuilder,
         world_count: int,
         spacing: tuple[float, float, float],
+        array_backed: bool = False,
         *,
         xforms: Sequence[Transform] | None,
         label_prefixes: Sequence[str | None] | None = None,
-        array_backed: bool = False,
     ) -> None:
         if world_count <= 0:
             return
@@ -3222,13 +3220,7 @@ class ModelBuilder:
 
         base_world = self.world_count
         worlds = list(range(base_world, base_world + world_count))
-        self._merge_builder_copies(
-            builder,
-            worlds,
-            xforms,
-            label_prefixes,
-            array_backed=array_backed,
-        )
+        self._merge_builder_copies(builder, worlds, xforms, label_prefixes, array_backed)
 
         self.world_gravity.extend(builder._gravity_as_vector() for _ in range(world_count))
         self.world_count += world_count
@@ -3239,7 +3231,6 @@ class ModelBuilder:
         worlds: Sequence[int],
         xforms: Sequence[Transform | None],
         label_prefixes: Sequence[str | None],
-        *,
         array_backed: bool = False,
     ) -> None:
         if builder.up_axis != self.up_axis:
@@ -3317,8 +3308,7 @@ class ModelBuilder:
 
         world_range = np.arange(world_count, dtype=np.int64)
         start_arrays = {kind: base + world_range * counts[kind] for kind, base in bases.items()}
-        # muscle_point has no count attribute, so its base is the waypoint count. Read it from array_starts
-        # when muscle_bodies is array-backed: it was already resized above to hold the replicated worlds.
+        # Array backing already resized muscle_bodies, so its pre-merge length has to come from array_starts.
         muscle_point_base = array_starts.get("muscle_bodies", len(self.muscle_bodies))
         start_arrays["muscle_point"] = muscle_point_base + world_range * len(builder.muscle_bodies)
 
@@ -12199,7 +12189,7 @@ class ModelBuilder:
             )
             m.particle_flags = wp.array(particle_flags, dtype=wp.int32)
             m.particle_world = wp.array(self.particle_world, dtype=wp.int32)
-            m.particle_max_radius = np.max(self.particle_radius) if len(self.particle_radius) > 0 else 0.0
+            m.particle_max_radius = float(np.max(self.particle_radius)) if len(self.particle_radius) > 0 else 0.0
             m.particle_max_velocity = self.particle_max_velocity
 
             particle_colors = np.empty(self.particle_count, dtype=int)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -188,7 +188,7 @@ def _model_array_dtypes() -> dict[str, Any]:
     return result
 
 
-# Kept as lists because finalize() reads them in Python loops; other looped fields measured too small to add.
+# Kept as lists because finalize() reads them in Python loops.
 _FINALIZE_LIST_CONTROL_FLOW_FIELDS = frozenset({"shape_flags", "shape_type", "joint_type", "joint_dof_dim"})
 
 
@@ -3100,8 +3100,10 @@ class ModelBuilder:
         """Replicate a builder and immediately finalize the resulting model.
 
         Equivalent to :meth:`replicate` followed by :meth:`finalize`, but faster, and leaves this builder unmodified.
-        Use the separate calls when the replicated data must be changed in between. Replication and finalization
-        run in a single batched pass; subclass overrides of :meth:`replicate` or :meth:`finalize` are not invoked.
+        Use the separate calls when the replicated data must be changed in between. Uses an array-backed merge
+        internally to avoid the list/array conversion cost of two separate calls; subclass overrides of
+        :meth:`replicate` or :meth:`finalize` are not invoked.
+        Garbage collection is disabled process-wide for the duration of the call and restored afterward.
 
         Args:
             builder: The builder to replicate.
@@ -3163,7 +3165,7 @@ class ModelBuilder:
             copies = {}
             for field in fields(record):
                 value = getattr(record, field.name)
-                if isinstance(value, (list, dict)):
+                if isinstance(value, (list, dict, set)):
                     copies[field.name] = copy.copy(value)
             return replace(record, **copies)
 
@@ -3342,7 +3344,7 @@ class ModelBuilder:
         shape_starts = starts("shape")
         body_starts = starts("body")
 
-        attribute_specs.pop("shape_transform", None)
+        attribute_specs.pop("shape_transform")
         shape_transform_start = array_starts.get("shape_transform", int(bases["shape"]))
         if "shape_transform" not in array_starts:
             self.shape_transform.extend(source_list("shape_transform") * world_count)
@@ -3369,7 +3371,7 @@ class ModelBuilder:
         joint_coord_starts = starts("joint_coord")
         joint_dof_starts = starts("joint_dof")
 
-        attribute_specs.pop("joint_X_p", None)
+        attribute_specs.pop("joint_X_p")
         attribute_specs.pop("joint_q")
         joint_X_p_start = array_starts.get("joint_X_p", int(bases["joint"]))
         if "joint_X_p" not in array_starts:
@@ -3422,7 +3424,7 @@ class ModelBuilder:
                 self.joint_parents.setdefault(new_child, []).append((new_parent, joint))
                 self.joint_children.setdefault(new_parent, []).append((new_child, joint))
 
-        attribute_specs.pop("body_q", None)
+        attribute_specs.pop("body_q")
         if counts["body"]:
             if translations_only:
                 body_q = np.tile(np.asarray(builder.body_q, dtype=np.float32).reshape((-1, 7)), (world_count, 1))

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -246,6 +246,26 @@ class TestModelBuilderReplicate(unittest.TestCase):
         self.assertEqual(expected.shape_contact_pair_count, actual.shape_contact_pair_count)
         np.testing.assert_array_equal(expected.shape_contact_pairs.numpy(), actual.shape_contact_pairs.numpy())
 
+    def test_replicate_and_finalize_matches_muscle_waypoints(self):
+        """Offset muscle waypoints by the pre-merge count, not the array-backed allocation length."""
+        source = self._make_source()
+
+        for prefix_worlds in (0, 1):
+            with self.subTest(prefix_worlds=prefix_worlds):
+                expected_builder = ModelBuilder()
+                actual_builder = ModelBuilder()
+                for _ in range(prefix_worlds):
+                    expected_builder.add_builder(source)
+                    actual_builder.add_builder(source)
+
+                expected_builder.replicate(source, 3, spacing=(2.0, 0.0, 0.0))
+                expected = expected_builder.finalize(device="cpu")
+                actual = actual_builder.replicate_and_finalize(source, 3, spacing=(2.0, 0.0, 0.0), device="cpu")
+
+                for name in ("muscle_start", "muscle_bodies", "muscle_points"):
+                    with self.subTest(attribute=name):
+                        np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
+
     def test_replicate_and_finalize_matches_coord_layout_targets(self):
         with mock.patch("newton.use_coord_layout_targets", True):
             source = self._make_source()

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -341,6 +341,26 @@ class TestModelBuilderReplicate(unittest.TestCase):
                 self.assert_builder_merge_state_equal(unchanged_builder, actual_builder)
                 self.assert_models_equal(expected, actual)
 
+    def test_replicate_and_finalize_infers_row_shape_from_prefix(self):
+        """tri_indices row width must come from the destination when the replicated source has no triangles."""
+        source = ModelBuilder()
+        for i in range(3):
+            source.add_particle(wp.vec3(float(i), 0.0, 0.0), wp.vec3(), 1.0)
+
+        def make_destination() -> ModelBuilder:
+            builder = ModelBuilder()
+            particles = [builder.add_particle(wp.vec3(0.0, float(i), 0.0), wp.vec3(), 1.0) for i in range(3)]
+            builder.add_triangle(*particles)
+            return builder
+
+        expected_builder = make_destination()
+        expected_builder.replicate(source, 2, spacing=(1.0, 0.0, 0.0))
+        expected = expected_builder.finalize(device="cpu")
+
+        actual = make_destination().replicate_and_finalize(source, 2, spacing=(1.0, 0.0, 0.0), device="cpu")
+
+        self.assert_models_equal(expected, actual)
+
     def test_replicate_and_finalize_matches_legacy_target_layout(self):
         """Cover the DOF-shaped joint_target_q projection, which only runs while use_coord_layout_targets is
         off. Delete this test together with that flag; every other case runs the coordinate layout."""
@@ -438,22 +458,18 @@ class TestModelBuilderReplicate(unittest.TestCase):
                 self.assertLessEqual(combined_peaks[allocator], separate_peak)
 
     def test_replicate_and_finalize_preserves_gc_state(self):
-        """Restore the collector without forcing a collection, and leave an already-disabled one alone."""
+        """Leave the collector's enabled/disabled state as it was before the call."""
         source = self._make_source()
 
-        with mock.patch.object(gc, "collect", wraps=gc.collect) as collect:
-            ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
-        collect.assert_not_called()
-        self.assertTrue(gc.isenabled())
-
-        gc.disable()
-        try:
-            with mock.patch.object(gc, "collect", wraps=gc.collect) as collect:
-                ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
-            collect.assert_not_called()
-            self.assertFalse(gc.isenabled())
-        finally:
-            gc.enable()
+        for initially_enabled in (True, False):
+            with self.subTest(initially_enabled=initially_enabled):
+                if not initially_enabled:
+                    gc.disable()
+                try:
+                    ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
+                    self.assertEqual(gc.isenabled(), initially_enabled)
+                finally:
+                    gc.enable()
 
     def test_replicate_rejects_mismatched_explicit_transforms(self):
         with self.assertRaisesRegex(ValueError, "xforms must contain 2 entries, got 1"):

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -354,11 +354,13 @@ class TestModelBuilderReplicate(unittest.TestCase):
 
             expected_builder = ModelBuilder()
             expected_builder.replicate(source, _REPLICATE_WORLD_COUNT, spacing=(2.0, 3.0, 0.0))
-            expected = expected_builder.finalize(device="cpu")
+            with self.assertWarnsRegex(DeprecationWarning, "legacy DOF-shaped joint_target_q layout"):
+                expected = expected_builder.finalize(device="cpu")
 
-            actual = ModelBuilder().replicate_and_finalize(
-                source, _REPLICATE_WORLD_COUNT, spacing=(2.0, 3.0, 0.0), device="cpu"
-            )
+            with self.assertWarnsRegex(DeprecationWarning, "legacy DOF-shaped joint_target_q layout"):
+                actual = ModelBuilder().replicate_and_finalize(
+                    source, _REPLICATE_WORLD_COUNT, spacing=(2.0, 3.0, 0.0), device="cpu"
+                )
 
         self.assert_models_equal(expected, actual)
 

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -2,17 +2,74 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
+import os
+import tracemalloc
 import unittest
+from collections.abc import Callable
 from unittest import mock
 
 import numpy as np
 import warp as wp
 
+import newton
 from newton import Mesh, Model, ModelBuilder
-from newton._src.sim.builder import _FINALIZE_LIST_CONTROL_FLOW_FIELDS, _model_array_dtypes
 from newton.actuators import ControllerPD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 from newton.utils import compute_world_offsets
+
+# Runtime handles rebuilt by every finalize(); they carry a device pointer rather than model data.
+_OPAQUE_MODEL_TYPES = (wp.Bvh, wp.HashGrid, wp.Mesh, wp.Volume)
+
+# finalize() writes only part of each of these, leaving the rest as uninitialized memory that varies per run.
+_UNINITIALIZED_MODEL_ATTRIBUTES = ("body_colors", "bvh_shape_enabled", "particle_colors")
+
+# The leading component is downloaded whole, because scenes reference sibling mesh directories.
+_ASSET_SCENES = (
+    "anybotics_anymal_c/urdf/anymal.urdf",
+    "anybotics_anymal_c/usd/anymal_c.usda",
+    "anybotics_anymal_d/usd/anymal_d.usda",
+    "apptronik_apollo/usd_structured/apptronik_apollo.usda",
+    "booster_t1/usd_structured/T1.usda",
+    "disneyresearch/dr_legs/usd/dr_legs.usda",
+    "disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda",
+    "franka_emika_panda/urdf/fr3.urdf",
+    "franka_emika_panda/urdf/fr3_franka_hand.urdf",
+    "manipulation_objects/cup/model.usda",
+    "manipulation_objects/pad/model.usda",
+    "robotiq_2f85_v4/usd_structured/Dual_wrist_camera.usda",
+    "shadow_hand/usd_structured/left_shadow_hand.usda",
+    "style3d/avatars/Female.usd",
+    "style3d/garments/Female_T_Shirt.usd",
+    "unitree_g1/mjcf/g1_29dof_with_hand_rev_1_0.xml",
+    "unitree_g1/usd/g1_isaac.usd",
+    "unitree_g1/usd_structured/g1_29dof_with_hand_rev_1_0.usda",
+    "unitree_go2/usd/go2.usda",
+    "unitree_h1/mjcf/h1_with_hand.xml",
+    "unitree_h1/urdf/h1.urdf",
+    "unitree_h1/usd/h1_minimal.usda",
+    "unitree_h1/usd_structured/h1.usda",
+    "universal_robots_ur10/usd/ur10_instanceable.usda",
+    "universal_robots_ur5e/usd_structured/ur5e.usda",
+    "wonik_allegro/urdf/allegro_hand_description_left.urdf",
+    "wonik_allegro/usd_structured/allegro_left.usda",
+)
+
+# Folders the rest of the suite already downloads, so the default run fetches nothing extra.
+_DEFAULT_ASSET_SCENES = (
+    "anybotics_anymal_d/usd/anymal_d.usda",
+    "disneyresearch/dr_legs/usd/dr_legs.usda",
+    "franka_emika_panda/urdf/fr3_franka_hand.urdf",
+    "universal_robots_ur10/usd/ur10_instanceable.usda",
+)
+
+_MEMORY_SCENES = (
+    "anybotics_anymal_d/usd/anymal_d.usda",
+    "franka_emika_panda/urdf/fr3_franka_hand.urdf",
+    "universal_robots_ur10/usd/ur10_instanceable.usda",
+)
+
+# Also the length of the scenarios' xforms and label_prefixes.
+_REPLICATE_WORLD_COUNT = 4
 
 
 class TestModelBuilderReplicate(unittest.TestCase):
@@ -106,6 +163,19 @@ class TestModelBuilderReplicate(unittest.TestCase):
         return builder
 
     @staticmethod
+    def _make_destination_with_prefix(source: ModelBuilder) -> ModelBuilder:
+        """Destination carrying global entities, a pre-merged copy of ``source``, and one existing world."""
+        builder = ModelBuilder()
+        body = builder.add_body(label="global")
+        builder.add_shape_sphere(body, radius=0.1, label="global_shape")
+        builder.add_builder(source, label_prefix="prefix")
+        builder.begin_world()
+        existing = builder.add_body(label="existing")
+        builder.add_shape_box(existing, hx=0.1, hy=0.1, hz=0.1, label="existing_shape")
+        builder.end_world()
+        return builder
+
+    @staticmethod
     def _make_destination() -> ModelBuilder:
         builder = ModelBuilder()
         body = builder.add_body(label="global")
@@ -156,6 +226,41 @@ class TestModelBuilderReplicate(unittest.TestCase):
             for field in ("indices", "pos_indices", "controller_args", "delay_args", "clamping_args"):
                 self.assertEqual(getattr(expected_entry, field), getattr(actual_entry, field))
 
+    def assert_model_values_equal(self, expected, actual, path: str) -> None:
+        """Compare two finalized-model values, recursing through containers and objects that lack ``__eq__``."""
+        self.assertIs(type(expected), type(actual), path)
+
+        if isinstance(expected, _OPAQUE_MODEL_TYPES):
+            return
+        if isinstance(expected, wp.array):
+            self.assertEqual(expected.dtype, actual.dtype, path)
+            self.assertEqual(expected.shape, actual.shape, path)
+            expected, actual = expected.numpy(), actual.numpy()
+
+        if isinstance(expected, np.ndarray):
+            self.assertEqual(expected.dtype, actual.dtype, path)
+            if expected.dtype.kind == "f":
+                np.testing.assert_allclose(actual, expected, err_msg=path)
+            else:
+                np.testing.assert_array_equal(actual, expected, err_msg=path)
+        elif isinstance(expected, (float, np.floating)):
+            np.testing.assert_allclose(actual, expected, err_msg=path)
+        elif isinstance(expected, (bool, int, str, bytes, np.integer, np.bool_, set, frozenset, type(None))):
+            self.assertEqual(expected, actual, path)
+        elif isinstance(expected, (list, tuple)):
+            for index, (expected_item, actual_item) in enumerate(zip(expected, actual, strict=True)):
+                self.assert_model_values_equal(expected_item, actual_item, f"{path}[{index}]")
+        elif isinstance(expected, dict):
+            self.assertEqual(set(expected), set(actual), path)
+            for key in expected:
+                self.assert_model_values_equal(expected[key], actual[key], f"{path}[{key!r}]")
+        elif isinstance(expected, type) or type(expected).__eq__ is not object.__eq__:
+            self.assertEqual(expected, actual, path)
+        elif hasattr(expected, "__dict__"):
+            self.assert_model_values_equal(vars(expected), vars(actual), path)
+        else:
+            self.fail(f"{path}: unhandled type {type(expected).__name__}; add an explicit comparison")
+
     def test_replicate_matches_add_world_loop(self):
         world_count = 4
         for use_coord_layout_targets in (False, True):
@@ -188,104 +293,155 @@ class TestModelBuilderReplicate(unittest.TestCase):
 
         self.assert_builder_merge_state_equal(expected, actual)
 
-    def test_replicate_and_finalize_matches_separate_calls(self):
-        """Match ordinary replication using an array-backed scratch builder."""
-        source = self._make_source()
+    def assert_models_equal(self, expected: Model, actual: Model) -> None:
+        """Compare every attribute of two finalized models."""
+        self.assertEqual(set(vars(expected)), set(vars(actual)))
+        for name in sorted(set(vars(expected)) - set(_UNINITIALIZED_MODEL_ATTRIBUTES)):
+            with self.subTest(attribute=name):
+                self.assert_model_values_equal(getattr(expected, name), getattr(actual, name), name)
+
+    def test_replicate_and_finalize_matches_every_model_attribute(self):
+        """Compare the whole model, over destination shapes, per-world placement, labels, and target layout."""
         xforms = [
             wp.transform((1.0, 2.0, 3.0), wp.quat_rpy(0.1, 0.2, 0.3)),
             wp.transform((-2.0, 1.0, 0.5), wp.quat_rpy(-0.2, 0.4, 0.1)),
+            wp.transform((0.5, -1.5, 2.0), wp.quat_rpy(0.3, -0.1, 0.2)),
+            wp.transform((-1.0, 0.5, -2.5), wp.quat_rpy(-0.1, -0.3, 0.4)),
         ]
+        prefixes = [f"/World/envs/env_{index}/Robot" for index in range(_REPLICATE_WORLD_COUNT)]
+        placed = {"xforms": xforms, "label_prefixes": prefixes}
+        spaced = {"spacing": (2.0, 3.0, 0.0)}
 
-        def make_destination_with_mutable_prefix() -> ModelBuilder:
-            destination = ModelBuilder()
-            body = destination.add_body(label="global")
-            destination.add_shape_sphere(body, radius=0.1, label="global_shape")
-            destination.add_builder(source, label_prefix="prefix")
-            destination.begin_world()
-            existing = destination.add_body(label="existing")
-            destination.add_shape_box(existing, hx=0.1, hy=0.1, hz=0.1, label="existing_shape")
-            destination.end_world()
-            return destination
+        # Prefixes on half of these, so the unprefixed label path stays covered.
+        scenarios = (
+            ("empty/spacing", False, spaced),
+            ("prefixed/xforms/labels", True, placed),
+            ("empty/xforms/labels", False, placed),
+            ("prefixed/spacing", True, spaced),
+        )
 
-        expected_builder = make_destination_with_mutable_prefix()
-        expected_builder.replicate(source, len(xforms), xforms=xforms)
-        expected = expected_builder.finalize(device="cpu")
+        for label, prefixed_destination, replicate_kwargs in scenarios:
+            with self.subTest(scenario=label), mock.patch("newton.use_coord_layout_targets", True):
+                # The target layout selects the joint_target_q merge frequency, so build under the patch.
+                source = self._make_source()
 
-        unchanged_builder = make_destination_with_mutable_prefix()
-        actual_builder = make_destination_with_mutable_prefix()
-        captured = {}
-        original_finalize = ModelBuilder._finalize
+                def make_destination(prefixed=prefixed_destination, source=source) -> ModelBuilder:
+                    return self._make_destination_with_prefix(source) if prefixed else ModelBuilder()
 
-        def capture_finalize(scratch, *args, **kwargs):
-            captured["scratch"] = scratch
-            return original_finalize(scratch, *args, **kwargs)
-
-        with mock.patch.object(ModelBuilder, "_finalize", autospec=True, side_effect=capture_finalize):
-            actual = actual_builder.replicate_and_finalize(source, len(xforms), xforms=xforms, device="cpu")
-
-        scratch = captured["scratch"]
-        self.assertIsNot(scratch, actual_builder)
-        array_backed = {name for name in _model_array_dtypes() if isinstance(getattr(scratch, name, None), np.ndarray)}
-        self.assertTrue(array_backed)
-        self.assertTrue(all(getattr(scratch, name).flags.c_contiguous for name in array_backed))
-        self.assertTrue(all(isinstance(getattr(scratch, name), list) for name in _FINALIZE_LIST_CONTROL_FLOW_FIELDS))
-
-        for name in array_backed:
-            with self.subTest(attribute=name, property="dtype"):
-                warp_dtype = _model_array_dtypes()[name]
-                scalar_dtype = getattr(warp_dtype, "_wp_scalar_type_", warp_dtype)
-                self.assertEqual(getattr(scratch, name).dtype, np.dtype(wp.dtype_to_numpy(scalar_dtype)))
-
-        self.assert_builder_merge_state_equal(unchanged_builder, actual_builder)
-        for name in array_backed:
-            with self.subTest(attribute=name):
-                self.assertEqual(getattr(actual, name).dtype, getattr(expected, name).dtype)
-                np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
-
-        self.assertEqual(expected.world_count, actual.world_count)
-        self.assertEqual(expected.shape_contact_pair_count, actual.shape_contact_pair_count)
-        np.testing.assert_array_equal(expected.shape_contact_pairs.numpy(), actual.shape_contact_pairs.numpy())
-
-    def test_replicate_and_finalize_matches_muscle_waypoints(self):
-        """Offset muscle waypoints by the pre-merge count, not the array-backed allocation length."""
-        source = self._make_source()
-
-        for prefix_worlds in (0, 1):
-            with self.subTest(prefix_worlds=prefix_worlds):
-                expected_builder = ModelBuilder()
-                actual_builder = ModelBuilder()
-                for _ in range(prefix_worlds):
-                    expected_builder.add_builder(source)
-                    actual_builder.add_builder(source)
-
-                expected_builder.replicate(source, 3, spacing=(2.0, 0.0, 0.0))
+                expected_builder = make_destination()
+                expected_builder.replicate(source, _REPLICATE_WORLD_COUNT, **replicate_kwargs)
                 expected = expected_builder.finalize(device="cpu")
-                actual = actual_builder.replicate_and_finalize(source, 3, spacing=(2.0, 0.0, 0.0), device="cpu")
 
-                for name in ("muscle_start", "muscle_bodies", "muscle_points"):
-                    with self.subTest(attribute=name):
-                        np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
+                unchanged_builder = make_destination()
+                actual_builder = make_destination()
+                actual = actual_builder.replicate_and_finalize(
+                    source, _REPLICATE_WORLD_COUNT, device="cpu", **replicate_kwargs
+                )
 
-    def test_replicate_and_finalize_matches_coord_layout_targets(self):
-        with mock.patch("newton.use_coord_layout_targets", True):
+                self.assert_builder_merge_state_equal(unchanged_builder, actual_builder)
+                self.assert_models_equal(expected, actual)
+
+    def test_replicate_and_finalize_matches_legacy_target_layout(self):
+        """Cover the DOF-shaped joint_target_q projection, which only runs while use_coord_layout_targets is
+        off. Delete this test together with that flag; every other case runs the coordinate layout."""
+        with mock.patch("newton.use_coord_layout_targets", False):
             source = self._make_source()
+            # BALL and DISTANCE drop their quat-w padding at different offsets than FREE.
+            spinner = source.add_link(label="spinner")
+            source.add_joint_ball(parent=-1, child=spinner, label="ball")
+            floater = source.add_link(label="floater")
+            source.add_joint_distance(parent=-1, child=floater, label="distance")
+
             expected_builder = ModelBuilder()
-            expected_builder.replicate(source, 3, spacing=(2.0, 3.0, 0.0))
+            expected_builder.replicate(source, _REPLICATE_WORLD_COUNT, spacing=(2.0, 3.0, 0.0))
             expected = expected_builder.finalize(device="cpu")
 
-            actual = ModelBuilder().replicate_and_finalize(source, 3, spacing=(2.0, 3.0, 0.0), device="cpu")
+            actual = ModelBuilder().replicate_and_finalize(
+                source, _REPLICATE_WORLD_COUNT, spacing=(2.0, 3.0, 0.0), device="cpu"
+            )
 
-        for name in ("joint_q", "joint_qd", "joint_target_q", "joint_target_qd"):
-            with self.subTest(attribute=name):
-                np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
+        self.assert_models_equal(expected, actual)
+
+    @staticmethod
+    def _import_asset_scene(scene: str) -> ModelBuilder:
+        """Import one newton-assets scene given its repository-relative path."""
+        folder, _, relative_path = scene.partition("/")
+        path = newton.utils.download_asset(folder) / relative_path
+        builder = ModelBuilder()
+        importers = {".urdf": builder.add_urdf, ".xml": builder.add_mjcf}
+        importers.get(path.suffix, builder.add_usd)(str(path))
+        return builder
+
+    @staticmethod
+    def _build_measuring_peaks(build: Callable[[], Model]) -> tuple[Model, dict[str, int]]:
+        """Build a model, reporting peak bytes allocated through Python and through Warp.
+
+        Warp allocates outside the Python allocator, so neither tracker sees the other's memory.
+        """
+        gc.collect()
+        with wp.ScopedMemoryTracker("replicate", print=False) as tracker:
+            tracker.clear()
+            tracemalloc.start()
+            try:
+                model = build()
+                peaks = {"python": tracemalloc.get_traced_memory()[1]}
+            finally:
+                tracemalloc.stop()
+            peaks["warp"] = wp._src.context.runtime.core.wp_alloc_tracker_get_peak_bytes()
+        return model, peaks
+
+    def test_replicate_and_finalize_matches_asset_scenes(self):
+        """Agree with separate calls on real assets. Set NEWTON_TEST_ALL_ASSETS to sweep every scene."""
+        scenes = _ASSET_SCENES if os.environ.get("NEWTON_TEST_ALL_ASSETS") else _DEFAULT_ASSET_SCENES
+        world_count = 2
+        for scene in scenes:
+            with self.subTest(asset=scene):
+                source = self._import_asset_scene(scene)
+
+                expected_builder = ModelBuilder()
+                expected_builder.replicate(source, world_count)
+                expected = expected_builder.finalize(device="cpu")
+
+                actual = ModelBuilder().replicate_and_finalize(source, world_count, device="cpu")
+
+                self.assert_models_equal(expected, actual)
+
+    def test_replicate_and_finalize_allocates_no_more_at_batch_size(self):
+        """Replicate one source covering every feature at a realistic batch size, and check the contiguous
+        arrays and the suspended collector cost no more memory than the separate calls do."""
+        source = self._make_source()
+        for scene in _MEMORY_SCENES:
+            source.add_builder(self._import_asset_scene(scene))
+
+        # The contiguous-array path repays its fixed cost past roughly 32 worlds; below that it peaks higher.
+        world_count = 64
+
+        def separate() -> Model:
+            destination = ModelBuilder()
+            destination.replicate(source, world_count)
+            return destination.finalize(device="cpu")
+
+        def combined() -> Model:
+            return ModelBuilder().replicate_and_finalize(source, world_count, device="cpu")
+
+        # BVHs are built once per mesh, so without this they land on whichever path is measured first.
+        ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
+
+        expected, separate_peaks = self._build_measuring_peaks(separate)
+        actual, combined_peaks = self._build_measuring_peaks(combined)
+
+        self.assert_models_equal(expected, actual)
+        for allocator, separate_peak in separate_peaks.items():
+            with self.subTest(peak=allocator):
+                self.assertLessEqual(combined_peaks[allocator], separate_peak)
 
     def test_replicate_and_finalize_preserves_gc_state(self):
-        """Preserve disabled GC and otherwise collect once after finalization."""
+        """Restore the collector without forcing a collection, and leave an already-disabled one alone."""
         source = self._make_source()
 
         with mock.patch.object(gc, "collect", wraps=gc.collect) as collect:
             ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
-        collect.assert_called_once_with()
+        collect.assert_not_called()
         self.assertTrue(gc.isenabled())
 
         gc.disable()
@@ -751,10 +907,3 @@ class TestModelBuilderReplicateLabelPrefixes(unittest.TestCase):
         """label_prefixes must have exactly one entry per replicated world."""
         with self.assertRaises(ValueError):
             ModelBuilder().replicate(self._source("root"), 2, label_prefixes=["only-one"])
-
-    def test_atomic_path_applies_the_same_prefixes(self):
-        """replicate_and_finalize() names each world exactly as replicate() does."""
-        prefixes = [f"/World/envs/env_{index}/Robot" for index in range(3)]
-        model = ModelBuilder().replicate_and_finalize(self._source(), 3, label_prefixes=prefixes, device="cpu")
-
-        self.assertEqual(list(model.shape_label), [f"{prefix}/box" for prefix in prefixes])

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -9,6 +9,7 @@ import numpy as np
 import warp as wp
 
 from newton import Mesh, Model, ModelBuilder
+from newton._src.sim.builder import _FINALIZE_LIST_CONTROL_FLOW_FIELDS, _model_array_dtypes
 from newton.actuators import ControllerPD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 from newton.utils import compute_world_offsets
@@ -186,6 +187,78 @@ class TestModelBuilderReplicate(unittest.TestCase):
         actual.replicate(source, len(xforms), xforms=xforms)
 
         self.assert_builder_merge_state_equal(expected, actual)
+
+    def test_replicate_and_finalize_matches_separate_calls(self):
+        """Match ordinary replication using an array-backed scratch builder."""
+        source = self._make_source()
+        xforms = [
+            wp.transform((1.0, 2.0, 3.0), wp.quat_rpy(0.1, 0.2, 0.3)),
+            wp.transform((-2.0, 1.0, 0.5), wp.quat_rpy(-0.2, 0.4, 0.1)),
+        ]
+
+        def make_destination_with_mutable_prefix() -> ModelBuilder:
+            destination = ModelBuilder()
+            body = destination.add_body(label="global")
+            destination.add_shape_sphere(body, radius=0.1, label="global_shape")
+            destination.add_builder(source, label_prefix="prefix")
+            destination.begin_world()
+            existing = destination.add_body(label="existing")
+            destination.add_shape_box(existing, hx=0.1, hy=0.1, hz=0.1, label="existing_shape")
+            destination.end_world()
+            return destination
+
+        expected_builder = make_destination_with_mutable_prefix()
+        expected_builder.replicate(source, len(xforms), xforms=xforms)
+        expected = expected_builder.finalize(device="cpu")
+
+        unchanged_builder = make_destination_with_mutable_prefix()
+        actual_builder = make_destination_with_mutable_prefix()
+        captured = {}
+        original_finalize = ModelBuilder._finalize
+
+        def capture_finalize(scratch, *args, **kwargs):
+            captured["scratch"] = scratch
+            return original_finalize(scratch, *args, **kwargs)
+
+        with mock.patch.object(ModelBuilder, "_finalize", autospec=True, side_effect=capture_finalize):
+            actual = actual_builder.replicate_and_finalize(source, len(xforms), xforms=xforms, device="cpu")
+
+        scratch = captured["scratch"]
+        self.assertIsNot(scratch, actual_builder)
+        array_backed = {name for name in _model_array_dtypes() if isinstance(getattr(scratch, name, None), np.ndarray)}
+        self.assertTrue(array_backed)
+        self.assertTrue(all(getattr(scratch, name).flags.c_contiguous for name in array_backed))
+        self.assertTrue(all(isinstance(getattr(scratch, name), list) for name in _FINALIZE_LIST_CONTROL_FLOW_FIELDS))
+
+        for name in array_backed:
+            with self.subTest(attribute=name, property="dtype"):
+                warp_dtype = _model_array_dtypes()[name]
+                scalar_dtype = getattr(warp_dtype, "_wp_scalar_type_", warp_dtype)
+                self.assertEqual(getattr(scratch, name).dtype, np.dtype(wp.dtype_to_numpy(scalar_dtype)))
+
+        self.assert_builder_merge_state_equal(unchanged_builder, actual_builder)
+        for name in array_backed:
+            with self.subTest(attribute=name):
+                self.assertEqual(getattr(actual, name).dtype, getattr(expected, name).dtype)
+                np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
+
+        self.assertEqual(expected.world_count, actual.world_count)
+        self.assertEqual(expected.shape_contact_pair_count, actual.shape_contact_pair_count)
+        np.testing.assert_array_equal(expected.shape_contact_pairs.numpy(), actual.shape_contact_pairs.numpy())
+
+    def test_replicate_and_finalize_matches_coord_layout_targets(self):
+        """Match ordinary replication with coordinate-layout joint targets."""
+        with mock.patch("newton.use_coord_layout_targets", True):
+            source = self._make_source()
+            expected_builder = ModelBuilder()
+            expected_builder.replicate(source, 3, spacing=(2.0, 3.0, 0.0))
+            expected = expected_builder.finalize(device="cpu")
+
+            actual = ModelBuilder().replicate_and_finalize(source, 3, spacing=(2.0, 3.0, 0.0), device="cpu")
+
+        for name in ("joint_q", "joint_qd", "joint_target_q", "joint_target_qd"):
+            with self.subTest(attribute=name):
+                np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
 
     def test_replicate_rejects_mismatched_explicit_transforms(self):
         with self.assertRaisesRegex(ValueError, "xforms must contain 2 entries, got 1"):
@@ -641,3 +714,10 @@ class TestModelBuilderReplicateLabelPrefixes(unittest.TestCase):
         """label_prefixes must have exactly one entry per replicated world."""
         with self.assertRaises(ValueError):
             ModelBuilder().replicate(self._source("root"), 2, label_prefixes=["only-one"])
+
+    def test_atomic_path_applies_the_same_prefixes(self):
+        """replicate_and_finalize() names each world exactly as replicate() does."""
+        prefixes = [f"/World/envs/env_{index}/Robot" for index in range(3)]
+        model = ModelBuilder().replicate_and_finalize(self._source(), 3, label_prefixes=prefixes, device="cpu")
+
+        self.assertEqual(list(model.shape_label), [f"{prefix}/box" for prefix in prefixes])

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -247,7 +247,6 @@ class TestModelBuilderReplicate(unittest.TestCase):
         np.testing.assert_array_equal(expected.shape_contact_pairs.numpy(), actual.shape_contact_pairs.numpy())
 
     def test_replicate_and_finalize_matches_coord_layout_targets(self):
-        """Match ordinary replication with coordinate-layout joint targets."""
         with mock.patch("newton.use_coord_layout_targets", True):
             source = self._make_source()
             expected_builder = ModelBuilder()

--- a/newton/tests/test_builder_replicate.py
+++ b/newton/tests/test_builder_replicate.py
@@ -260,6 +260,24 @@ class TestModelBuilderReplicate(unittest.TestCase):
             with self.subTest(attribute=name):
                 np.testing.assert_array_equal(getattr(expected, name).numpy(), getattr(actual, name).numpy())
 
+    def test_replicate_and_finalize_preserves_gc_state(self):
+        """Preserve disabled GC and otherwise collect once after finalization."""
+        source = self._make_source()
+
+        with mock.patch.object(gc, "collect", wraps=gc.collect) as collect:
+            ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
+        collect.assert_called_once_with()
+        self.assertTrue(gc.isenabled())
+
+        gc.disable()
+        try:
+            with mock.patch.object(gc, "collect", wraps=gc.collect) as collect:
+                ModelBuilder().replicate_and_finalize(source, 2, device="cpu")
+            collect.assert_not_called()
+            self.assertFalse(gc.isenabled())
+        finally:
+            gc.enable()
+
     def test_replicate_rejects_mismatched_explicit_transforms(self):
         with self.assertRaisesRegex(ValueError, "xforms must contain 2 entries, got 1"):
             ModelBuilder().replicate(self._make_source(), 2, xforms=[wp.transform_identity()])


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a faster way to replicate multiple model worlds and finalize them in a single operation.
  * Improved support for transforms, label prefixes, world assignments, and referenced data.
  * Preserved the source builder during model creation.

* **Bug Fixes**
  * Improved handling of particle flags, joint dimensions, collision meshes, geometry, and contact data.

* **Documentation**
  * Clarified when to use combined replication and finalization versus separate operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->