### PR TITLE
Prepare Newton 1.5.1rc1

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.0``
+     - ``1.5.1rc1``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.0"
+version = "1.5.1rc1"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0"
+version = "1.5.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare the `release-1.5` branch for Newton 1.5.1 RC1.

- Set project metadata to `1.5.1rc1`.
- Regenerate the public API version table.
- Update only Newton's own version entry in `uv.lock`.

The rolling 1.5.1 changelog and README documentation links are intentionally
unchanged in this RC. Their final date and `/1.5.1/` links will be prepared in
the GA PR after RC validation.

The maintainer explicitly waived the release audit for this patch release.
After this PR merges, the release workflows and name availability will be
checked again against the exact merged head before creating `v1.5.1rc1`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run docs/generate_api.py
uvx --python 3.12 pre-commit run -a
uv run --extra dev --extra torch-cu12 python -m unittest <six focused tests>
uv build --out-dir <output>
uv run --isolated --no-project --with <wheel> python -c <version checks>
```

All pre-commit hooks passed. Five focused backport regressions passed on CUDA;
the ViewerGL large-mesh regression skipped because no display backend is
available. The clean wheel and source distribution are named for `1.5.1rc1`,
and an isolated wheel install reports `1.5.1rc1` from both package metadata and
`newton.__version__`.

PyPI has no `newton==1.5.1rc1` release and `v1.5.1rc1` is unused locally and on
the canonical remote as of 2026-08-27. Both will be checked again immediately
before tagging.
