### PR TITLE
Stabilize XPBD contact-force equilibrium test

### DIFF
--- a/changelog/+xpbd-contact-force-test-7c4e91a2.skip
+++ b/changelog/+xpbd-contact-force-test-7c4e91a2.skip
@@ -1,0 +1,1 @@
+Stabilize the XPBD static-equilibrium contact-force regression test.

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -879,8 +879,7 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     cube_mg = cube_mass * gravity
 
     builder = newton.ModelBuilder()
-    builder.add_ground_plane()
-    ground_shape = 0
+    ground_shape = builder.add_ground_plane()
 
     builder.default_shape_cfg.density = sphere_density
     sphere_body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, sphere_radius), wp.quat_identity()))
@@ -934,6 +933,7 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     box_force = np.zeros(3)
     cube_left_fz_on_body = 0.0
     cube_right_fz_on_body = 0.0
+    box_contact_count = 0
 
     for _ in range(avg_steps):
         for _ in range(num_substeps):
@@ -950,7 +950,6 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
         s0 = contacts.rigid_contact_shape0.numpy()[:nc]
         s1 = contacts.rigid_contact_shape1.numpy()[:nc]
 
-        box_step_count = 0
         for ci in range(nc):
             # ``contacts.force`` is force on body0 by body1. Sum into a "force-on-ground"
             # bucket regardless of which side ground was recorded as: flip sign when
@@ -972,19 +971,31 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
                 heavy_force += f
             elif other_body == box_body:
                 box_force += f
-                box_step_count += 1
+                box_contact_count += 1
             elif other_body == cube_left_body:
                 cube_left_fz_on_body += -f[2]
             elif other_body == cube_right_body:
                 cube_right_fz_on_body += -f[2]
-
-        test.assertGreater(box_step_count, 1, "Box should generate multiple ground contact points")
 
     sphere_force /= avg_steps
     heavy_force /= avg_steps
     box_force /= avg_steps
     cube_left_fz_on_body /= avg_steps
     cube_right_fz_on_body /= avg_steps
+
+    # Contact ordering can produce an occasional edge-contact frame after the
+    # bodies have settled. Validate that multiple box contacts contribute over
+    # the same averaging window used for the force assertions.
+    test.assertGreater(
+        box_contact_count,
+        avg_steps,
+        "Box should average more than one ground contact point per step",
+    )
+
+    # XPBD contact accumulation uses parallel floating-point atomics, so small
+    # lateral reactions vary with contact ordering. Bound them relative to the
+    # supported weight instead of using a mass-independent absolute tolerance.
+    max_horizontal_force_ratio = 0.02
 
     np.testing.assert_allclose(
         sphere_force[2],
@@ -993,10 +1004,10 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
         err_msg="Sphere on plane: vertical contact force should match -mg",
     )
     np.testing.assert_allclose(
-        sphere_force[0], 0.0, atol=0.5, err_msg="Sphere on plane: horizontal X force should be ~0"
-    )
-    np.testing.assert_allclose(
-        sphere_force[1], 0.0, atol=0.5, err_msg="Sphere on plane: horizontal Y force should be ~0"
+        sphere_force[:2],
+        0.0,
+        atol=max_horizontal_force_ratio * sphere_mass * gravity,
+        err_msg="Sphere on plane: horizontal contact force should be small relative to its weight",
     )
 
     np.testing.assert_allclose(
@@ -1006,10 +1017,10 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
         err_msg="Heavy sphere on plane: vertical contact force should match -mg",
     )
     np.testing.assert_allclose(
-        heavy_force[0], 0.0, atol=0.5, err_msg="Heavy sphere on plane: horizontal X force should be ~0"
-    )
-    np.testing.assert_allclose(
-        heavy_force[1], 0.0, atol=0.5, err_msg="Heavy sphere on plane: horizontal Y force should be ~0"
+        heavy_force[:2],
+        0.0,
+        atol=max_horizontal_force_ratio * heavy_mass * gravity,
+        err_msg="Heavy sphere on plane: horizontal contact force should be small relative to its weight",
     )
 
     np.testing.assert_allclose(
@@ -1018,8 +1029,12 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
         rtol=0.10,
         err_msg="Box on plane: total vertical contact force over multiple contacts should match -mg, not N*mg",
     )
-    np.testing.assert_allclose(box_force[0], 0.0, atol=1.0, err_msg="Box on plane: horizontal X force should be ~0")
-    np.testing.assert_allclose(box_force[1], 0.0, atol=1.0, err_msg="Box on plane: horizontal Y force should be ~0")
+    np.testing.assert_allclose(
+        box_force[:2],
+        0.0,
+        atol=max_horizontal_force_ratio * box_mass * gravity,
+        err_msg="Box on plane: horizontal contact force should be small relative to its weight",
+    )
 
     # The exact split is sensitive to contact ordering, but the total reaction
     # must support all three cubes regardless of which bottom cube carries it.

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -879,6 +879,12 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     cube_mg = cube_mass * gravity
 
     builder = newton.ModelBuilder()
+    # This regression targets normal support forces. Disable friction so that
+    # contact-order roundoff cannot grow into unrelated lateral or rolling
+    # transients while the combined scene settles.
+    builder.default_shape_cfg.mu = 0.0
+    builder.default_shape_cfg.mu_torsional = 0.0
+    builder.default_shape_cfg.mu_rolling = 0.0
     ground_shape = builder.add_ground_plane()
 
     builder.default_shape_cfg.density = sphere_density
@@ -992,10 +998,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
         "Box should average more than one ground contact point per step",
     )
 
-    # XPBD contact accumulation uses parallel floating-point atomics, so small
-    # lateral reactions vary with contact ordering. Bound them relative to the
-    # supported weight instead of using a mass-independent absolute tolerance.
-    max_horizontal_force_ratio = 0.02
+    # With friction disabled and a vertical plane normal, the reported linear
+    # contact forces should not contain horizontal components.
+    horizontal_force_atol = 1.0e-6
 
     np.testing.assert_allclose(
         sphere_force[2],
@@ -1006,8 +1011,8 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     np.testing.assert_allclose(
         sphere_force[:2],
         0.0,
-        atol=max_horizontal_force_ratio * sphere_mass * gravity,
-        err_msg="Sphere on plane: horizontal contact force should be small relative to its weight",
+        atol=horizontal_force_atol,
+        err_msg="Sphere on plane: horizontal contact force should be zero",
     )
 
     np.testing.assert_allclose(
@@ -1019,8 +1024,8 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     np.testing.assert_allclose(
         heavy_force[:2],
         0.0,
-        atol=max_horizontal_force_ratio * heavy_mass * gravity,
-        err_msg="Heavy sphere on plane: horizontal contact force should be small relative to its weight",
+        atol=horizontal_force_atol,
+        err_msg="Heavy sphere on plane: horizontal contact force should be zero",
     )
 
     np.testing.assert_allclose(
@@ -1032,8 +1037,8 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     np.testing.assert_allclose(
         box_force[:2],
         0.0,
-        atol=max_horizontal_force_ratio * box_mass * gravity,
-        err_msg="Box on plane: horizontal contact force should be small relative to its weight",
+        atol=horizontal_force_atol,
+        err_msg="Box on plane: horizontal contact force should be zero",
     )
 
     # The exact split is sensitive to contact ordering, but the total reaction


### PR DESCRIPTION
## Description

Stabilize the consolidated XPBD static-equilibrium contact-force test against CUDA contact-order variation observed in unrelated pull requests.

- Validate that multiple box contacts contribute across the 60-step averaging window instead of requiring them on every individual frame.
- Disable friction in this normal-support regression so contact-order roundoff cannot grow into unrelated lateral or rolling transients, and require horizontal force components to remain zero.
- Use the shape index returned by `add_ground_plane()` rather than assuming it is zero.

The existing vertical support-force tolerances and pyramid ground-reaction checks are unchanged. Example unrelated failure: [PR #4017 CI job](https://github.com/newton-physics/newton/actions/runs/32997084519/job/98269935767?pr=4017).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md) (test-only `.skip` fragment)

## Test plan

Baseline stress testing reproduced the intermittent failure once in ten CUDA runs, with a 94.40024 N lateral box reaction against the old 1 N absolute tolerance. The first CI revision then exposed an 18.2% low vertical box reaction on the AWS GPU runner. The final friction-isolated setup passed ten consecutive CUDA runs locally while retaining the original vertical-force bounds.

```console
uv run --extra dev -m newton.tests -k test_xpbd_contact_force_static_equilibrium_cuda_0
uv run --extra dev -m newton.tests -k test_xpbd_contact_force_static_equilibrium_cpu
uvx pre-commit run -a
```

All commands pass. The focused CUDA test also passed ten consecutive executions in one process.

## Bug fix

**Steps to reproduce:**

1. Run `test_xpbd_contact_force_static_equilibrium_cuda_0` repeatedly on a CUDA device.
2. Observe intermittent failures from a transient single/zero-contact box frame or a small lateral reaction exceeding the fixed absolute tolerance.
3. Rerun the same commit and observe the test pass unchanged.

**Minimal reproduction:**

```powershell
uv run python -c "import unittest; from newton.tests.test_solver_xpbd import TestSolverXPBD; name='test_xpbd_contact_force_static_equilibrium_cuda_0'; suite=unittest.TestSuite(TestSolverXPBD(name) for _ in range(10)); result=unittest.TextTestRunner().run(suite); raise SystemExit(not result.wasSuccessful())"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XPBD static-equilibrium contact-force validation for spheres and boxes.
  * Contact-force checks now provide more consistent horizontal-force results by disabling friction effects during validation.
  * Ground-contact accumulation and multi-contact behavior continue to be validated.

* **Tests**
  * Updated regression coverage for ground-plane contact behavior, contact counting, and near-zero horizontal forces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
