### PR TITLE
Fix sparse PADMM info collection

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -1255,7 +1255,7 @@ class PADMMSolver:
             problem.delassus.gemv(
                 x=self._data.state.y,
                 y=self._data.info.v_plus,
-                world_mask=wp.ones((problem.data.num_worlds,), dtype=wp.int32, device=self.device),
+                world_mask=wp.ones((problem.data.num_worlds,), dtype=wp.bool, device=self.device),
                 alpha=1.0,
                 beta=1.0,
             )

--- a/newton/tests/kamino/test_kamino_solvers_padmm.py
+++ b/newton/tests/kamino/test_kamino_solvers_padmm.py
@@ -814,6 +814,55 @@ class TestPADMMSolver(unittest.TestCase):
         # Check solution
         check_padmm_solution(self, test.model, test.problem, solver, verbose=self.verbose)
 
+    def test_08a_padmm_collect_info_matches_solution(self):
+        """Record consistent diagnostics for dense and sparse PADMM problems."""
+        info_vectors = {}
+        for sparse in (False, True):
+            with self.subTest(sparse=sparse):
+                test = TestSetup(
+                    builder_fn=basics.build_box_on_plane,
+                    device=self.default_device,
+                    sparse=sparse,
+                )
+                solver = PADMMSolver(
+                    model=test.model,
+                    config=PADMMSolver.Config(
+                        primal_tolerance=1.0e3,
+                        dual_tolerance=1.0e3,
+                        compl_tolerance=1.0e3,
+                        max_iterations=8,
+                    ),
+                    warmstart=PADMMWarmStartMode.NONE,
+                    use_acceleration=False,
+                    use_graph_conditionals=False,
+                    collect_info=True,
+                )
+
+                test.build()
+                solver.reset()
+                solver.coldstart()
+                solver.solve(problem=test.problem)
+
+                info = solver.data.info
+                status = solver.data.status
+                solution = solver.data.solution
+                iterations = int(status.numpy()[0]["iterations"])
+
+                # History was written
+                self.assertTrue((info.norm_x.numpy()[:iterations] != 0.0).all())
+                np.testing.assert_array_equal(info.norm_x.numpy()[iterations:], 0.0)
+
+                # Solution is consistent with info
+                np.testing.assert_allclose(info.lambdas.numpy(), solution.lambdas.numpy())
+                np.testing.assert_allclose(info.v_aug.numpy(), info.v_plus.numpy() + info.s.numpy())
+
+                # Store info for dense-sparse comparison
+                info_vectors[sparse] = (info.v_plus.numpy(), info.v_aug.numpy(), info.s.numpy())
+
+        # Compare dense-sparse info
+        for dense_values, sparse_values in zip(info_vectors[False], info_vectors[True], strict=True):
+            np.testing.assert_allclose(dense_values, sparse_values, rtol=1e-5, atol=1e-6)
+
     def test_09_apadmm_restart_matches_bilateral_reference(self):
         """Match a NumPy reference across an APADMM solve whose final iteration restarts.
 


### PR DESCRIPTION
## Description

Fix sparse PADMM diagnostics collection by passing the boolean world mask required by the sparse Delassus `gemv` path. Add a focused dense/sparse regression test that verifies diagnostic snapshots and recorded history.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests.kamino.test_kamino_solvers_padmm
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create a sparse Kamino `DualProblem`.
2. Create `PADMMSolver` with `collect_info=True`.
3. Solve the problem on CUDA.
4. Observe a Warp kernel launch failure because `segment_mask` receives an `int32` array instead of `bool`.

**Minimal reproduction:**

```python
solver = PADMMSolver(model=model, collect_info=True)
solver.coldstart()
solver.solve(sparse_problem)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse PADMM solver information collection for more accurate results.

* **Tests**
  * Added coverage validating solver history and final solution consistency.
  * Verified that dense and sparse solver runs produce matching outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->