### PR TITLE
Expose the Gaussian splat BVH for refit

### DIFF
--- a/changelog/+gaussian-refit-bvh-4b6e1a29.added.md
+++ b/changelog/+gaussian-refit-bvh-4b6e1a29.added.md
@@ -1,0 +1,1 @@
+Expose the Gaussian splat BVH via `Gaussian.bvh` and add `Gaussian.bvh_refit()` to refit it in place after the finalized data changes, mirroring `Model.bvh_refit_shapes`.

--- a/changelog/+gaussian-warp-aliases-5e2c9a7d.deprecated.md
+++ b/changelog/+gaussian-warp-aliases-5e2c9a7d.deprecated.md
@@ -1,0 +1,1 @@
+Deprecate `Gaussian.warp_data` and `Gaussian.warp_bvh`; use the `Gaussian.Data` object returned by `Gaussian.finalize()` and `Gaussian.bvh` instead.

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -2481,6 +2481,12 @@ class Gaussian:
         min_response: wp.float32
         sorting_mode: wp.int32
 
+    _WARP_DATA_DEPRECATION_MSG = (
+        "Gaussian.warp_data is deprecated in Newton 1.6; use the Gaussian.Data object returned by "
+        "Gaussian.finalize() instead."
+    )
+    _WARP_BVH_DEPRECATION_MSG = "Gaussian.warp_bvh is deprecated in Newton 1.6; use Gaussian.bvh instead."
+
     def __init__(
         self,
         positions: np.ndarray,
@@ -2620,6 +2626,36 @@ class Gaussian:
         :class:`Data` arrays change.
         """
         return self._warp_bvh
+
+    @property
+    def warp_data(self) -> "Gaussian.Data | None":
+        """Deprecated alias for the finalized Warp Gaussian data.
+
+        .. deprecated:: 1.6
+            Use the :class:`Data` object returned by :meth:`finalize` instead.
+        """
+        warnings.warn(self._WARP_DATA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        return self._warp_data
+
+    @warp_data.setter
+    def warp_data(self, value: "Gaussian.Data | None") -> None:
+        warnings.warn(self._WARP_DATA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        self._warp_data = value
+
+    @property
+    def warp_bvh(self) -> wp.Bvh | None:
+        """Deprecated alias for :attr:`bvh`.
+
+        .. deprecated:: 1.6
+            Use :attr:`bvh` instead.
+        """
+        warnings.warn(self._WARP_BVH_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        return self._warp_bvh
+
+    @warp_bvh.setter
+    def warp_bvh(self, value: wp.Bvh | None) -> None:
+        warnings.warn(self._WARP_BVH_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        self._warp_bvh = value
 
     def _find_sh_degree(self) -> int:
         """Spherical harmonics degree (0-3), inferred from *sh_coeffs* shape."""

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -2554,8 +2554,8 @@ class Gaussian:
         self._sh_coeffs.setflags(write=False)
 
         # GPU arrays populated by finalize()
-        self.warp_bvh: wp.Bvh = None
-        self.warp_data: Gaussian.Data = None
+        self._warp_bvh: wp.Bvh = None
+        self._warp_data: Gaussian.Data = None
 
         # Inertia: Gaussians are render-only so they contribute no mass
         self.has_inertia = False
@@ -2619,7 +2619,7 @@ class Gaussian:
         Use :meth:`bvh_refit` to update it in place after the finalized
         :class:`Data` arrays change.
         """
-        return self.warp_bvh
+        return self._warp_bvh
 
     def _find_sh_degree(self) -> int:
         """Spherical harmonics degree (0-3), inferred from *sh_coeffs* shape."""
@@ -2647,16 +2647,16 @@ class Gaussian:
         from ..sensors.warp_raytrace.gaussians import compute_gaussian_bvh_bounds  # noqa: PLC0415
 
         with wp.ScopedDevice(device):
-            self.warp_data = Gaussian.Data()
-            self.warp_data.transforms = wp.array(
+            self._warp_data = Gaussian.Data()
+            self._warp_data.transforms = wp.array(
                 np.append(self._positions, self._rotations, axis=1), dtype=wp.transformf
             )
-            self.warp_data.scales = wp.array(self._scales, dtype=wp.vec3f)
-            self.warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
-            self.warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
-            self.warp_data.min_response = self.min_response
-            self.warp_data.sorting_mode = self.sorting_mode
-            self.warp_data.num_points = self.warp_data.transforms.shape[0]
+            self._warp_data.scales = wp.array(self._scales, dtype=wp.vec3f)
+            self._warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
+            self._warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
+            self._warp_data.min_response = self.min_response
+            self._warp_data.sorting_mode = self.sorting_mode
+            self._warp_data.num_points = self._warp_data.transforms.shape[0]
 
             lowers = wp.zeros(self.count, dtype=wp.vec3f)
             uppers = wp.zeros(self.count, dtype=wp.vec3f)
@@ -2664,12 +2664,12 @@ class Gaussian:
             wp.launch(
                 kernel=compute_gaussian_bvh_bounds,
                 dim=self.count,
-                inputs=[self.warp_data, lowers, uppers],
+                inputs=[self._warp_data, lowers, uppers],
             )
 
-            self.warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
-            self.warp_data.bvh_id = self.warp_bvh.id
-        return self.warp_data
+            self._warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
+            self._warp_data.bvh_id = self._warp_bvh.id
+        return self._warp_data
 
     def bvh_refit(self) -> None:
         """Refit the Gaussian :attr:`bvh` in place for the current finalized data.
@@ -2689,16 +2689,16 @@ class Gaussian:
         """
         from ..sensors.warp_raytrace.gaussians import compute_gaussian_bvh_bounds  # noqa: PLC0415
 
-        if self.warp_bvh is None or self.warp_data is None:
+        if self._warp_bvh is None or self._warp_data is None:
             raise RuntimeError("Gaussian.bvh_refit() requires Gaussian.finalize() to have been called first.")
 
-        with wp.ScopedDevice(self.warp_bvh.device):
+        with wp.ScopedDevice(self._warp_bvh.device):
             wp.launch(
                 kernel=compute_gaussian_bvh_bounds,
                 dim=self.count,
-                inputs=[self.warp_data, self.warp_bvh.lowers, self.warp_bvh.uppers],
+                inputs=[self._warp_data, self._warp_bvh.lowers, self._warp_bvh.uppers],
             )
-            self.warp_bvh.refit()
+            self._warp_bvh.refit()
 
     # ---- Factory methods -----------------------------------------------------
 

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -2611,6 +2611,16 @@ class Gaussian:
         """Sorting mode, Gaussian.SortingMode."""
         return self._sorting_mode
 
+    @property
+    def bvh(self) -> wp.Bvh | None:
+        """The finalized Warp BVH over the Gaussians, or ``None`` before :meth:`finalize`.
+
+        Mirrors the scene shape BVH exposed as :attr:`~newton.Model.bvh_shapes`.
+        Use :meth:`bvh_refit` to update it in place after the finalized
+        :class:`Data` arrays change.
+        """
+        return self.warp_bvh
+
     def _find_sh_degree(self) -> int:
         """Spherical harmonics degree (0-3), inferred from *sh_coeffs* shape."""
         c = self._sh_coeffs.shape[1]
@@ -2660,6 +2670,35 @@ class Gaussian:
             self.warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
             self.warp_data.bvh_id = self.warp_bvh.id
         return self.warp_data
+
+    def bvh_refit(self) -> None:
+        """Refit the Gaussian :attr:`bvh` in place for the current finalized data.
+
+        Recomputes per-Gaussian bounds from the finalized GPU data and refits
+        the BVH in place, keeping its existing topology. Call this after
+        mutating the finalized :class:`Data` arrays (e.g. ``transforms`` or
+        ``scales``) on the device so the acceleration structure tracks the
+        moved Gaussians. Structural changes (a different Gaussian count)
+        require a full rebuild via :meth:`finalize` instead.
+
+        This mirrors :meth:`~newton.Model.bvh_refit_shapes` for the scene
+        shape BVH.
+
+        Raises:
+            RuntimeError: If :meth:`finalize` has not been called yet.
+        """
+        from ..sensors.warp_raytrace.gaussians import compute_gaussian_bvh_bounds  # noqa: PLC0415
+
+        if self.warp_bvh is None or self.warp_data is None:
+            raise RuntimeError("Gaussian.bvh_refit() requires Gaussian.finalize() to have been called first.")
+
+        with wp.ScopedDevice(self.warp_bvh.device):
+            wp.launch(
+                kernel=compute_gaussian_bvh_bounds,
+                dim=self.count,
+                inputs=[self.warp_data, self.warp_bvh.lowers, self.warp_bvh.uppers],
+            )
+            self.warp_bvh.refit()
 
     # ---- Factory methods -----------------------------------------------------
 

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -2647,29 +2647,26 @@ class Gaussian:
         from ..sensors.warp_raytrace.gaussians import compute_gaussian_bvh_bounds  # noqa: PLC0415
 
         with wp.ScopedDevice(device):
-            self._warp_data = Gaussian.Data()
-            self._warp_data.transforms = wp.array(
-                np.append(self._positions, self._rotations, axis=1), dtype=wp.transformf
-            )
-            self._warp_data.scales = wp.array(self._scales, dtype=wp.vec3f)
-            self._warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
-            self._warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
-            self._warp_data.min_response = self.min_response
-            self._warp_data.sorting_mode = self.sorting_mode
-            self._warp_data.num_points = self._warp_data.transforms.shape[0]
-
+            warp_data = Gaussian.Data()
+            warp_data.transforms = wp.array(np.append(self._positions, self._rotations, axis=1), dtype=wp.transformf)
+            warp_data.scales = wp.array(self._scales, dtype=wp.vec3f)
+            warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
+            warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
+            warp_data.min_response = self.min_response
+            warp_data.sorting_mode = self.sorting_mode
+            warp_data.num_points = warp_data.transforms.shape[0]
             lowers = wp.zeros(self.count, dtype=wp.vec3f)
             uppers = wp.zeros(self.count, dtype=wp.vec3f)
-
             wp.launch(
                 kernel=compute_gaussian_bvh_bounds,
                 dim=self.count,
-                inputs=[self._warp_data, lowers, uppers],
+                inputs=[warp_data, lowers, uppers],
             )
-
-            self._warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
-            self._warp_data.bvh_id = self._warp_bvh.id
-        return self._warp_data
+            warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
+            warp_data.bvh_id = warp_bvh.id
+            self._warp_data = warp_data
+            self._warp_bvh = warp_bvh
+        return warp_data
 
     def bvh_refit(self) -> None:
         """Refit the Gaussian :attr:`bvh` in place for the current finalized data.


### PR DESCRIPTION
## Description

The `Gaussian` splat asset owns a Warp BVH built during `finalize()`, but there was no public way to refit it after the finalized Gaussian data changes. This adds a clean accessor
and an in-place refit method that mirror the scene shape BVH API (`Model.bvh_shapes` / `Model.bvh_refit_shapes`):

- `Gaussian.bvh` — read-only property exposing the finalized `wp.Bvh` (or `None` before `finalize()`), dropping the implementation-flavored `warp_` prefix the scene attributes also omit.
- `Gaussian.bvh_refit()` — recomputes per-Gaussian bounds from the finalized GPU `Data` and refits the BVH in place, keeping its existing topology. Guards with a `RuntimeError` if `finalize()` has
not been called, matching the scene refit methods.

Like the scene refit, this preserves tree topology and only updates bounds, so it suits moved/rescaled Gaussians; a change in Gaussian *count* still requires a full rebuild via `finalize()`.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
    [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

Verified manually that the pre-finalize guard raises, `Gaussian.bvh` returns the finalized BVH, and bounds update in place after mutating the finalized data:

```python
import numpy as np, warp as wp, newton

g = newton.Gaussian(
    positions=np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float32),
    rotations=np.array([[0, 0, 0, 1], [0, 0, 0, 1]], dtype=np.float32),
    scales=np.ones((2, 3), dtype=np.float32),
    opacities=np.ones(2, dtype=np.float32),
    sh_coeffs=np.ones((2, 3), dtype=np.float32),
)
g.finalize(device="cpu")
before = g.bvh.lowers.numpy().copy()

tr = g.warp_data.transforms.numpy(); tr[0, 0] = 5.0
g.warp_data.transforms = wp.array(tr, dtype=wp.transformf, device="cpu")
g.bvh_refit()
assert not np.allclose(before, g.bvh.lowers.numpy())

Existing Gaussian tests pass:

uv run --extra dev -m newton.tests -k gaussian

New feature / API change

import newton

gaussian = newton.Gaussian.create_from_ply("object.ply")
gaussian.finalize(device="cuda")

# ... mutate gaussian.warp_data.transforms / scales on the device ...

gaussian.bvh_refit()   # refit the BVH in place
bvh = gaussian.bvh     # access the finalized Warp BVH
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed the Gaussian bounding volume hierarchy (BVH) for inspection.
  * Added support for refitting the existing BVH after finalized Gaussian data changes.
  * BVH refitting now reports an error when attempted before Gaussian data is finalized.

* **Deprecations**
  * Deprecated legacy Gaussian data and BVH aliases. Use the finalized Gaussian data and `Gaussian.bvh` instead. Compatibility access remains available with deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->