### PR TITLE
Select the pyglet headless backend without a display

### DIFF
--- a/changelog/3931.fixed.md
+++ b/changelog/3931.fixed.md
@@ -1,0 +1,1 @@
+Select pyglet's headless backend when `ViewerGL` is constructed with `headless=True` on a Linux session that exposes no display, so headless rendering no longer requires setting `PYGLET_HEADLESS` beforehand. A session with a display, and a windowed viewer, keep pyglet's default backend.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -190,12 +190,19 @@ Warp array on the viewer device:
 
 .. note::
 
-    On a machine without a display, pyglet must also be put in headless mode. pyglet binds its
-    display backend the first time that backend is imported, and Newton imports pyglet's window
-    and display modules when the first :class:`~newton.viewer.ViewerGL` is constructed, so the
-    option has to be set before that point. Otherwise the snippet above fails with
-    ``pyglet.display.xlib.NoSuchDisplayException: Cannot connect to "None"`` on Linux, since
-    pyglet defaults to Xlib. Either set the environment variable::
+    pyglet also has to be in headless mode on a machine without a display, since it defaults to
+    Xlib on Linux and has nothing to connect to. A headless :class:`~newton.viewer.ViewerGL`
+    selects pyglet's headless backend itself when the session exposes neither ``DISPLAY`` nor
+    ``WAYLAND_DISPLAY``, so the snippet above runs as written. A session that has a display keeps
+    the default backend, and so does a windowed viewer.
+
+    The check is on the variables, not on a live connection, so a session that inherits a stale
+    ``DISPLAY`` — a container started from a desktop shell, for example — still fails with
+    ``NoSuchDisplayException``. Choose the backend explicitly there. pyglet binds the backend while
+    the module is imported and cannot rebind afterwards, so this cannot be recovered by retrying.
+
+    To choose the backend yourself — for the case above, or to render headlessly on a machine that
+    does have a display — set the environment variable::
 
         PYGLET_HEADLESS=1 python your_script.py
 
@@ -207,6 +214,10 @@ Warp array on the viewer device:
         pyglet.options["headless"] = True
 
         viewer = newton.viewer.ViewerGL(headless=True)
+
+    Either has to come first: pyglet binds its display backend the first time that backend is
+    imported, and Newton imports pyglet's window and display modules when the first
+    :class:`~newton.viewer.ViewerGL` is constructed.
 
     On a machine with several GPUs, ``PYGLET_HEADLESS_DEVICE`` (or
     ``pyglet.options["headless_device"]``) selects which one renders; it defaults to ``0``,

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -943,6 +943,23 @@ class MeshInstancerGL:
         gl.glBindVertexArray(0)
 
 
+def needs_pyglet_headless_backend(headless: bool | None) -> bool:
+    """Return whether pyglet has to use its headless backend to open a window.
+
+    Only Linux is reported, and only for a headless viewer on a session that
+    exposes neither an X nor a Wayland display: pyglet defaults to Xlib there
+    and has nothing to connect to. A windowed viewer, a session with a
+    display, and every other platform are left to pyglet's own defaults.
+
+    Args:
+        headless: Whether the viewer was asked for headless rendering.
+    """
+    if not headless or not sys.platform.startswith("linux"):
+        return False
+
+    return not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY")
+
+
 class RendererGL:
     gl = None  # Class-level variable to hold the imported module
     _fallback_texture = None  # 1x1 white texture bound when no albedo is set (suppresses macOS GL warning)
@@ -1020,6 +1037,13 @@ class RendererGL:
 
             # disable error checking for performance
             pyglet.options["debug_gl"] = False
+
+            # A headless viewer has no window to show, so on a machine that
+            # offers no display there is nothing for the default Xlib backend
+            # to connect to. Select the headless backend for that case before
+            # the first window is opened, which is where pyglet binds it.
+            if needs_pyglet_headless_backend(headless) and not pyglet.options["headless"]:
+                pyglet.options["headless"] = True
 
             # try imports
             from pyglet.graphics.shader import Shader, ShaderProgram  # noqa: F401

--- a/newton/tests/test_viewer_gl_headless_backend.py
+++ b/newton/tests/test_viewer_gl_headless_backend.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from unittest import mock
+
+from newton._src.viewer.gl import opengl
+
+# Run the viewer in a session that offers no display and has not already put
+# pyglet in headless mode, which is the configuration the selection exists for.
+_DISPLAY_VARS = ("DISPLAY", "WAYLAND_DISPLAY", "PYGLET_HEADLESS")
+
+_CONSTRUCT_HEADLESS_VIEWER = textwrap.dedent(
+    """
+    import newton.viewer
+
+    viewer = newton.viewer.ViewerGL(width=64, height=48, headless=True)
+    try:
+        print("VIEWER_CONSTRUCTED")
+    finally:
+        viewer.close()
+    """
+)
+
+
+class TestPygletHeadlessBackendSelection(unittest.TestCase):
+    # Resolved per call rather than imported by name, so that the behavioral
+    # test below, which reaches the same selection through ViewerGL, still
+    # runs when the selection is missing.
+    @staticmethod
+    def _needs_headless_backend(headless):
+        return opengl.needs_pyglet_headless_backend(headless)
+
+    def test_headless_viewer_without_a_display_needs_the_headless_backend(self):
+        """Verify a headless viewer on a display-less Linux session selects the headless backend."""
+        with mock.patch.object(sys, "platform", "linux"), mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(self._needs_headless_backend(True))
+
+    def test_windowed_viewer_keeps_the_default_backend(self):
+        """Verify a windowed viewer is left on pyglet's default backend."""
+        with mock.patch.object(sys, "platform", "linux"), mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(self._needs_headless_backend(False))
+            self.assertFalse(self._needs_headless_backend(None))
+
+    def test_an_available_display_keeps_the_default_backend(self):
+        """Verify a session with a display keeps the default backend, headless viewer or not.
+
+        Headless rendering is about not showing a window, not about the
+        session lacking one, so a viewer on a machine that has a display must
+        keep the backend that can drive it.
+        """
+        for variable in ("DISPLAY", "WAYLAND_DISPLAY"):
+            with self.subTest(variable=variable):
+                with (
+                    mock.patch.object(sys, "platform", "linux"),
+                    mock.patch.dict(os.environ, {variable: ":0"}, clear=True),
+                ):
+                    self.assertFalse(self._needs_headless_backend(True))
+
+    def test_other_platforms_keep_the_default_backend(self):
+        """Verify the selection is confined to Linux, whose default backend is Xlib."""
+        for platform in ("darwin", "win32"):
+            with self.subTest(platform=platform):
+                with (
+                    mock.patch.object(sys, "platform", platform),
+                    mock.patch.dict(os.environ, {}, clear=True),
+                ):
+                    self.assertFalse(self._needs_headless_backend(True))
+
+
+class TestViewerGLHeadlessWithoutDisplay(unittest.TestCase):
+    def test_headless_viewer_constructs_without_a_display(self):
+        """Verify ``ViewerGL(headless=True)`` opens with no display and no pyglet setup.
+
+        pyglet binds its display backend once per process, so this runs in a
+        subprocess with the display variables scrubbed. Without the backend
+        selection the constructor raises ``NoSuchDisplayException``.
+        """
+        if any(os.environ.get(variable) for variable in _DISPLAY_VARS[:2]):
+            self.skipTest("session has a display, so the headless backend is not selected")
+        if not sys.platform.startswith("linux"):
+            self.skipTest("pyglet only defaults to Xlib on Linux")
+
+        env = {key: value for key, value in os.environ.items() if key not in _DISPLAY_VARS}
+        result = subprocess.run(
+            [sys.executable, "-c", _CONSTRUCT_HEADLESS_VIEWER],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=600,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            self.assertNotIn(
+                "NoSuchDisplayException",
+                result.stderr,
+                "ViewerGL(headless=True) must not ask pyglet for a display it cannot have",
+            )
+            # Anything else means this machine cannot render at all, which the
+            # backend selection can do nothing about.
+            self.skipTest(f"ViewerGL backend not available:\n{result.stderr}")
+
+        self.assertIn("VIEWER_CONSTRUCTED", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_viewer_gl_headless_backend.py
+++ b/newton/tests/test_viewer_gl_headless_backend.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -14,11 +15,31 @@ from newton._src.viewer.gl import opengl
 # pyglet in headless mode, which is the configuration the selection exists for.
 _DISPLAY_VARS = ("DISPLAY", "WAYLAND_DISPLAY", "PYGLET_HEADLESS")
 
+# Exit code the subprocess reserves for a host that cannot render at all, which
+# the backend selection can do nothing about. Every other non-zero exit is a
+# failure of the behavior under test.
+_UNAVAILABLE_EXIT_CODE = 3
+
 _CONSTRUCT_HEADLESS_VIEWER = textwrap.dedent(
-    """
+    f"""
+    import sys
+
     import newton.viewer
 
-    viewer = newton.viewer.ViewerGL(width=64, height=48, headless=True)
+    # The pyglet errors that mean the machine offers no usable GL, kept apart
+    # from a real failure. NoSuchDisplayException is deliberately absent: it is
+    # exactly the failure this test exists to catch.
+    UNAVAILABLE = {{"ConfigException", "ContextException", "MissingFunctionException", "NoSuchConfigException"}}
+
+    try:
+        viewer = newton.viewer.ViewerGL(width=64, height=48, headless=True)
+    except Exception as exc:
+        error_type = type(exc)
+        if error_type.__module__.startswith("pyglet.") and error_type.__name__ in UNAVAILABLE:
+            print(f"VIEWER_UNAVAILABLE: {{error_type.__name__}}: {{exc}}")
+            sys.exit({_UNAVAILABLE_EXIT_CODE})
+        raise
+
     try:
         print("VIEWER_CONSTRUCTED")
     finally:
@@ -84,6 +105,8 @@ class TestViewerGLHeadlessWithoutDisplay(unittest.TestCase):
             self.skipTest("session has a display, so the headless backend is not selected")
         if not sys.platform.startswith("linux"):
             self.skipTest("pyglet only defaults to Xlib on Linux")
+        if importlib.util.find_spec("pyglet") is None:
+            self.skipTest("ViewerGL dependencies not available: pyglet is not installed")
 
         env = {key: value for key, value in os.environ.items() if key not in _DISPLAY_VARS}
         result = subprocess.run(
@@ -95,15 +118,16 @@ class TestViewerGLHeadlessWithoutDisplay(unittest.TestCase):
             check=False,
         )
 
+        if result.returncode == _UNAVAILABLE_EXIT_CODE:
+            self.skipTest(f"ViewerGL backend not available:\n{result.stdout}")
+
         if result.returncode != 0:
             self.assertNotIn(
                 "NoSuchDisplayException",
                 result.stderr,
                 "ViewerGL(headless=True) must not ask pyglet for a display it cannot have",
             )
-            # Anything else means this machine cannot render at all, which the
-            # backend selection can do nothing about.
-            self.skipTest(f"ViewerGL backend not available:\n{result.stderr}")
+            self.fail(f"ViewerGL(headless=True) failed without a display:\n{result.stdout}\n{result.stderr}")
 
         self.assertIn("VIEWER_CONSTRUCTED", result.stdout)
 


### PR DESCRIPTION
## Description

`ViewerGL(headless=True)` inherits pyglet's default Xlib backend on Linux, so on a machine that runs
no X or Wayland server the constructor raises
`pyglet.display.xlib.NoSuchDisplayException: Cannot connect to "None"` before rendering anything.

#3931 asks whether the viewer should set `pyglet.options["headless"]` itself. This is the narrowest
version of that, offered for your consideration — no objection at all if you would rather keep the
choice with the caller.

The selection fires only where the default cannot work: a headless viewer, on Linux, in a session
that exposes neither `DISPLAY` nor `WAYLAND_DISPLAY`. A session that has a display keeps the default
backend, so does a windowed viewer, so does every other platform, and so does a caller who has
already put pyglet in headless mode. That last case is the global-state concern raised on the issue —
nothing changes for anyone managing pyglet themselves.

#3932 documented the manual workaround. With this change the documented `headless=True` snippet runs
as written, so the note now describes how to *override* the backend rather than what you must set
before Newton will work.

One side effect worth flagging: six GL viewer tests across three modules currently skip with
`Cannot connect to "None"` on a display-less machine, and run with this applied.

```
uv run --extra dev -m newton.tests -k viewer
  before:  Ran 233 tests ... skipped=6
  after:   Ran 233 tests ... OK   (0 skipped)
```

The skips are in `test_viewer_get_frame` (3), `test_viewer_camera` (2), and
`test_viewer_image_logger_class` (1). I could not tell from outside whether they also skip on your
runners; `.github/workflows/` sets no `PYGLET_HEADLESS`, `DISPLAY`, or Xvfb, so they may.

### Known boundary

The check reads `DISPLAY` and `WAYLAND_DISPLAY` rather than probing for a live connection, so a
session that inherits a *stale* `DISPLAY` — a container started from a desktop shell — still fails
the same way. I measured both halves of that rather than assuming:

```
DISPLAY=:99 python -c "newton.viewer.ViewerGL(headless=True)"
  -> pyglet.display.xlib.NoSuchDisplayException  (unchanged by this PR)
```

Retrying is not an option: pyglet binds the backend during import, and it survives a purge of
`pyglet.*` from `sys.modules` — a second attempt fails with
`RuntimeError: Canvas must be an instance of XlibCanvas <class '...HeadlessCanvas'>`. So the
up-front environment check is the only mechanism available, and the docs note now tells anyone in
that position to choose the backend explicitly. Happy to widen it if you would rather it probed.

Closes #3931.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

New tests, on a display-less Linux box with four H100s:

```
uv run --extra dev -m newton.tests -k test_viewer_gl_headless_backend
Ran 5 tests in 10.164s
OK
```

`TestPygletHeadlessBackendSelection` covers the decision itself — headless without a display, a
windowed viewer, `DISPLAY` set, `WAYLAND_DISPLAY` set, and non-Linux platforms.
`TestViewerGLHeadlessWithoutDisplay` builds a real `ViewerGL(headless=True)` in a subprocess with the
display variables scrubbed, since pyglet binds its backend once per process. It fails on a
`NoSuchDisplayException` and skips on any other backend error, so a machine that simply cannot render
does not report a false failure.

Reverting only `newton/_src/viewer/gl/opengl.py` turns that test red on the exact symptom:

```
AssertionError: 'NoSuchDisplayException' unexpectedly found in ...
  : ViewerGL(headless=True) must not ask pyglet for a display it cannot have
```

Wider runs:

```
uv run --extra dev -m newton.tests -k viewer          # Ran 233 tests ... OK
uvx pre-commit run -a                                 # all hooks pass
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs <outdir>   # build succeeded
```

I do not have a Wayland or macOS machine to hand, so those paths are covered by the unit tests on the
selection rather than end to end.

## Bug fix

**Steps to reproduce:**

1. Use a Linux machine with no X or Wayland server running (a container or a CI runner).
2. Leave `PYGLET_HEADLESS` unset.
3. Run the headless snippet from `docs/guide/visualization.rst`.
4. The constructor raises before rendering.

**Minimal reproduction:**

```python
import newton.viewer

# On a display-less Linux session, without this PR:
#   pyglet.display.xlib.NoSuchDisplayException: Cannot connect to "None"
viewer = newton.viewer.ViewerGL(width=64, height=48, headless=True)
viewer.close()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Headless OpenGL viewers now automatically use pyglet’s headless backend on Linux systems without a display.
  * Manual `PYGLET_HEADLESS` configuration remains supported.
  * Windowed viewers and sessions with an available display continue using the default backend.

* **Documentation**
  * Updated visualization guidance to reflect automatic headless behavior, stale display-variable issues, and configuration requirements before creating a viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->