### PR TITLE
Prepare Newton 1.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- towncrier release notes start -->
 
-## [1.5.1] - 2026-08-26
+## [1.5.1] - 2026-08-27
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Newton was initiated by [Disney Research](https://www.disneyresearch.com/), [Goo
 - **OS:** Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
 - **GPU:** NVIDIA GPU (Maxwell or newer), driver 545 or newer (CUDA 12). No local CUDA Toolkit installation required. macOS runs on CPU.
 
-For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/1.5.0/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/1.5.0/guide/compatibility.html).
+For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/1.5.1/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/1.5.1/guide/compatibility.html).
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ pip install "newton[examples]"
 python -m newton.examples
 ```
 
-To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/1.5.0/guide/installation.html).
+To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/1.5.1/guide/installation.html).
 
 ## Examples
 
@@ -918,11 +918,11 @@ python -m newton.examples basic_viewer --viewer gl --num-frames 500 --device cpu
 
 ## Contributing and Development
 
-See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/1.5.0/guide/development.html) for instructions on how to contribute to Newton.
+See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/1.5.1/guide/development.html) for instructions on how to contribute to Newton.
 
 ## Support and Community Discussion
 
-For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/1.5.0/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
+For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/1.5.1/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
 
 ## Code of Conduct
 

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.5.1rc1``
+     - ``1.5.1``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.5.1rc1"
+version = "1.5.1"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.1rc1"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare the final Newton 1.5.1 patch release after RC1 validation and
maintainer go/no-go approval.

This PR:

- changes the project, generated API, and lock metadata from `1.5.1rc1` to
  `1.5.1`;
- dates the rolling 1.5.1 changelog section on the planned release date;
- updates README documentation links from `/1.5.0/` to `/1.5.1/`.

There are no runtime code or dependency-version changes. The lockfile diff is
limited to Newton's own version entry. The maintainer waived the release audit
for this patch release.

RC1 validation included the tag-triggered platform and GPU suites,
minimum-dependency and four-GPU workflows, clean public-wheel installation,
six focused Linux/CUDA regressions, the installed-wheel suite, and the focused
ViewerGL regression on Windows. The two installed-wheel ASV-helper import
errors reproduce on 1.5.0 and are accepted for 1.5.1; the existing fix remains
main-only by maintainer decision.

Known release-branch CI exceptions may recur: this branch predates both
`scripts/ci/detect_api_changes.py` and `asv/run_pr_benchmarks.py`, while the
corresponding `pull_request_target` workflows are sourced from current main.
Those jobs fail before inspecting or benchmarking this change.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uvx --python 3.12 pre-commit run -a`
- Six exact Torch-controller, heightfield, and MPR 1.5.1 regression tests with
  `python -m unittest -v` under `uv run --extra dev --extra torch-cu12`
- `uv build --out-dir /tmp/newton-1.5.1-dist.TZZjYh`
- Isolated outside-checkout installation of the built wheel; package metadata
  and `newton.__version__` both report `1.5.1`, importing from `site-packages`
