### PR TITLE
Fix sparse topology classification test

### DIFF
--- a/newton/tests/test_particle_surface.py
+++ b/newton/tests/test_particle_surface.py
@@ -859,11 +859,14 @@ def test_sparse_topology_classification_strides_over_capacity(test, device):
         max_grid_cells=30_000,
         device=device,
     )
-    surface._workspace.launch_threads = 1
-
     surface.update_field(positions, radii)
 
-    counts = surface._workspace.grid_counts.numpy()
+    workspace = surface._workspace
+    workspace.grid_counts.zero_()
+    workspace.launch_threads = 1
+    workspace._classify_topology()
+
+    counts = workspace.grid_counts.numpy()
     cell_count = surface._sparse_volume.get_active_stats().voxel_count
     node_count = cell_count
     test.assertEqual(int(counts[0]), node_count)


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Limit the forced single-thread launch to topology classification. The test previously serialized the entire sparse field update and could hang GPU test jobs while exercising unrelated kernels.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sparse topology classification coverage to explicitly refresh field data before classification.
  * Improved test control by resetting grid counts and using a single processing thread.
  * Existing topology count expectations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->