### PR TITLE
Assert VBD edge/face push along the contact normal

### DIFF
--- a/changelog/+vbd-edge-face-normal-7f3ac21d.skip
+++ b/changelog/+vbd-edge-face-normal-7f3ac21d.skip
@@ -1,0 +1,1 @@
+Test-only: assert the VBD edge/face push along the contact normal instead of +y.

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -4104,11 +4104,17 @@ def _build_edge_over_post(device):
 
 
 def test_edge_face_pushes_vertices_out(test, device):
-    """A soft edge/face penetrating a rigid box pushes its triangle's vertices out (+y).
+    """A soft edge/face penetrating a rigid box pushes its triangle's vertices out.
 
     With section 2 absent the particle force stays zero (legacy count is 0, gravity off),
     so the vertices never move. With section 2 present the barycentric distribution drives
-    v0 and v1 (the spanning edge) up out of the box.
+    v0 and v1 (the spanning edge) out of the box along the contact normal.
+
+    The +y penetration depth is constant along the part of the edge inside the post, so the
+    contact point is degenerate there and lands where the +y and +x exits are nearly
+    equidistant (they differ by ~4e-5). Which face the contact resolves to is therefore
+    decided by rounding and varies across devices, so assert the push along the emitted
+    contact normal rather than along +y.
     """
     model, (v0, v1, _v2) = _build_edge_over_post(device)
 
@@ -4128,15 +4134,18 @@ def test_edge_face_pushes_vertices_out(test, device):
     test.assertEqual(int(np.sum(idx[:, 1] < 0)), 0, "vertices should be outside the legacy particle margin")
     test.assertGreater(total, 0, "edge/face contacts must be detected")
 
+    normal = contacts.soft_contact_normal.numpy()[0]
+
     solver = newton.solvers.SolverVBD(model)
 
-    y0_before = state_in.particle_q.numpy()[:, 1].copy()
+    q_before = state_in.particle_q.numpy().copy()
     solver.step(state_in, state_out, None, contacts, dt=1.0 / 60.0)
-    y0_after = state_out.particle_q.numpy()[:, 1]
+    q_after = state_out.particle_q.numpy()
 
-    # The two vertices of the spanning edge are pushed up out of the +y face.
-    test.assertGreater(y0_after[v0] - y0_before[v0], 1.0e-3, "v0 should be pushed +y")
-    test.assertGreater(y0_after[v1] - y0_before[v1], 1.0e-3, "v1 should be pushed +y")
+    # The two vertices of the spanning edge are pushed out along the contact normal.
+    for name, v in (("v0", v0), ("v1", v1)):
+        push = float(np.dot(q_after[v] - q_before[v], normal))
+        test.assertGreater(push, 1.0e-3, f"{name} should be pushed along the contact normal")
 
 
 def _build_sphere_on_fixed_soft_triangle(device):

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -4134,7 +4134,13 @@ def test_edge_face_pushes_vertices_out(test, device):
     test.assertEqual(int(np.sum(idx[:, 1] < 0)), 0, "vertices should be outside the legacy particle margin")
     test.assertGreater(total, 0, "edge/face contacts must be detected")
 
-    normal = contacts.soft_contact_normal.numpy()[0]
+    # Every record lies on one flat face of the post, so they share a normal. Assert that
+    # rather than letting the push check below depend silently on record 0.
+    normals = contacts.soft_contact_normal.numpy()[:total]
+    test.assertTrue(
+        bool(np.allclose(normals, normals[0], atol=1.0e-6)), "edge/face records should share one face normal"
+    )
+    normal = normals[0]
 
     solver = newton.solvers.SolverVBD(model)
 


### PR DESCRIPTION
## Description

`TestVBDFullSurfaceContact::test_edge_face_pushes_vertices_out` asserts that the spanning edge's two
vertices move in **+y**, but the scene cannot guarantee that direction.

The post spans `|x| <= 0.1, |y| <= 0.5` and the triangle sits at `y = 0.47`, so the +y penetration
depth is **constant** along the whole part of the edge inside the post. The contact point is
degenerate there, and it lands at `x ≈ 0.0700` — exactly the crossover where the +x exit
(`0.1 - x`) equals the +y exit (`0.5 - 0.47`). The two distances differ by about **4e-5**, so which
face the contact resolves to comes down to rounding.

On an H100 (sm_90) it resolves to +x and the assertion reads exactly `0.0`; the same build passes on
CPU. The SDF is not wrong in either case — sweeping the triangle height over `0.450 … 0.495` on CPU
and CUDA, the emitted normal matches the true nearest exit in **16 of 16** samples, and the CPU arm
hits the same knife edge at other heights (`y = 0.495`, `0.465`, `0.460`).

This asserts the push along the emitted contact normal instead. That is the property the
full-surface path actually provides — the vertices are driven out of the post either way
(`|Δ| ≈ 0.084` for `v0`, and all three end up outside the box) — and it no longer depends on the tie.

Analysis and the bisect that led here: https://github.com/newton-physics/newton/issues/907#issuecomment-5437956725

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

Test-only change, so the fragment is a `.skip`.

## Test plan

On a 2× H100 80GB (sm_90) box, driver 580.126.16, Warp 1.17.0.dev20260807:

```
# fails on main (cuda:0 and cuda:1), passes on cpu
uv run --extra dev -m newton.tests -k test_edge_face_pushes_vertices_out

# with this PR: cpu, cuda:0 and cuda:1 all pass
# and the surrounding class stays green
uv run --extra dev -m newton.tests -k TestVBDFullSurfaceContact   # Ran 24 tests ... OK
```

`uvx pre-commit run -a` passes.

## Bug fix

**Steps to reproduce:**

1. On a GPU where the contact resolves to +x (reproduced on H100, sm_90; CPU also reproduces it at
   `y = 0.495`, `0.465` or `0.460`), run
   `uv run --extra dev -m newton.tests -k test_edge_face_pushes_vertices_out`.
2. Observe `AssertionError: np.float32(0.0) not greater than 0.001 : v0 should be pushed +y`.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton
from newton.tests.unittest_utils import configure_sdf_for_collision_shapes

builder = newton.ModelBuilder()
builder.gravity = (0.0, 0.0, 0.0)
builder.add_shape_box(
    body=-1, xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()), hx=0.1, hy=0.5, hz=0.1
)
v0 = builder.add_particle(wp.vec3(-0.4, 0.47, 0.0), wp.vec3(0.0), 0.1)
v1 = builder.add_particle(wp.vec3(0.4, 0.47, 0.0), wp.vec3(0.0), 0.1)
v2 = builder.add_particle(wp.vec3(0.0, 0.47, 0.4), wp.vec3(0.0), 0.1)
builder.add_triangle(v0, v1, v2)
builder.color()
configure_sdf_for_collision_shapes(builder)
model = builder.finalize()

pipeline = newton.CollisionPipeline(
    model, broad_phase="nxn", soft_contact_margin=0.1, enable_rigid_soft_full_surface_contact=True
)
contacts = pipeline.contacts()
state_in, state_out = model.state(), model.state()
pipeline.collide(state_in, contacts)

# The contact point lands on the +x / +y crossover, so the normal is decided by rounding.
bary = contacts.soft_contact_barycentric.numpy()[0]
cp_x = float(bary @ np.array([-0.4, 0.4, 0.0]))
print("contact point x =", cp_x)          # ~0.0700, where 0.1 - x == 0.5 - 0.47
print("normal          =", contacts.soft_contact_normal.numpy()[0])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soft-contact handling for degenerate box collisions by using the calculated contact normal rather than a fixed direction.

* **Tests**
  * Updated edge/face contact validation to account for device-dependent contact normals.
  * Added checks ensuring contacting vertices move outward consistently across supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->