### PR TITLE
Refocus particle surface tests

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -980,7 +980,7 @@ add_example_test(
         "num-frames": 10,
         "voxel-size": 0.15,
         "surface-voxel-size": 0.075,
-        "surface-max-grid-cells": 4_000_000,
+        "surface-max-grid-cells": 300_000,
         "particles-per-cell": 1,
         "world-count": 2,
     },

--- a/newton/tests/test_particle_surface.py
+++ b/newton/tests/test_particle_surface.py
@@ -2,124 +2,133 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 import warp as wp
 
 import newton
-from newton._src.geometry import particle_surface_sparse_kernels as sparse_kernels
 from newton.geometry import ParticleSurface, extract_particle_surface
 from newton.solvers import SolverImplicitMPM
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
-_TEST_MAX_GRID_CELLS = 250_000
+_TEST_MAX_GRID_CELLS = 32_768
+_TEST_MULTI_WORLD_MAX_GRID_CELLS = 49_152
 
 
 @wp.kernel
-def _address_large_candidate_voxel_slots(addresses: wp.array[wp.vec2i]):
-    addresses[0] = sparse_kernels._candidate_voxel_bit_address(1 << 22, 0)
-    addresses[1] = sparse_kernels._candidate_voxel_bit_address((1 << 23) - 1, 511)
+def _sample_sparse_field_kernel(
+    volume: wp.uint64,
+    voxel_data: wp.array[wp.float32],
+    coordinates: wp.array[wp.vec3],
+    background: float,
+    samples: wp.array[wp.float32],
+):
+    index = wp.tid()
+    samples[index] = wp.volume_sample_index(
+        volume,
+        coordinates[index],
+        wp.Volume.LINEAR,
+        voxel_data,
+        background,
+    )
 
 
-def test_large_candidate_voxel_slots(test, device):
-    addresses = wp.empty(2, dtype=wp.vec2i, device=device)
-    wp.launch(_address_large_candidate_voxel_slots, dim=1, inputs=[addresses], device=device)
-
-    np.testing.assert_array_equal(addresses.numpy(), [[1 << 26, 0], [(1 << 27) - 1, 31]])
-
-
-def _make_sphere_particles(n=3000, seed=42, device=None):
+def _make_sphere_particles(n=512, seed=42, device=None):
+    """Create a deterministic particle sampling of a unit sphere."""
     rng = np.random.default_rng(seed)
     pts = []
     count = 0
     while count < n:
-        p = rng.uniform(-1, 1, size=(n * 2, 3))
-        accepted = p[np.linalg.norm(p, axis=1) < 1.0]
+        candidates = rng.uniform(-1.0, 1.0, size=(2 * n, 3))
+        accepted = candidates[np.linalg.norm(candidates, axis=1) < 1.0]
         pts.append(accepted)
         count += accepted.shape[0]
-    pts = np.concatenate(pts)[:n].astype(np.float32)
-    positions = wp.array(pts, dtype=wp.vec3, device=device)
-    radii = wp.full(n, value=0.05, dtype=float, device=device)
+    positions = wp.array(np.concatenate(pts)[:n].astype(np.float32), dtype=wp.vec3, device=device)
+    radii = wp.full(n, value=0.05, dtype=wp.float32, device=device)
     return positions, radii
 
 
-def _make_ellipsoid_particles(n=3000, seed=42, device=None):
-    positions, _ = _make_sphere_particles(n=n, seed=seed, device="cpu")
-    pts = positions.numpy()
-    pts *= np.array([1.0, 0.35, 0.2], dtype=np.float32)
-    positions = wp.array(pts, dtype=wp.vec3, device=device)
-    radii = wp.full(n, value=0.04, dtype=float, device=device)
-    return positions, radii
+def _assert_nonempty_mesh(test, mesh):
+    """Return the arrays of a nonempty triangle mesh."""
+    vertices, indices, normals = mesh.to_arrays()
+    test.assertIsNotNone(vertices)
+    test.assertIsNotNone(indices)
+    test.assertGreater(vertices.shape[0], 0)
+    test.assertGreater(indices.shape[0], 0)
+    test.assertEqual(indices.shape[0] % 3, 0)
+    return vertices, indices, normals
 
 
-def _make_disk_particles(n=3000, seed=123, z_extent=0.02, device=None):
-    rng = np.random.default_rng(seed)
-    xy = []
-    count = 0
-    while count < n:
-        candidates = rng.uniform(-1.0, 1.0, size=(n, 2))
-        accepted = candidates[np.linalg.norm(candidates, axis=1) < 1.0]
-        xy.append(accepted)
-        count += accepted.shape[0]
-    xy = np.concatenate(xy)[:n]
-    z = rng.uniform(-z_extent, z_extent, size=(n, 1))
-    positions_np = np.concatenate((xy, z), axis=1).astype(np.float32)
-    positions = wp.array(positions_np, dtype=wp.vec3, device=device)
-    radii = wp.full(n, value=0.04, dtype=float, device=device)
-    return positions, radii
-
-
-def _sparse_field_samples(surface, world=None):
+def _sample_sparse_field(surface, positions, *, world=0):
+    """Sample a public sparse field at world-local positions."""
     sparse_field = surface.sparse_field
     if sparse_field is None:
         raise ValueError("Particle surface field has not been extracted")
-    workspace = surface._workspace
-    node_count = sparse_field.volume.get_active_stats().voxel_count
-    packed = workspace.voxel_ijk[:node_count].numpy()
-    worlds = workspace.node_world[:node_count].numpy()
-    offsets = sparse_field.world_index_offsets.numpy()
-    if world is not None:
-        selected = worlds == world
-        packed = packed[selected]
-        worlds = worlds[selected]
-    coordinates = packed - offsets[worlds]
-    values = sparse_field.voxel_data[:node_count].numpy()
-    if world is not None:
-        values = values[selected]
-    order = np.lexsort(coordinates.T[::-1])
-    return coordinates[order], values[order]
+    positions = np.asarray(positions, dtype=np.float32)
+    offset = sparse_field.world_index_offsets.numpy()[world]
+    coordinates = positions / np.float32(surface.voxel_size) + offset
+    coordinates = wp.array(coordinates, dtype=wp.vec3, device=sparse_field.voxel_data.device)
+    samples = wp.empty(coordinates.shape[0], dtype=wp.float32, device=coordinates.device)
+    wp.launch(
+        _sample_sparse_field_kernel,
+        dim=coordinates.shape[0],
+        inputs=[
+            sparse_field.volume.id,
+            sparse_field.voxel_data,
+            coordinates,
+            sparse_field.background,
+            samples,
+        ],
+        device=coordinates.device,
+    )
+    return samples.numpy()
+
+
+def _sorted_vertices(vertices):
+    """Return mesh vertices in deterministic lexicographic order."""
+    values = vertices.numpy()
+    return values[np.lexsort(values.T[::-1])]
 
 
 def test_one_shot(test, device):
+    """Extract a valid anisotropic mesh with the one-shot public API."""
     positions, radii = _make_sphere_particles(device=device)
-    verts, indices, normals = extract_particle_surface(
+    mesh = extract_particle_surface(
         positions,
         radii,
-        voxel_size=0.05,
-        kernel_radius=0.15,
+        voxel_size=0.1,
+        kernel_radius=0.3,
         anisotropic=True,
+        anisotropy_min_neighbors=4,
         anisotropy_binning=True,
     )
-    test.assertIsNotNone(verts)
-    test.assertGreater(verts.shape[0], 0)
-    test.assertGreater(indices.shape[0], 0)
-    test.assertEqual(indices.shape[0] % 3, 0)
-    test.assertEqual(normals.shape[0], verts.shape[0])
+
+    vertices, _indices, normals = _assert_nonempty_mesh(test, mesh)
+    test.assertEqual(normals.shape[0], vertices.shape[0])
 
 
 def test_reusable_context(test, device):
-    positions, radii = _make_sphere_particles(device=device)
-    ctx = ParticleSurface(voxel_size=0.05, kernel_radius=0.15, device=device)
-    verts, _, _ = ctx.extract(positions, radii=radii)
-    test.assertIsNotNone(verts)
+    """Reuse a particle-surface context for consecutive extractions."""
+    positions, radii = _make_sphere_particles(n=256, device=device)
+    surface = ParticleSurface(
+        voxel_size=0.12,
+        kernel_radius=0.36,
+        mesh_smooth_iterations=1,
+        device=device,
+    )
 
-    verts2, _, _ = ctx.extract(positions, radii=radii)
-    test.assertIsNotNone(verts2)
+    first = surface.extract(positions, radii)
+    second = surface.extract(positions, radii)
+
+    first_vertices, first_indices, _first_normals = _assert_nonempty_mesh(test, first)
+    second_vertices, second_indices, _second_normals = _assert_nonempty_mesh(test, second)
+    test.assertEqual(first_vertices.shape, second_vertices.shape)
+    test.assertEqual(first_indices.shape, second_indices.shape)
 
 
 def test_multi_world_mesh(test, device):
-    positions, radii = _make_sphere_particles(n=500, device=device)
+    """Pack independent world meshes into disjoint public offset ranges."""
+    positions, radii = _make_sphere_particles(n=256, device=device)
     positions_np = positions.numpy()
     offset = np.array([4.0, 0.0, 0.0], dtype=np.float32)
     combined_positions = wp.array(
@@ -133,14 +142,14 @@ def test_multi_world_mesh(test, device):
         device=device,
     )
     particle_world = wp.array(
-        np.concatenate((np.zeros(500, dtype=np.int32), np.ones(500, dtype=np.int32))),
+        np.concatenate((np.zeros(256, dtype=np.int32), np.ones(256, dtype=np.int32))),
         dtype=wp.int32,
         device=device,
     )
 
     surface = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
+        voxel_size=0.1,
+        kernel_radius=0.3,
         anisotropic=True,
         anisotropy_min_neighbors=4,
         anisotropy_binning=True,
@@ -148,39 +157,78 @@ def test_multi_world_mesh(test, device):
         device=device,
     )
     mesh = surface.extract(combined_positions, combined_radii, particle_world=particle_world)
-    vertices, indices, normals = mesh.to_arrays()
+    vertices, indices, normals = _assert_nonempty_mesh(test, mesh)
 
-    vertex_world_offsets = mesh.vertex_world_offsets.numpy()
-    index_world_offsets = mesh.index_world_offsets.numpy()
-    test.assertEqual(int(vertex_world_offsets[-1]), vertices.shape[0])
-    test.assertEqual(int(index_world_offsets[-1]), indices.shape[0])
-    test.assertEqual(int(vertex_world_offsets[1]), int(vertex_world_offsets[2] - vertex_world_offsets[1]))
-    test.assertEqual(int(index_world_offsets[1]), int(index_world_offsets[2] - index_world_offsets[1]))
-    test.assertEqual(int(vertex_world_offsets[2]), int(vertex_world_offsets[3]))
-    test.assertEqual(int(index_world_offsets[2]), int(index_world_offsets[3]))
+    vertex_offsets = mesh.vertex_world_offsets.numpy()
+    index_offsets = mesh.index_world_offsets.numpy()
+    test.assertEqual(int(vertex_offsets[-1]), vertices.shape[0])
+    test.assertEqual(int(index_offsets[-1]), indices.shape[0])
+    test.assertEqual(int(vertex_offsets[1]), int(vertex_offsets[2] - vertex_offsets[1]))
+    test.assertEqual(int(index_offsets[1]), int(index_offsets[2] - index_offsets[1]))
+    test.assertEqual(int(vertex_offsets[2]), int(vertex_offsets[3]))
+    test.assertEqual(int(index_offsets[2]), int(index_offsets[3]))
 
+    vertices_np = vertices.numpy()
     indices_np = indices.numpy()
     for world in range(2):
-        world_indices = indices_np[index_world_offsets[world] : index_world_offsets[world + 1]]
-        test.assertGreaterEqual(int(np.min(world_indices)), int(vertex_world_offsets[world]))
-        test.assertLess(int(np.max(world_indices)), int(vertex_world_offsets[world + 1]))
-
-    test.assertEqual(normals.shape[0], vertices.shape[0])
-    sparse_field = surface.sparse_field
-    test.assertEqual(sparse_field.world_index_offsets.shape, (3,))
-    world_index_offsets = sparse_field.world_index_offsets.numpy()
-    np.testing.assert_array_equal(world_index_offsets[2], [0, 0, 0])
-    test.assertEqual(surface._grid_dims_for_world(0), surface._grid_dims_for_world(1))
-    test.assertEqual(surface._grid_dims_for_world(2), (0, 0, 0))
-    test.assertIsNone(surface._field_for_world(2))
-    np.testing.assert_allclose(
-        np.array(surface._grid_origin_for_world(1)) - np.array(surface._grid_origin_for_world(0)),
-        offset,
-        atol=1.0e-6,
+        world_indices = indices_np[index_offsets[world] : index_offsets[world + 1]]
+        test.assertGreaterEqual(int(np.min(world_indices)), int(vertex_offsets[world]))
+        test.assertLess(int(np.max(world_indices)), int(vertex_offsets[world + 1]))
+    mean_offset = np.mean(vertices_np[vertex_offsets[1] : vertex_offsets[2]], axis=0) - np.mean(
+        vertices_np[vertex_offsets[0] : vertex_offsets[1]], axis=0
     )
+    np.testing.assert_allclose(mean_offset, offset, atol=2.0e-5)
+    test.assertEqual(normals.shape[0], vertices.shape[0])
+
+    sparse_field = surface.sparse_field
+    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
+    test.assertEqual(sparse_field.world_index_offsets.shape, (3,))
+    np.testing.assert_array_equal(sparse_field.world_index_offsets.numpy()[2], [0, 0, 0])
+    np.testing.assert_array_equal(sparse_field.per_world_status.numpy(), [0, 0, 0])
+
+
+def test_multi_world_fixed_capacity(test, device):
+    """Preserve per-world mesh ranges with fixed-capacity extraction."""
+    positions, radii = _make_sphere_particles(n=256, device=device)
+    positions_np = positions.numpy()
+    offset = np.array([4.0, 0.0, 0.0], dtype=np.float32)
+    combined_positions = wp.array(
+        np.concatenate((positions_np, positions_np + offset)),
+        dtype=wp.vec3,
+        device=device,
+    )
+    combined_radii = wp.array(
+        np.concatenate((radii.numpy(), radii.numpy())),
+        dtype=wp.float32,
+        device=device,
+    )
+    particle_world = wp.array(
+        np.concatenate((np.zeros(256, dtype=np.int32), np.ones(256, dtype=np.int32))),
+        dtype=wp.int32,
+        device=device,
+    )
+    surface = ParticleSurface(
+        voxel_size=0.1,
+        kernel_radius=0.3,
+        max_grid_cells=_TEST_MULTI_WORLD_MAX_GRID_CELLS,
+        world_count=2,
+        device=device,
+    )
+
+    mesh = surface.extract(combined_positions, combined_radii, particle_world=particle_world)
+    vertices, indices, _normals = _assert_nonempty_mesh(test, mesh)
+
+    vertex_offsets = mesh.vertex_world_offsets.numpy()
+    index_offsets = mesh.index_world_offsets.numpy()
+    test.assertEqual(int(vertex_offsets[-1]), vertices.shape[0])
+    test.assertEqual(int(index_offsets[-1]), indices.shape[0])
+    test.assertEqual(int(vertex_offsets[1]), int(vertex_offsets[2] - vertex_offsets[1]))
+    test.assertEqual(int(index_offsets[1]), int(index_offsets[2] - index_offsets[1]))
+    np.testing.assert_array_equal(surface.sparse_field.per_world_status.numpy(), [0, 0])
 
 
 def test_multi_world_large_topology_halo(test, device):
+    """Keep large field-processing halos isolated between packed worlds."""
     positions = wp.zeros(2, dtype=wp.vec3, device=device)
     radii = wp.array([0.18, 0.32], dtype=wp.float32, device=device)
     particle_world = wp.array([0, 1], dtype=wp.int32, device=device)
@@ -198,131 +246,92 @@ def test_multi_world_large_topology_halo(test, device):
     multi_world_surface = ParticleSurface(world_count=2, **options)
     multi_world_surface.update_field(positions, radii, particle_world=particle_world)
 
+    axis = np.arange(-16, 17, dtype=np.float32) * options["voxel_size"]
+    samples = np.stack(np.meshgrid(axis, axis, axis, indexing="ij"), axis=-1).reshape(-1, 3)
     for world in range(2):
-        single_world_surface = ParticleSurface(**options)
-        single_world_surface.update_field(positions[world : world + 1], radii[world : world + 1])
-        multi_coordinates, multi_values = _sparse_field_samples(multi_world_surface, world=world)
-        single_coordinates, single_values = _sparse_field_samples(single_world_surface)
-        np.testing.assert_array_equal(multi_coordinates, single_coordinates)
-        np.testing.assert_allclose(multi_values, single_values, rtol=1.0e-6, atol=1.0e-6)
+        with test.subTest(world=world):
+            single_world_surface = ParticleSurface(**options)
+            single_world_surface.update_field(positions[world : world + 1], radii[world : world + 1])
+            actual = _sample_sparse_field(multi_world_surface, samples, world=world)
+            expected = _sample_sparse_field(single_world_surface, samples)
+            np.testing.assert_allclose(actual, expected, rtol=1.0e-6, atol=1.0e-6)
 
 
-def test_multi_world_capacity(test, device):
-    positions, radii = _make_sphere_particles(n=200, device=device)
-    positions_np = positions.numpy()
-    combined_positions = wp.array(
-        np.concatenate((positions_np, positions_np)),
-        dtype=wp.vec3,
-        device=device,
-    )
-    combined_radii = wp.array(
-        np.concatenate((radii.numpy(), radii.numpy())),
-        dtype=wp.float32,
-        device=device,
-    )
-    particle_world = wp.array(
-        np.concatenate((np.zeros(200, dtype=np.int32), np.ones(200, dtype=np.int32))),
-        dtype=wp.int32,
-        device=device,
-    )
-    exact_surface = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        world_count=2,
-        device=device,
-    )
-    exact_surface._extract(
-        combined_positions,
-        combined_radii,
-        particle_world=particle_world,
-        compute_mesh=False,
-    )
-    cell_world_start = exact_surface._grid_cell_world_start.numpy()
-    world_cell_counts = np.diff(cell_world_start)
-    total_cell_count = int(cell_world_start[-1])
-
+def test_update_field_and_resurface(test, device):
+    """Update the public sparse field without a mesh and resurface it later."""
+    positions, radii = _make_sphere_particles(n=256, device=device)
     surface = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        max_grid_cells=total_cell_count,
-        world_count=2,
+        voxel_size=0.12,
+        kernel_radius=0.36,
+        field_mode="sdf",
+        redistance_iterations=1,
         device=device,
     )
 
-    mesh = surface.extract(combined_positions, combined_radii, particle_world=particle_world)
-    vertices, indices, _normals = mesh.to_arrays()
-    vertex_world_offsets = mesh.vertex_world_offsets.numpy()
-    index_world_offsets = mesh.index_world_offsets.numpy()
-    test.assertEqual(int(vertex_world_offsets[-1]), vertices.shape[0])
-    test.assertEqual(int(index_world_offsets[-1]), indices.shape[0])
-    test.assertEqual(int(vertex_world_offsets[1]), int(vertex_world_offsets[2] - vertex_world_offsets[1]))
+    sparse_field = surface.update_field(positions, radii)
+
+    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
+    test.assertIsInstance(sparse_field.volume, wp.Volume)
+    test.assertEqual(sparse_field.voxel_data.dtype, wp.float32)
+    test.assertLess(float(sparse_field.voxel_data.numpy().min()), 0.0)
+    mesh = surface.resurface(compute_normals=False)
+    _vertices, _indices, normals = _assert_nonempty_mesh(test, mesh)
+    test.assertIsNone(normals)
+
+
+def test_capacity_status_and_mesh(test, device):
+    """Match exact extraction and report fixed-capacity overflow."""
+    positions, radii = _make_sphere_particles(n=256, seed=17, device=device)
+    reference = ParticleSurface(
+        voxel_size=0.12,
+        kernel_radius=0.36,
+        device=device,
+    )
+    reference_mesh = reference.extract(positions, radii, compute_normals=False)
+    reference_vertices, reference_indices, _reference_normals = _assert_nonempty_mesh(test, reference_mesh)
+    surface = ParticleSurface(
+        voxel_size=0.12,
+        kernel_radius=0.36,
+        max_grid_cells=_TEST_MAX_GRID_CELLS,
+        device=device,
+    )
+
+    mesh = surface.extract(positions, radii, compute_normals=False)
+
+    vertices, indices, normals = _assert_nonempty_mesh(test, mesh)
+    test.assertIsNone(normals)
+    test.assertEqual(vertices.shape, reference_vertices.shape)
+    test.assertEqual(indices.shape, reference_indices.shape)
+    np.testing.assert_allclose(
+        _sorted_vertices(vertices), _sorted_vertices(reference_vertices), rtol=1.0e-6, atol=1.0e-6
+    )
+    axis = np.arange(-10, 11, 2, dtype=np.float32) * surface.voxel_size
+    samples = np.stack(np.meshgrid(axis, axis, axis, indexing="ij"), axis=-1).reshape(-1, 3)
+    np.testing.assert_allclose(
+        _sample_sparse_field(surface, samples),
+        _sample_sparse_field(reference, samples),
+        rtol=1.0e-6,
+        atol=1.0e-6,
+    )
+    np.testing.assert_array_equal(surface.sparse_field.per_world_status.numpy(), [0])
 
     overflow_surface = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        max_grid_cells=int(np.max(world_cell_counts)),
-        world_count=2,
+        voxel_size=0.12,
+        kernel_radius=0.36,
+        max_grid_cells=512,
         device=device,
     )
-    overflow_mesh = overflow_surface.extract(
-        combined_positions,
-        combined_radii,
-        particle_world=particle_world,
-    )
+    overflow_mesh = overflow_surface.extract(positions[:1], radii[:1], compute_normals=False)
+    test.assertNotEqual(int(overflow_surface.sparse_field.per_world_status.numpy()[0]), 0)
     with test.assertRaisesRegex(ValueError, "exceeds configured max_grid_cells"):
         overflow_mesh.to_arrays()
 
-    if wp.get_device(device).is_cuda:
-        with wp.ScopedCapture(device=device) as capture:
-            surface.extract(combined_positions, combined_radii, particle_world=particle_world)
-        wp.capture_launch(capture.graph)
 
-
-def test_field_only_extraction(test, device):
-    positions, radii = _make_sphere_particles(device=device)
-    ctx = ParticleSurface(voxel_size=0.05, kernel_radius=0.15, device=device)
-    verts, indices, normals = ctx._extract(positions, radii=radii, compute_mesh=False)
-
-    test.assertIsNone(verts)
-    test.assertIsNone(indices)
-    test.assertIsNone(normals)
-    test.assertIsNotNone(ctx._field)
-
-    verts, indices, normals = ctx.resurface()
-    test.assertIsNotNone(verts)
-    test.assertGreater(verts.shape[0], 0)
-    test.assertEqual(indices.shape[0] % 3, 0)
-    test.assertEqual(normals.shape[0], verts.shape[0])
-
-
-def test_dynamic_grid_uses_realized_support(test, device):
-    positions = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
-    radii = wp.array([0.05], dtype=wp.float32, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.02,
-        kernel_radius=0.2,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_ratio=16.0,
-        anisotropy_scale=2.0,
-        anisotropy_min_neighbors=4,
-        field_smooth_iterations=0,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    ctx._extract(positions, radii=radii, compute_mesh=False)
-
-    G = ctx._G.numpy()[0]
-    reach = 2.0 * np.linalg.norm(np.linalg.inv(G), axis=0)
-    grid_min = np.array([ctx._grid_origin_value[i] for i in range(3)])
-    grid_max = grid_min + (np.array(ctx._grid_dims_value) - 1) * ctx.voxel_size
-    test.assertTrue(np.all(grid_min <= -reach))
-    test.assertTrue(np.all(grid_max >= reach))
-
-
-def test_isotropic_fallback_stencil_covers_support(test, device):
-    positions = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+def test_isotropic_support_is_not_clipped(test, device):
+    """Preserve the complete isotropic surface in exact and capacity modes."""
+    positions = wp.zeros(1, dtype=wp.vec3, device=device)
     radii = wp.array([1.0], dtype=wp.float32, device=device)
+    meshes = []
     for max_grid_cells in (None, 10_000):
         with test.subTest(max_grid_cells=max_grid_cells):
             surface = ParticleSurface(
@@ -337,98 +346,53 @@ def test_isotropic_fallback_stencil_covers_support(test, device):
                 mesh_smooth_iterations=0,
                 device=device,
             )
-
-            mesh = surface.extract(positions, radii, compute_normals=False)
-
-            np.testing.assert_array_equal(mesh._counts.numpy(), [270, 1608, 0])
-            active_voxel_count = surface._sparse_volume.get_active_stats().voxel_count
-            if max_grid_cells is None:
-                candidate_leaf_count = surface._workspace.leaf_volume.get_active_stats().voxel_count
-            else:
-                leaf_hash = surface._workspace.leaf_hash
-                candidate_leaf_count = int(leaf_hash.active_slots.numpy()[leaf_hash.capacity])
-            candidate_voxel_count = 512 * candidate_leaf_count
-            test.assertEqual(active_voxel_count, 1761)
-            test.assertLess(active_voxel_count, candidate_voxel_count)
+            vertices, indices, _normals = _assert_nonempty_mesh(
+                test,
+                surface.extract(positions, radii, compute_normals=False),
+            )
+            test.assertEqual(vertices.shape[0], 270)
+            test.assertEqual(indices.shape[0], 1608)
+            test.assertGreater(float(np.min(np.max(np.abs(vertices.numpy()), axis=0))), 3.8)
+            np.testing.assert_array_equal(surface.sparse_field.per_world_status.numpy(), [0])
+            meshes.append(_sorted_vertices(vertices))
+    np.testing.assert_allclose(meshes[0], meshes[1], rtol=1.0e-6, atol=1.0e-6)
 
 
-def test_rebuildable_support_stencil_uses_anisotropy_bound(test, device):
-    surface = ParticleSurface(
-        voxel_size=0.015,
-        max_grid_cells=512,
-        kernel_radius=0.05,
-        kernel_scale=0.6,
-        anisotropic=True,
-        anisotropy_ratio=16.0,
-        anisotropy_scale=2.0,
-        anisotropy_strength=0.95,
-        device=device,
-    )
-
-    test.assertEqual(surface._workspace._support_leaf_radius, 3)
-    surface._workspace.ensure_support_leaf_keys(17)
-    test.assertEqual(surface._workspace._support_leaf_radius, 3)
-
-
-def test_rebuildable_topology_scratch_is_fixed(test, device):
-    radii = wp.full(3, value=0.05, dtype=float, device=device)
+def test_sparse_grid_handles_distant_particles(test, device):
+    """Extract distant particles without reserving their empty intervening span."""
+    positions = wp.array([[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+    radii = wp.full(2, value=0.05, dtype=wp.float32, device=device)
     surface = ParticleSurface(
         voxel_size=0.1,
-        max_grid_cells=100_000,
         kernel_radius=0.3,
-        anisotropic=False,
-        padding=0,
-        field_smooth_iterations=0,
-        mesh_smooth_iterations=0,
+        smooth_lambda=0.0,
+        max_grid_cells=4_096,
         device=device,
     )
 
-    clustered = wp.array([[0.0, 0.0, 0.0]] * 3, dtype=wp.vec3, device=device)
-    surface._extract(clustered, radii, compute_mesh=False)
-    leaf_hash = surface._workspace.leaf_hash
-    initial_hash_capacity = leaf_hash.capacity
-    initial_topology_capacity = surface._workspace.topology_voxels.shape[0]
-    initial_hash_keys_ptr = leaf_hash.keys.ptr
-    initial_hash_slots_ptr = leaf_hash.active_slots.ptr
-    initial_leaf_ijk_ptr = surface._workspace.leaf_ijk.ptr
-    initial_occupancy_ptr = surface._workspace.topology_occupancy.ptr
-    initial_occupancy_temp_ptr = surface._workspace.topology_occupancy_temp.ptr
-    initial_topology_ptr = surface._workspace.topology_voxels.ptr
+    sparse_field = surface.update_field(positions, radii)
 
-    spread = wp.array([[-5.0, 0.0, 0.0], [0.0, 0.0, 0.0], [5.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
-    surface._extract(spread, radii, compute_mesh=False)
-
-    test.assertEqual(leaf_hash.capacity, initial_hash_capacity)
-    test.assertEqual(surface._workspace.topology_occupancy.shape[0], 16 * initial_hash_capacity)
-    test.assertEqual(surface._workspace.topology_voxels.shape[0], initial_topology_capacity)
-    test.assertEqual(leaf_hash.keys.ptr, initial_hash_keys_ptr)
-    test.assertEqual(leaf_hash.active_slots.ptr, initial_hash_slots_ptr)
-    test.assertEqual(surface._workspace.leaf_ijk.ptr, initial_leaf_ijk_ptr)
-    test.assertEqual(surface._workspace.topology_occupancy.ptr, initial_occupancy_ptr)
-    test.assertEqual(surface._workspace.topology_occupancy_temp.ptr, initial_occupancy_temp_ptr)
-    test.assertEqual(surface._workspace.topology_voxels.ptr, initial_topology_ptr)
-    np.testing.assert_array_equal(surface._workspace.rebuild_status.numpy(), np.zeros(5, dtype=np.uint32))
-
-
-def test_mesh_smoothing(test, device):
-    positions, radii = _make_sphere_particles(device=device)
-    ctx = ParticleSurface(voxel_size=0.05, kernel_radius=0.15, mesh_smooth_iterations=3, device=device)
-    verts, _, _ = ctx.extract(positions, radii=radii)
-    test.assertIsNotNone(verts)
+    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
+    np.testing.assert_array_equal(sparse_field.per_world_status.numpy(), [0])
+    test.assertTrue(np.all(_sample_sparse_field(surface, [[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]]) > 0.0))
 
 
 def test_empty_particles(test, device):
-    positions = wp.array(np.zeros((0, 3), dtype=np.float32), dtype=wp.vec3, device=device)
-    radii = wp.array(np.zeros(0, dtype=np.float32), dtype=float, device=device)
-    ctx = ParticleSurface(voxel_size=0.05, device=device)
-    verts, indices, normals = ctx.extract(positions, radii=radii)
-    test.assertIsNone(verts)
+    """Return an empty result for an empty particle set."""
+    positions = wp.empty(0, dtype=wp.vec3, device=device)
+    radii = wp.empty(0, dtype=wp.float32, device=device)
+    surface = ParticleSurface(voxel_size=0.1, device=device)
+
+    vertices, indices, normals = surface.extract(positions, radii)
+
+    test.assertIsNone(vertices)
     test.assertIsNone(indices)
     test.assertIsNone(normals)
 
 
 def test_nonfinite_positions_are_skipped(test, device):
-    reference_positions = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+    """Ignore nonfinite particles without changing the valid sparse field."""
+    reference_positions = wp.zeros(1, dtype=wp.vec3, device=device)
     reference_radii = wp.array([0.05], dtype=wp.float32, device=device)
     positions = wp.array(
         [[0.0, 0.0, 0.0], [np.inf, np.nan, -np.inf]],
@@ -436,556 +400,126 @@ def test_nonfinite_positions_are_skipped(test, device):
         device=device,
     )
     radii = wp.array([0.05, 0.05], dtype=wp.float32, device=device)
-
     reference = ParticleSurface(voxel_size=0.05, kernel_radius=0.15, device=device)
     surface = ParticleSurface(voxel_size=0.05, kernel_radius=0.15, device=device)
     reference.update_field(reference_positions, reference_radii)
     surface.update_field(positions, radii)
 
-    test.assertEqual(surface._grid_dims_value, reference._grid_dims_value)
-    np.testing.assert_allclose(surface._grid_origin_value, reference._grid_origin_value)
-    np.testing.assert_allclose(surface._field.numpy(), reference._field.numpy())
+    axis = np.arange(-5, 6, dtype=np.float32) * surface.voxel_size
+    samples = np.stack(np.meshgrid(axis, axis, axis, indexing="ij"), axis=-1).reshape(-1, 3)
+    np.testing.assert_allclose(
+        _sample_sparse_field(surface, samples),
+        _sample_sparse_field(reference, samples),
+        rtol=1.0e-6,
+        atol=1.0e-6,
+    )
 
 
 def test_radii_length_mismatch(test, device):
-    positions = wp.array(np.zeros((4, 3), dtype=np.float32), dtype=wp.vec3, device=device)
-    radii = wp.full(3, value=0.05, dtype=float, device=device)
-    ctx = ParticleSurface(voxel_size=0.1, device=device)
+    """Reject radii whose length does not match the particle positions."""
+    positions = wp.zeros(4, dtype=wp.vec3, device=device)
+    radii = wp.full(3, value=0.05, dtype=wp.float32, device=device)
+    surface = ParticleSurface(voxel_size=0.1, device=device)
+
     with test.assertRaisesRegex(ValueError, "radii length"):
-        ctx.extract(positions, radii=radii, compute_normals=False)
+        surface.extract(positions, radii, compute_normals=False)
 
 
 def test_radii_device_mismatch(test, device):
+    """Reject radii stored on a different device than the positions."""
     if not wp.is_cuda_available():
         test.skipTest("requires CUDA for cross-device validation")
 
     positions_device = wp.get_device(device)
     radii_device = wp.get_device("cuda:0") if positions_device.is_cpu else wp.get_device("cpu")
-    positions = wp.array(np.zeros((4, 3), dtype=np.float32), dtype=wp.vec3, device=positions_device)
-    radii = wp.full(4, value=0.05, dtype=float, device=radii_device)
-    ctx = ParticleSurface(voxel_size=0.1, device=positions_device)
+    positions = wp.zeros(4, dtype=wp.vec3, device=positions_device)
+    radii = wp.full(4, value=0.05, dtype=wp.float32, device=radii_device)
+    surface = ParticleSurface(voxel_size=0.1, device=positions_device)
 
     with test.assertRaisesRegex(ValueError, "radii device"):
-        ctx.extract(positions, radii=radii, compute_normals=False)
+        surface.extract(positions, radii, compute_normals=False)
 
 
 def test_array_layout_validation(test, device):
+    """Reject arrays with unsupported dimensions or element types."""
     positions = wp.zeros(4, dtype=wp.vec3, device=device)
     radii = wp.full(4, value=0.05, dtype=wp.float32, device=device)
-    ctx = ParticleSurface(voxel_size=0.1, device=device)
+    surface = ParticleSurface(voxel_size=0.1, device=device)
 
     with test.assertRaisesRegex(ValueError, "positions must be a 1-D array"):
-        ctx.extract(wp.zeros((4, 3), dtype=wp.float32, device=device), radii=radii)
+        surface.extract(wp.zeros((4, 3), dtype=wp.float32, device=device), radii)
     with test.assertRaisesRegex(TypeError, "positions must have dtype wp.vec3"):
-        ctx.extract(wp.zeros(4, dtype=wp.float32, device=device), radii=radii)
+        surface.extract(wp.zeros(4, dtype=wp.float32, device=device), radii)
     with test.assertRaisesRegex(TypeError, "radii must have dtype wp.float32"):
-        ctx.extract(positions, radii=wp.full(4, value=0.05, dtype=wp.float64, device=device))
+        surface.extract(positions, wp.full(4, value=0.05, dtype=wp.float64, device=device))
     with test.assertRaisesRegex(TypeError, "particle_flags must have dtype wp.int32"):
-        ctx.extract(positions, radii=radii, particle_flags=wp.ones(4, dtype=wp.float32, device=device))
+        surface.extract(positions, radii, particle_flags=wp.ones(4, dtype=wp.float32, device=device))
     with test.assertRaisesRegex(TypeError, "particle_world must have dtype wp.int32"):
-        ctx.extract(positions, radii=radii, particle_world=wp.zeros(4, dtype=wp.float32, device=device))
+        surface.extract(positions, radii, particle_world=wp.zeros(4, dtype=wp.float32, device=device))
 
 
-def test_anisotropic(test, device):
-    positions, radii = _make_ellipsoid_particles(device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.05,
-        kernel_radius=0.15,
-        anisotropic=True,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    verts, _, _ = ctx.extract(positions, radii=radii)
-    test.assertIsNotNone(verts, "Anisotropic extraction produced no surface")
-    test.assertGreater(verts.shape[0], 0)
-
-    # Field should be close to 1.0 in the interior
-    field_np = ctx._field.numpy()
-    test.assertGreater(field_np.max(), 0.5, "Anisotropic field max should be significant")
-
-    # G matrices should not all be isotropic (anisotropy should be active)
-    G_np = ctx._G.numpy()
-    diag_spread = np.max(np.abs(G_np[:, 0, 0] - G_np[:, 2, 2]))
-    test.assertGreater(diag_spread, 1e-5, "G matrices should have direction-dependent scales")
-
-
-def test_anisotropy_strength(test, device):
-    positions, radii = _make_ellipsoid_particles(n=1500, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_strength=0.0,
-        field_smooth_iterations=0,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    verts, indices, _ = ctx.extract(positions, radii=radii, compute_normals=False)
-    test.assertIsNotNone(verts)
-    test.assertGreater(indices.shape[0], 0)
-
-    G_np = ctx._G.numpy()
-    iso_scale = 1.0 / (ctx._kernel_scale * ctx._kernel_radius)
-    np.testing.assert_allclose(G_np[:, 0, 0], iso_scale, rtol=1.0e-5, atol=1.0e-5)
-    np.testing.assert_allclose(G_np[:, 1, 1], iso_scale, rtol=1.0e-5, atol=1.0e-5)
-    np.testing.assert_allclose(G_np[:, 2, 2], iso_scale, rtol=1.0e-5, atol=1.0e-5)
-    np.testing.assert_allclose(G_np[:, 0, 1], 0.0, atol=1.0e-5)
-    np.testing.assert_allclose(G_np[:, 0, 2], 0.0, atol=1.0e-5)
-    np.testing.assert_allclose(G_np[:, 1, 2], 0.0, atol=1.0e-5)
-
-
-def test_anisotropy_ratio_one_uses_isotropic_scale(test, device):
-    positions, radii = _make_ellipsoid_particles(n=500, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        kernel_scale=0.75,
-        anisotropic=True,
-        anisotropy_ratio=1.0,
-        anisotropy_scale=2.0,
-        anisotropy_min_neighbors=4,
-        field_smooth_iterations=0,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-
-    ctx.update_field(positions, radii)
-
-    G_np = ctx._G.numpy()
-    expected = np.eye(3, dtype=np.float32) / (ctx._kernel_scale * ctx._kernel_radius)
-    np.testing.assert_allclose(
-        G_np,
-        np.broadcast_to(expected, G_np.shape),
-        rtol=1.0e-5,
-        atol=1.0e-5,
-    )
-    np.testing.assert_array_equal(ctx._isotropic_fallback.numpy(), np.ones(positions.shape[0], dtype=np.int32))
-
-
-def test_anisotropy_bin_coordinate_overflow_uses_isotropic_fallback(test, device):
-    positions = wp.array([[0.0, 0.0, 0.0], [10_000.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
-    radii = wp.full(2, value=0.05, dtype=wp.float32, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        kernel_scale=0.75,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_binning=True,
-        anisotropy_min_neighbors=0,
-        field_smooth_iterations=0,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-
-    ctx.update_field(positions, radii)
-
-    expected_scale = 1.0 / (ctx._kernel_scale * ctx._kernel_radius)
-    np.testing.assert_allclose(ctx._G.numpy()[1], np.eye(3) * expected_scale, rtol=1.0e-5, atol=1.0e-5)
-    test.assertEqual(int(ctx._isotropic_fallback.numpy()[1]), 1)
-
-
-def test_sdf_field_mode(test, device):
-    positions, radii = _make_sphere_particles(n=2000, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_mode="sdf",
-        redistance_iterations=2,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    test.assertIsNone(ctx.sparse_field)
-    verts, indices, _ = ctx.extract(positions, radii=radii, compute_normals=False)
-    test.assertIsNotNone(verts)
-    test.assertGreater(indices.shape[0], 0)
-
-    sparse_field = ctx.sparse_field
-    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
-    test.assertIsInstance(sparse_field.volume, wp.Volume)
-    test.assertEqual(sparse_field.voxel_data.dtype, wp.float32)
-    test.assertAlmostEqual(sparse_field.background, 0.25)
-    test.assertEqual(sparse_field.world_index_offsets.shape, (1,))
-    np.testing.assert_array_equal(sparse_field.world_index_offsets.numpy(), [[0, 0, 0]])
-    field_np = sparse_field.voxel_data.numpy()
-    test.assertLess(field_np.min(), 0.0)
-    test.assertGreater(field_np.max(), 0.0)
-
-    verts2, indices2, _ = ctx.resurface(compute_normals=False)
-    test.assertIsNotNone(verts2)
-    test.assertGreater(indices2.shape[0], 0)
-
-    smooth_ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_mode="sdf",
-        redistance_iterations=2,
-        mesh_smooth_iterations=2,
-        device=device,
-    )
-    test.assertGreater(smooth_ctx._marching_threshold(), 0.0)
-
-
-def test_update_field_matches_extract_field(test, device):
-    positions, radii = _make_sphere_particles(n=900, device=device)
-    ref = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_mode="sdf",
-        field_smooth_iterations=1,
-        field_smooth_radius=1,
-        redistance_iterations=1,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    ref.extract(positions, radii=radii, compute_normals=False)
-
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_mode="sdf",
-        field_smooth_iterations=1,
-        field_smooth_radius=1,
-        redistance_iterations=1,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    sparse_field = ctx.update_field(positions, radii)
-
-    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
-    np.testing.assert_allclose(sparse_field.voxel_data.numpy(), ref._field.numpy(), rtol=1.0e-6, atol=1.0e-6)
-
-
-def test_grid_capacity_extraction(test, device):
-    positions, radii = _make_sphere_particles(n=300, seed=17, device=device)
-    reference = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_min_neighbors=4,
-        anisotropy_ratio=16.0,
-        anisotropy_scale=2.0,
-        anisotropy_strength=0.95,
-        mesh_smooth_iterations=0,
-        device=device,
-    )
-    reference_vertices, reference_indices, _ = reference.extract(positions, radii=radii, compute_normals=False)
-    max_grid_cells = reference._sparse_volume.get_active_stats().voxel_count
-
-    surface = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_min_neighbors=4,
-        anisotropy_ratio=16.0,
-        anisotropy_scale=2.0,
-        anisotropy_strength=0.95,
-        mesh_smooth_iterations=0,
-        max_grid_cells=max_grid_cells,
-        device=device,
-    )
-    mesh = surface.extract(positions, radii, compute_normals=False)
-
-    reference_coordinates, reference_field = _sparse_field_samples(reference)
-    capacity_coordinates, capacity_field = _sparse_field_samples(surface)
-    np.testing.assert_array_equal(capacity_coordinates, reference_coordinates)
-    np.testing.assert_allclose(capacity_field, reference_field, rtol=1.0e-6, atol=1.0e-6)
-    mesh_counts = mesh._counts.numpy()
-    test.assertEqual(int(mesh_counts[0]), reference_vertices.shape[0])
-    test.assertEqual(int(mesh_counts[1]), reference_indices.shape[0])
-    np.testing.assert_array_equal(surface.sparse_field.per_world_status.numpy(), [0])
-
-    logical_overflow_surface = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_min_neighbors=4,
-        anisotropy_ratio=16.0,
-        anisotropy_scale=2.0,
-        anisotropy_strength=0.95,
-        mesh_smooth_iterations=0,
-        max_grid_cells=max_grid_cells - 1,
-        device=device,
-    )
-    logical_overflow_mesh = logical_overflow_surface.extract(positions, radii, compute_normals=False)
-    test.assertEqual(logical_overflow_surface._sparse_volume.get_active_stats().voxel_count, max_grid_cells)
-    np.testing.assert_array_equal(logical_overflow_surface.sparse_field.per_world_status.numpy(), [1])
-    with test.assertRaisesRegex(ValueError, "exceeds configured max_grid_cells"):
-        logical_overflow_mesh.to_arrays()
-
-    if wp.get_device(device).is_cuda:
-        with wp.ScopedCapture(device=device) as capture:
-            surface.extract(positions, radii, compute_normals=False)
-        wp.capture_launch(capture.graph)
-
-
-def test_sparse_density_matches_reference(test, device):
-    positions_np = np.array(
-        [
-            [-0.217, 0.133, -0.091],
-            [-0.041, 0.207, 0.052],
-            [0.164, -0.118, 0.139],
-            [0.293, 0.064, -0.176],
-        ],
-        dtype=np.float32,
-    )
-    radii_np = np.array([0.051, 0.063, 0.057, 0.069], dtype=np.float32)
-    positions = wp.array(positions_np, dtype=wp.vec3, device=device)
-    radii = wp.array(radii_np, dtype=float, device=device)
-    voxel_size = 0.07
-    kernel_radius = 0.23
-    kernel_scale = 0.65
-    surface = ParticleSurface(
-        voxel_size=voxel_size,
-        kernel_radius=kernel_radius,
-        kernel_scale=kernel_scale,
-        smooth_lambda=0.0,
-        padding=0,
-        max_grid_cells=20_000,
-        device=device,
-    )
-
-    surface.update_field(positions, radii)
-
-    coordinates, actual = _sparse_field_samples(surface)
-    _, leaf_counts = np.unique(coordinates // 8, axis=0, return_counts=True)
-    test.assertTrue(np.any((leaf_counts > 1) & (leaf_counts < 512)))
-
-    sample_positions = np.float32(voxel_size) * coordinates.astype(np.float32)
-    scale = np.float32(1.0 / (kernel_scale * kernel_radius))
-    expected = np.zeros(coordinates.shape[0], dtype=np.float32)
-    for position, radius in zip(positions_np, radii_np, strict=True):
-        q = np.linalg.norm(scale * (sample_positions - position), axis=1)
-        kernel = np.zeros_like(q)
-        inner = q < 1.0
-        kernel[inner] = 1.0 - 1.5 * q[inner] ** 2 + 0.75 * q[inner] ** 3
-        outer = (q >= 1.0) & (q < 2.0)
-        kernel[outer] = 0.25 * (2.0 - q[outer]) ** 3
-        weight = np.float32(8.0 * radius**3 * scale**3 / np.pi)
-        expected += weight * kernel
-
-    np.testing.assert_allclose(actual, expected, rtol=3.0e-5, atol=2.0e-6)
-
-
-def test_sparse_anisotropic_density_matches_reference(test, device):
-    positions_np = np.array(
-        [
-            [-0.18, -0.025, 0.012],
-            [-0.14, 0.018, -0.016],
-            [-0.09, -0.012, 0.021],
-            [-0.04, 0.026, -0.008],
-            [0.01, -0.021, 0.017],
-            [0.06, 0.014, -0.019],
-            [0.11, -0.017, 0.009],
-            [0.16, 0.022, -0.013],
-        ],
-        dtype=np.float32,
-    )
-    radii_np = np.linspace(0.045, 0.059, positions_np.shape[0], dtype=np.float32)
-    positions = wp.array(positions_np, dtype=wp.vec3, device=device)
-    radii = wp.array(radii_np, dtype=float, device=device)
-    voxel_size = 0.055
-    surface = ParticleSurface(
-        voxel_size=voxel_size,
-        kernel_radius=0.24,
-        kernel_scale=0.6,
-        smooth_lambda=0.0,
-        anisotropic=True,
-        anisotropy_ratio=4.0,
-        anisotropy_scale=1.5,
-        anisotropy_min_neighbors=2,
-        anisotropy_strength=0.9,
-        padding=0,
-        max_grid_cells=30_000,
-        device=device,
-    )
-
-    surface.update_field(positions, radii)
-
-    coordinates, actual = _sparse_field_samples(surface)
-    sample_positions = np.float32(voxel_size) * coordinates.astype(np.float32)
-    smoothed = surface._smoothed.numpy()[: positions_np.shape[0]]
-    G_matrices = surface._G.numpy()[: positions_np.shape[0]]
-    det_G = surface._det_G.numpy()[: positions_np.shape[0]]
-    test.assertGreater(np.max(np.abs(G_matrices[:, 0, 0] - G_matrices[:, 1, 1])), 1.0e-3)
-
-    expected = np.zeros(coordinates.shape[0], dtype=np.float32)
-    for position, radius, G, determinant in zip(smoothed, radii_np, G_matrices, det_G, strict=True):
-        transformed = (sample_positions - position) @ G.T
-        q = np.linalg.norm(transformed, axis=1)
-        kernel = np.zeros_like(q)
-        inner = q < 1.0
-        kernel[inner] = 1.0 - 1.5 * q[inner] ** 2 + 0.75 * q[inner] ** 3
-        outer = (q >= 1.0) & (q < 2.0)
-        kernel[outer] = 0.25 * (2.0 - q[outer]) ** 3
-        weight = np.float32(8.0 * radius**3 * determinant / np.pi)
-        expected += weight * kernel
-
-    np.testing.assert_allclose(actual, expected, rtol=5.0e-5, atol=3.0e-6)
-
-
-def test_sparse_grid_avoids_empty_span(test, device):
-    positions = wp.array([[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
-    radii = wp.full(2, value=0.05, dtype=float, device=device)
-    surface = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        smooth_lambda=0.0,
-        max_grid_cells=30_000,
-        device=device,
-    )
-
-    surface.update_field(positions, radii)
-
-    test.assertIsInstance(surface._sparse_volume, wp.Volume)
-    active_cells = surface._sparse_volume.get_active_stats().voxel_count
-    dense_cell_count = int(np.prod(np.asarray(surface._grid_dims_value, dtype=np.int64) - 1))
-    test.assertLessEqual(active_cells, surface._workspace.max_grid_cells)
-    test.assertGreater(dense_cell_count, surface._workspace.max_grid_cells)
-    test.assertGreater(dense_cell_count, 5 * active_cells)
-    test.assertEqual(surface._workspace.max_grid_nodes, surface._workspace.max_grid_cells)
-    test.assertEqual(int(surface._workspace.grid_counts.numpy()[3]), 0)
-
-
-def test_sparse_topology_classification_strides_over_capacity(test, device):
-    positions, radii = _make_sphere_particles(n=100, seed=23, device=device)
-    surface = ParticleSurface(
-        voxel_size=0.1,
-        kernel_radius=0.3,
-        smooth_lambda=0.0,
-        max_grid_cells=30_000,
-        device=device,
-    )
-    surface._workspace.launch_threads = 1
-
-    surface.update_field(positions, radii)
-
-    counts = surface._workspace.grid_counts.numpy()
-    cell_count = surface._sparse_volume.get_active_stats().voxel_count
-    node_count = cell_count
-    test.assertEqual(int(counts[0]), node_count)
-    test.assertEqual(int(counts[1]), cell_count)
-
-
-def test_update_field_skips_inactive_particles(test, device):
-    active_positions, active_radii = _make_sphere_particles(n=600, seed=7, device="cpu")
-    active_np = active_positions.numpy()
-    inactive_np = np.full_like(active_np, np.nan)
-    all_np = np.concatenate((active_np, inactive_np), axis=0)
-    positions = wp.array(all_np, dtype=wp.vec3, device=device)
-
-    radii_np = np.concatenate((active_radii.numpy(), np.full(active_radii.shape[0], np.nan, dtype=np.float32)))
-    radii = wp.array(radii_np, dtype=float, device=device)
-
-    flags_np = np.concatenate(
-        (
-            np.full(active_np.shape[0], newton.ParticleFlags.ACTIVE, dtype=np.int32),
-            np.zeros(active_np.shape[0], dtype=np.int32),
-        )
-    )
-    flags = wp.array(flags_np, dtype=wp.int32, device=device)
-
-    ref = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_min_neighbors=4,
-        anisotropy_binning=True,
-        device=device,
-    )
-    ref.update_field(
-        wp.array(active_np, dtype=wp.vec3, device=device), wp.array(active_radii.numpy(), dtype=float, device=device)
-    )
-
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_min_neighbors=4,
-        anisotropy_binning=True,
-        device=device,
-    )
-    ctx.update_field(positions, radii, particle_flags=flags)
-
-    np.testing.assert_allclose(ctx._field.numpy(), ref._field.numpy(), rtol=1.0e-6, atol=1.0e-6)
-
-
-def test_update_field_cuda_graph(test, device):
-    device_obj = wp.get_device(device)
-    if not device_obj.is_cuda:
+def test_cuda_graph_extraction(test, device):
+    """Capture and replay fixed-capacity extraction in a CUDA graph."""
+    device = wp.get_device(device)
+    if not device.is_cuda:
         test.skipTest("requires CUDA graph capture")
 
-    positions_cpu, radii_cpu = _make_sphere_particles(n=512, seed=9, device="cpu")
-    positions_np = positions_cpu.numpy()
-    radii_np = radii_cpu.numpy()
-    flags_np = np.full(positions_np.shape[0], newton.ParticleFlags.ACTIVE, dtype=np.int32)
-    flags_np[::7] = 0
-    radii_np[::7] = np.nan
-    positions_np[::7] = np.nan
-
-    positions = wp.array(positions_np, dtype=wp.vec3, device=device)
-    radii = wp.array(radii_np, dtype=float, device=device)
-    flags = wp.array(flags_np, dtype=wp.int32, device=device)
-
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
+    positions, radii = _make_sphere_particles(n=256, seed=9, device=device)
+    surface = ParticleSurface(
+        voxel_size=0.12,
+        kernel_radius=0.36,
         anisotropic=True,
         anisotropy_min_neighbors=4,
         anisotropy_binning=True,
         field_mode="sdf",
-        field_smooth_iterations=1,
-        field_smooth_radius=1,
         redistance_iterations=1,
         max_grid_cells=_TEST_MAX_GRID_CELLS,
         device=device,
     )
-    ctx.update_field(positions, radii, particle_flags=flags)
-    origin_before = np.array(ctx._grid_origin_value)
+    initial_mesh = surface.extract(positions, radii, compute_normals=False)
+    initial_vertices, _initial_indices, _initial_normals = _assert_nonempty_mesh(test, initial_mesh)
+    initial_mean = np.mean(initial_vertices.numpy(), axis=0)
 
-    with wp.ScopedCapture(device=device_obj) as capture:
-        ctx.update_field(positions, radii, particle_flags=flags)
-    moved_positions_np = positions_np.copy()
-    moved_positions_np[flags_np != 0] += np.array([4.0, 0.0, 0.0], dtype=np.float32)
-    wp.copy(positions, wp.array(moved_positions_np, dtype=wp.vec3, device=device))
+    with wp.ScopedCapture(device=device) as capture:
+        captured_mesh = surface.extract(positions, radii, compute_normals=False)
+
+    translation = np.array([4.0 * surface.voxel_size, 0.0, 0.0], dtype=np.float32)
+    moved_positions = wp.array(positions.numpy() + translation, dtype=wp.vec3, device=device)
+    wp.copy(positions, moved_positions)
     wp.capture_launch(capture.graph)
 
-    field_np = ctx._field.numpy()
-    test.assertLess(field_np.min(), 0.0)
-    test.assertGreater(field_np.max(), 0.0)
-    np.testing.assert_allclose(np.array(ctx._grid_origin_value) - origin_before, [4.0, 0.0, 0.0], atol=ctx.voxel_size)
+    captured_vertices, _captured_indices, _captured_normals = _assert_nonempty_mesh(test, captured_mesh)
+    np.testing.assert_allclose(np.mean(captured_vertices.numpy(), axis=0) - initial_mean, translation, atol=2.0e-5)
 
 
 def test_particle_sdf_surface_method(test, device):
-    positions, radii = _make_sphere_particles(n=1200, device=device)
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
+    """Extract a signed-distance surface with the particle-SDF method."""
+    positions, radii = _make_sphere_particles(n=256, device=device)
+    surface = ParticleSurface(
+        voxel_size=0.12,
+        kernel_radius=0.36,
         surface_method="particle_sdf",
         particle_sdf_radius_scale=1.8,
         anisotropic=True,
         anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
         device=device,
     )
-    verts, indices, _ = ctx.extract(positions, radii=radii, compute_normals=False)
-    test.assertEqual(ctx.field_mode, "sdf")
-    test.assertIsNotNone(verts)
-    test.assertGreater(indices.shape[0], 0)
 
-    field_np = ctx._field.numpy()
-    test.assertLess(field_np.min(), 0.0)
-    test.assertGreater(field_np.max(), 0.0)
-    test.assertEqual(ctx._marching_threshold(), 0.0)
+    mesh = surface.extract(positions, radii, compute_normals=False)
+
+    _vertices, _indices, normals = _assert_nonempty_mesh(test, mesh)
+    test.assertIsNone(normals)
+    test.assertEqual(surface.field_mode, "sdf")
+    field = surface.sparse_field.voxel_data.numpy()
+    test.assertLess(float(field.min()), 0.0)
+    test.assertGreater(float(field.max()), 0.0)
 
 
-def test_isotropic_particle_sdf_values(test, device):
-    positions = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+def test_isotropic_particle_sdf_samples(test, device):
+    """Return analytic signed distances for one isotropic particle."""
+    positions = wp.zeros(1, dtype=wp.vec3, device=device)
     radii = wp.array([0.5], dtype=wp.float32, device=device)
-    ctx = ParticleSurface(
+    surface = ParticleSurface(
         voxel_size=1.0,
         kernel_radius=3.0,
         smooth_lambda=0.0,
@@ -993,294 +527,50 @@ def test_isotropic_particle_sdf_values(test, device):
         particle_sdf_band=2.0,
         device=device,
     )
-    ctx.update_field(positions, radii)
+    surface.update_field(positions, radii)
 
-    coordinates, values = _sparse_field_samples(ctx)
-    field = {tuple(coordinate): float(value) for coordinate, value in zip(coordinates, values, strict=True)}
-    test.assertAlmostEqual(field[(0, 0, 0)], -0.5)
-    test.assertAlmostEqual(field[(-1, 0, 0)], 0.5)
-    test.assertAlmostEqual(field[(0, -1, 0)], 0.5)
-    test.assertAlmostEqual(field[(0, 0, -1)], 0.5)
-    test.assertAlmostEqual(max(field.values()), 6.0)
-
-
-def test_anisotropy_scale(test, device):
-    positions, radii = _make_disk_particles(device=device)
-    ctx_tight = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_scale=0.75,
-        anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
-        field_smooth_iterations=0,
-        device=device,
+    samples = _sample_sparse_field(
+        surface,
+        [[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [10.0, 0.0, 0.0]],
     )
-    ctx_wide = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_scale=1.5,
-        anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
-        field_smooth_iterations=0,
-        device=device,
-    )
-
-    ctx_tight.extract(positions, radii=radii, compute_normals=False)
-    ctx_wide.extract(positions, radii=radii, compute_normals=False)
-
-    G_tight = ctx_tight._G.numpy()
-    G_wide = ctx_wide._G.numpy()
-    test.assertGreater(np.max(np.abs(G_tight - G_wide)), 1e-5)
-
-
-def test_anisotropic_kernel_scale_matches_isotropic_scale(test, device):
-    positions, radii = _make_disk_particles(device=device)
-    kernel_radius = 0.24
-    kernel_scale = 0.6
-    anisotropy_scale = 1.25
-    ctx = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=kernel_radius,
-        anisotropic=True,
-        kernel_scale=kernel_scale,
-        anisotropy_scale=anisotropy_scale,
-        anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
-        field_smooth_iterations=0,
-        device=device,
-    )
-
-    ctx.extract(positions, radii=radii, compute_normals=False)
-
-    expected_det = 1.0 / (kernel_radius * kernel_scale * anisotropy_scale) ** 3
-    actual_det = np.median(ctx._det_G.numpy())
-    test.assertLess(abs(actual_det - expected_det) / expected_det, 0.05)
-
-
-def test_anisotropy_ratio(test, device):
-    positions, radii = _make_disk_particles(device=device)
-    ctx_low = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_ratio=2.0,
-        anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
-        field_smooth_iterations=0,
-        device=device,
-    )
-    ctx_high = ParticleSurface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        anisotropic=True,
-        anisotropy_ratio=8.0,
-        anisotropy_min_neighbors=4,
-        mesh_smooth_iterations=0,
-        field_smooth_iterations=0,
-        device=device,
-    )
-
-    ctx_low.extract(positions, radii=radii, compute_normals=False)
-    ctx_high.extract(positions, radii=radii, compute_normals=False)
-
-    low_eigs = np.linalg.eigvalsh(ctx_low._G.numpy())
-    high_eigs = np.linalg.eigvalsh(ctx_high._G.numpy())
-    low_ratios = low_eigs[:, -1] / np.maximum(low_eigs[:, 0], 1.0e-12)
-    high_ratios = high_eigs[:, -1] / np.maximum(high_eigs[:, 0], 1.0e-12)
-
-    test.assertLessEqual(np.percentile(low_ratios, 95), 2.05)
-    test.assertGreater(np.percentile(high_ratios, 90), np.percentile(low_ratios, 90) + 1.0)
+    np.testing.assert_allclose(samples, [-0.5, 0.5, 0.5, 0.5, 6.0], rtol=1.0e-6, atol=1.0e-6)
 
 
 def test_particle_flags_filter_inactive(test, device):
-    active_positions, active_radii = _make_sphere_particles(n=1000, seed=11, device=device)
+    """Exclude particles without the public ACTIVE flag from extraction."""
+    active_positions, active_radii = _make_sphere_particles(n=256, seed=11, device=device)
     active_np = active_positions.numpy()
-    all_np = np.concatenate((active_np, active_np + np.array([8.0, 0.0, 0.0], dtype=np.float32)), axis=0)
-
-    positions = wp.array(all_np, dtype=wp.vec3, device=device)
-    radii_np = np.full(all_np.shape[0], 0.05, dtype=np.float32)
-    radii_np[active_np.shape[0] :] = np.nan
-    radii = wp.array(radii_np, dtype=float, device=device)
+    positions_np = np.concatenate((active_np, np.full_like(active_np, np.nan)))
+    radii_np = np.concatenate((active_radii.numpy(), np.full(active_radii.shape[0], np.nan, dtype=np.float32)))
     flags_np = np.concatenate(
         (
             np.full(active_np.shape[0], int(newton.ParticleFlags.ACTIVE), dtype=np.int32),
             np.zeros(active_np.shape[0], dtype=np.int32),
         )
     )
+    positions = wp.array(positions_np, dtype=wp.vec3, device=device)
+    radii = wp.array(radii_np, dtype=wp.float32, device=device)
     flags = wp.array(flags_np, dtype=wp.int32, device=device)
+    surface = ParticleSurface(voxel_size=0.12, kernel_radius=0.36, device=device)
 
-    active_ctx = ParticleSurface(voxel_size=0.08, kernel_radius=0.24, field_smooth_iterations=0, device=device)
-    flagged_ctx = ParticleSurface(voxel_size=0.08, kernel_radius=0.24, field_smooth_iterations=0, device=device)
+    mesh = surface.extract(positions, radii, compute_normals=False, particle_flags=flags)
 
-    active_ctx.extract(active_positions, radii=active_radii, compute_normals=False)
-    flagged_ctx.extract(positions, radii=radii, compute_normals=False, particle_flags=flags)
-
-    test.assertEqual(flagged_ctx._grid_dims_value, active_ctx._grid_dims_value)
-    np.testing.assert_allclose(
-        np.array(flagged_ctx._grid_origin_value), np.array(active_ctx._grid_origin_value), atol=1e-6
+    vertices, indices, _normals = _assert_nonempty_mesh(test, mesh)
+    reference_surface = ParticleSurface(voxel_size=0.12, kernel_radius=0.36, device=device)
+    reference_vertices, reference_indices, _reference_normals = _assert_nonempty_mesh(
+        test,
+        reference_surface.extract(active_positions, active_radii, compute_normals=False),
     )
+    test.assertEqual(vertices.shape, reference_vertices.shape)
+    test.assertEqual(indices.shape, reference_indices.shape)
 
-    inactive_flags = wp.zeros(all_np.shape[0], dtype=wp.int32, device=device)
-    verts, indices, normals = flagged_ctx.extract(
-        positions, radii=radii, compute_normals=False, particle_flags=inactive_flags
-    )
-    test.assertIsNone(verts)
-    test.assertIsNone(indices)
-    test.assertIsNone(normals)
-    verts, indices, normals = flagged_ctx.resurface(compute_normals=False)
-    test.assertIsNone(verts)
-    test.assertIsNone(indices)
-    test.assertIsNone(normals)
+    inactive_flags = wp.zeros(positions.shape[0], dtype=wp.int32, device=device)
+    empty_mesh = surface.extract(positions, radii, compute_normals=False, particle_flags=inactive_flags)
+    test.assertEqual(empty_mesh.to_arrays(), (None, None, None))
 
 
-def test_solver_extract_particle_surface(test, device):
-    builder = newton.ModelBuilder()
-    SolverImplicitMPM.register_custom_attributes(builder)
-    builder.add_particle_grid(
-        pos=wp.vec3(-0.15, -0.15, 0.0),
-        rot=wp.quat_identity(),
-        vel=wp.vec3(0.0),
-        dim_x=4,
-        dim_y=4,
-        dim_z=4,
-        cell_x=0.1,
-        cell_y=0.1,
-        cell_z=0.1,
-        mass=1.0,
-        jitter=0.0,
-        radius_mean=0.05,
-    )
-    builder.add_ground_plane()
-    model = builder.finalize(device=device)
-    state = model.state()
-
-    options = SolverImplicitMPM.Config()
-    options.grid_type = "dense"
-    options.voxel_size = 0.1
-    solver = SolverImplicitMPM(model, options)
-    default_surface = solver.create_particle_surface()
-    test.assertAlmostEqual(default_surface.voxel_size, 0.045)
-    surface = solver.create_particle_surface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_smooth_iterations=0,
-    )
-
-    with patch.object(surface, "extract", wraps=surface.extract) as extract:
-        verts, indices, normals = solver.extract_particle_surface(state, surface, compute_normals=False)
-
-    test.assertIs(extract.call_args.kwargs["particle_flags"], solver._mpm_model.particle_flags)
-
-    test.assertIsNotNone(verts)
-    test.assertGreater(verts.shape[0], 0)
-    test.assertGreater(indices.shape[0], 0)
-    test.assertIsNone(normals)
-
-    inactive_flags = wp.zeros(model.particle_count, dtype=wp.int32, device=device)
-    verts, indices, normals = solver.extract_particle_surface(
-        state, surface, compute_normals=False, particle_flags=inactive_flags
-    )
-    test.assertIsNone(verts)
-    test.assertIsNone(indices)
-    test.assertIsNone(normals)
-
-    surface_sdf = solver.create_particle_surface(
-        voxel_size=0.08,
-        kernel_radius=0.24,
-        field_smooth_iterations=0,
-        field_mode="sdf",
-        redistance_iterations=1,
-    )
-    empty_mesh = solver.extract_particle_surface(
-        state,
-        surface_sdf,
-        compute_normals=False,
-        extrapolate_into_colliders=True,
-        particle_flags=inactive_flags,
-    )
-    empty_vertices, empty_indices, empty_normals = empty_mesh.to_arrays()
-    test.assertIsNone(empty_vertices)
-    test.assertIsNone(empty_indices)
-    test.assertIsNone(empty_normals)
-
-    with patch.object(surface_sdf, "redistance", wraps=surface_sdf.redistance) as redistance:
-        verts, indices, normals = solver.extract_particle_surface(
-            state,
-            surface_sdf,
-            compute_normals=False,
-            extrapolate_into_colliders=True,
-            collider_extrapolation_depth=0.08,
-            collider_extrapolation_redistance_iterations=2,
-        )
-
-    redistance.assert_called_once_with(2)
-    test.assertIsNotNone(verts)
-    test.assertGreater(verts.shape[0], 0)
-    test.assertGreater(indices.shape[0], 0)
-    test.assertIsNone(normals)
-
-    capacity_surface_sdf = solver.create_particle_surface(
-        voxel_size=0.08,
-        max_grid_cells=_TEST_MAX_GRID_CELLS,
-        kernel_radius=0.24,
-        field_smooth_iterations=0,
-        field_mode="sdf",
-        redistance_iterations=1,
-    )
-    capacity_mesh = solver.extract_particle_surface(
-        state,
-        capacity_surface_sdf,
-        compute_normals=False,
-        extrapolate_into_colliders=True,
-        collider_extrapolation_depth=0.08,
-    )
-    capacity_counts = capacity_mesh._counts.numpy()
-    test.assertGreater(int(capacity_counts[0]), 0)
-    test.assertGreater(int(capacity_counts[1]), 0)
-
-    invalid_depths = (-0.01, float("inf"), 1.0)
-    for max_depth in invalid_depths:
-        with test.subTest(max_depth=max_depth), test.assertRaisesRegex(ValueError, "max_depth|topology halo"):
-            solver.extract_particle_surface(
-                state,
-                capacity_surface_sdf,
-                compute_normals=False,
-                extrapolate_into_colliders=True,
-                collider_extrapolation_depth=max_depth,
-            )
-    with test.assertRaisesRegex(ValueError, "onset"):
-        solver.extract_particle_surface(
-            state,
-            capacity_surface_sdf,
-            compute_normals=False,
-            extrapolate_into_colliders=True,
-            collider_extrapolation_onset=float("nan"),
-        )
-    with test.assertRaisesRegex(ValueError, "topology halo"):
-        solver.extract_particle_surface(
-            state,
-            capacity_surface_sdf,
-            compute_normals=False,
-            extrapolate_into_colliders=True,
-            collider_extrapolation_depth=0.1,
-            collider_extrapolation_onset=-0.3,
-        )
-
-    if wp.get_device(device).is_cuda:
-        with wp.ScopedCapture(device=device) as capture:
-            solver.extract_particle_surface(
-                state,
-                capacity_surface_sdf,
-                compute_normals=False,
-                extrapolate_into_colliders=True,
-                collider_extrapolation_depth=0.08,
-            )
-        wp.capture_launch(capture.graph)
-
-
-def test_solver_extract_particle_surface_multi_world(test, device):
+def _build_mpm_solver(device, *, world_count=1):
+    """Build a small MPM particle block for solver integration tests."""
     blueprint = newton.ModelBuilder()
     SolverImplicitMPM.register_custom_attributes(blueprint)
     blueprint.add_particle_grid(
@@ -1299,38 +589,52 @@ def test_solver_extract_particle_surface_multi_world(test, device):
     )
     blueprint.add_ground_plane()
 
-    builder = newton.ModelBuilder()
-    SolverImplicitMPM.register_custom_attributes(builder)
-    builder.add_world(blueprint)
-    builder.add_world(blueprint, xform=wp.transform(wp.vec3(2.0, 0.0, 0.0), wp.quat_identity()))
+    if world_count == 1:
+        builder = blueprint
+    else:
+        builder = newton.ModelBuilder()
+        SolverImplicitMPM.register_custom_attributes(builder)
+        for world in range(world_count):
+            builder.add_world(
+                blueprint,
+                xform=wp.transform(wp.vec3(2.0 * world, 0.0, 0.0), wp.quat_identity()),
+            )
     model = builder.finalize(device=device)
-    state = model.state()
+    config = SolverImplicitMPM.Config()
+    config.grid_type = "dense"
+    config.voxel_size = 0.1
+    config.separate_worlds = world_count > 1
+    return model, SolverImplicitMPM(model, config)
 
-    options = SolverImplicitMPM.Config()
-    options.grid_type = "dense"
-    options.voxel_size = 0.1
-    options.separate_worlds = True
-    solver = SolverImplicitMPM(model, options)
-    np.testing.assert_array_equal(np.sort(solver._mpm_model.collider.collider_world.numpy()), [0, 1])
+
+def test_solver_extract_particle_surface(test, device):
+    """Extract particles and collider-extended SDFs through the MPM solver API."""
+    model, solver = _build_mpm_solver(device)
+    state = model.state()
+    default_surface = solver.create_particle_surface()
+    test.assertAlmostEqual(default_surface.voxel_size, 0.045)
+
     surface = solver.create_particle_surface(
         voxel_size=0.08,
         kernel_radius=0.24,
         field_smooth_iterations=0,
     )
-
     mesh = solver.extract_particle_surface(state, surface, compute_normals=False)
-    vertices, indices, normals = mesh.to_arrays()
-    vertex_world_offsets = mesh.vertex_world_offsets.numpy()
-    index_world_offsets = mesh.index_world_offsets.numpy()
-
-    test.assertEqual(surface.world_count, 2)
-    test.assertEqual(int(vertex_world_offsets[-1]), vertices.shape[0])
-    test.assertEqual(int(index_world_offsets[-1]), indices.shape[0])
-    test.assertEqual(int(vertex_world_offsets[1]), int(vertex_world_offsets[2] - vertex_world_offsets[1]))
+    _vertices, _indices, normals = _assert_nonempty_mesh(test, mesh)
     test.assertIsNone(normals)
 
-    surface_sdf = solver.create_particle_surface(
+    inactive_flags = wp.zeros(model.particle_count, dtype=wp.int32, device=device)
+    empty_mesh = solver.extract_particle_surface(
+        state,
+        surface,
+        compute_normals=False,
+        particle_flags=inactive_flags,
+    )
+    test.assertEqual(empty_mesh.to_arrays(), (None, None, None))
+
+    collider_surface = solver.create_particle_surface(
         voxel_size=0.08,
+        max_grid_cells=_TEST_MAX_GRID_CELLS,
         kernel_radius=0.24,
         field_smooth_iterations=0,
         field_mode="sdf",
@@ -1338,18 +642,49 @@ def test_solver_extract_particle_surface_multi_world(test, device):
     )
     collider_mesh = solver.extract_particle_surface(
         state,
-        surface_sdf,
+        collider_surface,
         compute_normals=False,
         extrapolate_into_colliders=True,
         collider_extrapolation_depth=0.08,
     )
-    collider_vertices, collider_indices, _collider_normals = collider_mesh.to_arrays()
-    test.assertEqual(int(collider_mesh.vertex_world_offsets.numpy()[-1]), collider_vertices.shape[0])
-    test.assertEqual(int(collider_mesh.index_world_offsets.numpy()[-1]), collider_indices.shape[0])
+    _collider_vertices, _collider_indices, collider_normals = _assert_nonempty_mesh(test, collider_mesh)
+    test.assertIsNone(collider_normals)
+
+    with test.assertRaisesRegex(ValueError, "max_depth|topology halo"):
+        solver.extract_particle_surface(
+            state,
+            collider_surface,
+            compute_normals=False,
+            extrapolate_into_colliders=True,
+            collider_extrapolation_depth=float("inf"),
+        )
+
+
+def test_solver_extract_particle_surface_multi_world(test, device):
+    """Preserve per-world mesh ranges through MPM surface extraction."""
+    model, solver = _build_mpm_solver(device, world_count=2)
+    surface = solver.create_particle_surface(
+        voxel_size=0.08,
+        kernel_radius=0.24,
+        field_smooth_iterations=0,
+    )
+
+    mesh = solver.extract_particle_surface(model.state(), surface, compute_normals=False)
+    vertices, indices, normals = _assert_nonempty_mesh(test, mesh)
+
+    vertex_offsets = mesh.vertex_world_offsets.numpy()
+    index_offsets = mesh.index_world_offsets.numpy()
+    test.assertEqual(surface.world_count, 2)
+    test.assertEqual(int(vertex_offsets[-1]), vertices.shape[0])
+    test.assertEqual(int(index_offsets[-1]), indices.shape[0])
+    test.assertEqual(int(vertex_offsets[1]), int(vertex_offsets[2] - vertex_offsets[1]))
+    test.assertEqual(int(index_offsets[1]), int(index_offsets[2] - index_offsets[1]))
+    test.assertIsNone(normals)
 
 
 class TestParticleSurface(unittest.TestCase):
     def test_constructor_rejects_invalid_parameters(self):
+        """Reject invalid particle-surface configuration values."""
         invalid_cases = [
             ({"voxel_size": 0.0}, "voxel_size"),
             ({"voxel_size": np.nan}, "voxel_size"),
@@ -1371,86 +706,46 @@ class TestParticleSurface(unittest.TestCase):
             ),
         ]
         for kwargs, message in invalid_cases:
-            with self.subTest(kwargs=kwargs):
-                with self.assertRaisesRegex(ValueError, message):
-                    ParticleSurface(device="cpu", **kwargs)
-
-    def test_sphere_particle_helper_returns_requested_count(self):
-        positions, radii = _make_sphere_particles(n=37, device="cpu")
-        self.assertEqual(positions.shape[0], 37)
-        self.assertEqual(radii.shape[0], 37)
-
-    def test_context_reallocates_resources_on_device_change(self):
-        if not wp.is_cuda_available():
-            self.skipTest("requires CUDA for cross-device reuse validation")
-
-        positions_cpu, radii_cpu = _make_sphere_particles(n=512, device="cpu")
-        positions_cuda = wp.array(positions_cpu.numpy(), dtype=wp.vec3, device="cuda:0")
-        radii_cuda = wp.array(radii_cpu.numpy(), dtype=float, device="cuda:0")
-
-        ctx = ParticleSurface(
-            voxel_size=0.1,
-            kernel_radius=0.3,
-            anisotropic=True,
-            field_smooth_iterations=1,
-            device="cpu",
-        )
-        ctx.extract(positions_cpu, radii=radii_cpu, compute_normals=False)
-        self.assertEqual(ctx._field.device, wp.get_device("cpu"))
-        self.assertEqual(ctx._smoothed_positions.device, wp.get_device("cpu"))
-        self.assertEqual(ctx._G.device, wp.get_device("cpu"))
-
-        ctx.extract(positions_cuda, radii=radii_cuda, compute_normals=False)
-        self.assertEqual(ctx._field.device, wp.get_device("cuda:0"))
-        self.assertEqual(ctx._smoothed_positions.device, wp.get_device("cuda:0"))
-        self.assertEqual(ctx._G.device, wp.get_device("cuda:0"))
-        self.assertEqual(ctx._blur_weights.device, wp.get_device("cuda:0"))
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, message):
+                ParticleSurface(device="cpu", **kwargs)
 
 
 devices = get_test_devices(mode="basic")
 
 add_function_test(TestParticleSurface, "test_one_shot", test_one_shot, devices=devices)
 add_function_test(TestParticleSurface, "test_reusable_context", test_reusable_context, devices=devices)
+add_function_test(TestParticleSurface, "test_multi_world_mesh", test_multi_world_mesh, devices=devices)
 add_function_test(
     TestParticleSurface,
-    "test_large_candidate_voxel_slots",
-    test_large_candidate_voxel_slots,
+    "test_multi_world_fixed_capacity",
+    test_multi_world_fixed_capacity,
     devices=devices,
 )
-add_function_test(TestParticleSurface, "test_multi_world_mesh", test_multi_world_mesh, devices=devices)
 add_function_test(
     TestParticleSurface,
     "test_multi_world_large_topology_halo",
     test_multi_world_large_topology_halo,
     devices=devices,
 )
-add_function_test(TestParticleSurface, "test_multi_world_capacity", test_multi_world_capacity, devices=devices)
-add_function_test(TestParticleSurface, "test_field_only_extraction", test_field_only_extraction, devices=devices)
 add_function_test(
     TestParticleSurface,
-    "test_dynamic_grid_uses_realized_support",
-    test_dynamic_grid_uses_realized_support,
+    "test_update_field_and_resurface",
+    test_update_field_and_resurface,
+    devices=devices,
+)
+add_function_test(TestParticleSurface, "test_capacity_status_and_mesh", test_capacity_status_and_mesh, devices=devices)
+add_function_test(
+    TestParticleSurface,
+    "test_isotropic_support_is_not_clipped",
+    test_isotropic_support_is_not_clipped,
     devices=devices,
 )
 add_function_test(
     TestParticleSurface,
-    "test_isotropic_fallback_stencil_covers_support",
-    test_isotropic_fallback_stencil_covers_support,
+    "test_sparse_grid_handles_distant_particles",
+    test_sparse_grid_handles_distant_particles,
     devices=devices,
 )
-add_function_test(
-    TestParticleSurface,
-    "test_rebuildable_support_stencil_uses_anisotropy_bound",
-    test_rebuildable_support_stencil_uses_anisotropy_bound,
-    devices=devices,
-)
-add_function_test(
-    TestParticleSurface,
-    "test_rebuildable_topology_scratch_is_fixed",
-    test_rebuildable_topology_scratch_is_fixed,
-    devices=devices,
-)
-add_function_test(TestParticleSurface, "test_mesh_smoothing", test_mesh_smoothing, devices=devices)
 add_function_test(TestParticleSurface, "test_empty_particles", test_empty_particles, devices=devices)
 add_function_test(
     TestParticleSurface,
@@ -1461,75 +756,30 @@ add_function_test(
 add_function_test(TestParticleSurface, "test_radii_length_mismatch", test_radii_length_mismatch, devices=devices)
 add_function_test(TestParticleSurface, "test_radii_device_mismatch", test_radii_device_mismatch, devices=devices)
 add_function_test(TestParticleSurface, "test_array_layout_validation", test_array_layout_validation, devices=devices)
-add_function_test(TestParticleSurface, "test_anisotropic", test_anisotropic, devices=devices)
-add_function_test(TestParticleSurface, "test_anisotropy_strength", test_anisotropy_strength, devices=devices)
+add_function_test(TestParticleSurface, "test_cuda_graph_extraction", test_cuda_graph_extraction, devices=devices)
 add_function_test(
     TestParticleSurface,
-    "test_anisotropy_ratio_one_uses_isotropic_scale",
-    test_anisotropy_ratio_one_uses_isotropic_scale,
+    "test_particle_sdf_surface_method",
+    test_particle_sdf_surface_method,
     devices=devices,
 )
 add_function_test(
     TestParticleSurface,
-    "test_anisotropy_bin_coordinate_overflow_uses_isotropic_fallback",
-    test_anisotropy_bin_coordinate_overflow_uses_isotropic_fallback,
-    devices=devices,
-)
-add_function_test(TestParticleSurface, "test_sdf_field_mode", test_sdf_field_mode, devices=devices)
-add_function_test(
-    TestParticleSurface,
-    "test_update_field_matches_extract_field",
-    test_update_field_matches_extract_field,
-    devices=devices,
-)
-add_function_test(TestParticleSurface, "test_grid_capacity_extraction", test_grid_capacity_extraction, devices=devices)
-add_function_test(
-    TestParticleSurface,
-    "test_sparse_density_matches_reference",
-    test_sparse_density_matches_reference,
+    "test_isotropic_particle_sdf_samples",
+    test_isotropic_particle_sdf_samples,
     devices=devices,
 )
 add_function_test(
     TestParticleSurface,
-    "test_sparse_anisotropic_density_matches_reference",
-    test_sparse_anisotropic_density_matches_reference,
-    devices=devices,
-)
-add_function_test(
-    TestParticleSurface, "test_sparse_grid_avoids_empty_span", test_sparse_grid_avoids_empty_span, devices=devices
-)
-add_function_test(
-    TestParticleSurface,
-    "test_sparse_topology_classification_strides_over_capacity",
-    test_sparse_topology_classification_strides_over_capacity,
+    "test_particle_flags_filter_inactive",
+    test_particle_flags_filter_inactive,
     devices=devices,
 )
 add_function_test(
     TestParticleSurface,
-    "test_update_field_skips_inactive_particles",
-    test_update_field_skips_inactive_particles,
+    "test_solver_extract_particle_surface",
+    test_solver_extract_particle_surface,
     devices=devices,
-)
-add_function_test(TestParticleSurface, "test_update_field_cuda_graph", test_update_field_cuda_graph, devices=devices)
-add_function_test(
-    TestParticleSurface, "test_particle_sdf_surface_method", test_particle_sdf_surface_method, devices=devices
-)
-add_function_test(
-    TestParticleSurface, "test_isotropic_particle_sdf_values", test_isotropic_particle_sdf_values, devices=devices
-)
-add_function_test(TestParticleSurface, "test_anisotropy_scale", test_anisotropy_scale, devices=devices)
-add_function_test(
-    TestParticleSurface,
-    "test_anisotropic_kernel_scale_matches_isotropic_scale",
-    test_anisotropic_kernel_scale_matches_isotropic_scale,
-    devices=devices,
-)
-add_function_test(TestParticleSurface, "test_anisotropy_ratio", test_anisotropy_ratio, devices=devices)
-add_function_test(
-    TestParticleSurface, "test_particle_flags_filter_inactive", test_particle_flags_filter_inactive, devices=devices
-)
-add_function_test(
-    TestParticleSurface, "test_solver_extract_particle_surface", test_solver_extract_particle_surface, devices=devices
 )
 add_function_test(
     TestParticleSurface,

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -6,12 +6,10 @@ import sys
 import unittest
 from collections import namedtuple
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import numpy as np
-import warp as wp
 
-from newton._src.viewer.gl.opengl import MeshGL, MeshInstancerGL, RendererGL, RenderVertex
 from newton._src.viewer.viewer_gl import ViewerGL
 from newton._src.viewer.viewer_gui import ViewerGui
 from newton._src.viewer.viewer_null import ViewerNull
@@ -193,21 +191,22 @@ class TestViewerGLNumFramesValidation(unittest.TestCase):
             ViewerGL(num_frames=-1)
 
     def test_rejects_invalid_cuda_interop_mode(self):
+        """Reject CUDA interop values outside the public flag enum."""
         for value in (True, 1, 1.5, "dynamic"):
             with self.subTest(value=value), self.assertRaises(TypeError):
                 ViewerGL(enable_cuda_interop=value)  # type: ignore[arg-type]
 
     def test_cuda_interop_defaults_to_dynamic_meshes(self):
+        """Enable CUDA interop for dynamic meshes by default."""
         parameter = inspect.signature(ViewerGL).parameters["enable_cuda_interop"]
         self.assertEqual(parameter.default, ViewerGL.CudaInterop.DYNAMIC_MESH)
 
     def test_cuda_interop_flags_are_composable(self):
-        viewer = ViewerGL.__new__(ViewerGL)
-        viewer._enable_cuda_interop = ViewerGL.CudaInterop.POINTS | ViewerGL.CudaInterop.LINES
-
-        self.assertTrue(viewer._cuda_interop_enabled(ViewerGL.CudaInterop.POINTS))
-        self.assertTrue(viewer._cuda_interop_enabled(ViewerGL.CudaInterop.LINES))
-        self.assertFalse(viewer._cuda_interop_enabled(ViewerGL.CudaInterop.INSTANCES))
+        """Compose independent CUDA interop categories with bitwise flags."""
+        flags = ViewerGL.CudaInterop.POINTS | ViewerGL.CudaInterop.LINES
+        self.assertTrue(flags & ViewerGL.CudaInterop.POINTS)
+        self.assertTrue(flags & ViewerGL.CudaInterop.LINES)
+        self.assertFalse(flags & ViewerGL.CudaInterop.INSTANCES)
         self.assertEqual(
             ViewerGL.CudaInterop.ALL,
             ViewerGL.CudaInterop.DYNAMIC_MESH
@@ -218,259 +217,9 @@ class TestViewerGLNumFramesValidation(unittest.TestCase):
         )
 
     def test_rejects_unknown_cuda_interop_flags(self):
+        """Reject flag bits outside the supported CUDA interop categories."""
         with self.assertRaises(ValueError):
             ViewerGL(enable_cuda_interop=ViewerGL.CudaInterop(1 << 10))
-
-
-class TestViewerGLParticles(unittest.TestCase):
-    def test_hidden_particles_skip_instance_updates(self):
-        viewer = ViewerGL.__new__(ViewerGL)
-        viewer.show_particles = False
-        viewer._layer_force_hidden = Mock(return_value=False)
-        viewer._qualify = Mock(side_effect=lambda name: name)
-        viewer.log_points = Mock()
-
-        viewer._log_particles(SimpleNamespace())
-
-        viewer.log_points.assert_called_once_with("/model/particles", points=None, hidden=True)
-
-
-class TestViewerGLCleanup(unittest.TestCase):
-    def test_close_destroys_geometry_before_renderer(self):
-        events = []
-        viewer = ViewerGL.__new__(ViewerGL)
-        viewer._clear_array_textures = Mock(side_effect=lambda: events.append("textures"))
-        viewer._invalidate_pbo = Mock(side_effect=lambda: events.append("pbo"))
-        viewer._image_logger = SimpleNamespace(clear=lambda: events.append("images"))
-        viewer._destroy_render_geometry = Mock(side_effect=lambda: events.append("geometry"))
-        viewer.renderer = SimpleNamespace(close=lambda: events.append("renderer"))
-
-        viewer.close()
-
-        self.assertEqual(events, ["textures", "pbo", "images", "geometry", "renderer"])
-
-    def test_destroy_render_geometry_releases_all_owned_resources(self):
-        viewer = ViewerGL.__new__(ViewerGL)
-        instancer = MeshInstancerGL.__new__(MeshInstancerGL)
-        instancer.destroy = Mock()
-        mesh = Mock()
-        line = Mock()
-        arrow = Mock()
-        wireframe = Mock()
-        wireframe_owner = Mock()
-        point_mesh = Mock()
-        gaussian_mesh = Mock()
-        viewer.objects = {"instancer": instancer, "mesh": mesh}
-        viewer.lines = {"line": line}
-        viewer.arrows = {"arrow": arrow}
-        viewer.wireframe_shapes = {"wireframe": wireframe}
-        viewer._wireframe_vbo_owners = {1: wireframe_owner}
-        viewer._point_mesh = point_mesh
-        viewer._gaussian_mesh = gaussian_mesh
-
-        viewer._destroy_render_geometry()
-
-        for resource in (instancer, mesh, line, arrow, wireframe, wireframe_owner, point_mesh, gaussian_mesh):
-            resource.destroy.assert_called_once_with()
-        self.assertFalse(viewer.objects)
-        self.assertFalse(viewer.lines)
-        self.assertFalse(viewer.arrows)
-        self.assertFalse(viewer.wireframe_shapes)
-        self.assertFalse(viewer._wireframe_vbo_owners)
-        self.assertIsNone(viewer._point_mesh)
-        self.assertIsNone(viewer._gaussian_mesh)
-
-    def test_instancer_releases_registration_before_gl_buffers(self):
-        events = []
-
-        class Registration:
-            def __del__(self):
-                events.append("registration")
-
-        instancer = MeshInstancerGL.__new__(MeshInstancerGL)
-        instancer._instance_transform_cuda_buffer = Registration()
-        instancer.vao = 1
-        instancer.instance_transform_buffer = 2
-        instancer.instance_color_buffer = 3
-        instancer.instance_material_buffer = 4
-        gl = Mock()
-        gl.glDeleteVertexArrays.side_effect = lambda *_args: events.append("vao")
-        gl.glDeleteBuffers.side_effect = lambda *_args: events.append("buffer")
-
-        with patch.object(RendererGL, "gl", gl):
-            instancer.destroy()
-            instancer.destroy()
-
-        self.assertEqual(events, ["registration", "vao", "buffer", "buffer", "buffer"])
-        self.assertIsNone(instancer.vao)
-        self.assertIsNone(instancer.instance_transform_buffer)
-        self.assertIsNone(instancer.instance_color_buffer)
-        self.assertIsNone(instancer.instance_material_buffer)
-
-
-class TestViewerGLDynamicMeshes(unittest.TestCase):
-    def test_dynamic_mesh_uploads_indices_through_cuda_interop(self):
-        mesh = MeshGL.__new__(MeshGL)
-        mesh.device = wp.get_device("cpu")
-        mesh.max_points = 3
-        mesh.max_indices = 3
-        mesh.vertex_byte_size = 32
-        mesh.index_byte_size = 4
-        mesh.dynamic = True
-        mesh.indices = None
-        mesh.normals = None
-        mesh.vertices = wp.zeros(3, dtype=RenderVertex)
-        mesh.index_cuda_buffer = Mock()
-        mesh.index_cuda_buffer.map.return_value = wp.empty(3, dtype=wp.uint32)
-        mesh.vertex_cuda_buffer = Mock()
-        mesh.vertex_cuda_buffer.map.return_value = wp.empty(3, dtype=RenderVertex)
-        mesh.update_texture = Mock()
-
-        points = wp.zeros(3, dtype=wp.vec3)
-        indices = wp.array([0, 1, 2], dtype=wp.int32)
-        normals = wp.zeros(3, dtype=wp.vec3)
-        gl = Mock(GL_DYNAMIC_DRAW=1, GL_STATIC_DRAW=2, GL_ELEMENT_ARRAY_BUFFER=3, GL_ARRAY_BUFFER=4)
-
-        with patch.object(RendererGL, "gl", gl), patch("newton._src.viewer.gl.opengl.wp.launch"):
-            mesh.update(points, indices, normals, None)
-            mesh.index_cuda_buffer.map.assert_called_once_with(dtype=wp.uint32, shape=(3,))
-            mesh.index_cuda_buffer.unmap.assert_called_once_with()
-            mesh.vertex_cuda_buffer.map.assert_called_once_with(dtype=RenderVertex, shape=(3,))
-            mesh.vertex_cuda_buffer.unmap.assert_called_once_with()
-            gl.glBufferSubData.assert_not_called()
-
-    def test_dynamic_normal_scratch_supports_shrink_then_growth(self):
-        mesh = MeshGL.__new__(MeshGL)
-        mesh.device = wp.get_device("cpu")
-        mesh.max_points = 8
-        mesh.num_points = 3
-        mesh._points = wp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=wp.vec3)
-        mesh.indices = wp.array([0, 1, 2], dtype=wp.uint32)
-        mesh.normals = None
-
-        normal_lengths = []
-
-        def record_normals(_points, _indices, normals, **_kwargs):
-            normal_lengths.append(len(normals))
-            return normals
-
-        with patch("newton._src.viewer.gl.opengl.compute_vertex_normals", side_effect=record_normals):
-            mesh.recompute_normals()
-            scratch = mesh.normals
-            self.assertEqual(len(scratch), 8)
-
-            mesh.num_points = 7
-            mesh._points = wp.zeros(7, dtype=wp.vec3)
-            mesh.recompute_normals()
-
-        self.assertIs(mesh.normals, scratch)
-        self.assertEqual(len(mesh.normals), 8)
-        self.assertEqual(normal_lengths, [3, 7])
-
-    def test_dynamic_mesh_reuses_capacity_and_rebinds_instancers_on_growth(self):
-        class FakeMesh:
-            def __init__(
-                self,
-                num_points,
-                num_indices,
-                device,
-                hidden=False,
-                backface_culling=True,
-                dynamic=False,
-                *,
-                enable_cuda_interop=False,
-            ):
-                self.max_points = num_points
-                self.max_indices = num_indices
-                self.num_points = num_points
-                self.num_indices = num_indices
-                self.device = device
-                self.hidden = hidden
-                self.backface_culling = backface_culling
-                self.dynamic = dynamic
-                self.enable_cuda_interop = enable_cuda_interop
-                self.color = (0.7, 0.5, 0.3)
-                self.material = (0.5, 0.0, 0.0, 0.0)
-                self.destroyed = False
-
-            def update(self, points, indices, normals, uvs, texture):
-                self.num_points = len(points)
-                self.num_indices = len(indices)
-
-            def destroy(self):
-                self.destroyed = True
-
-        class FakeInstancer:
-            def __init__(self, mesh):
-                self.mesh = mesh
-                self.rebinds = 0
-
-            def set_mesh(self, mesh):
-                self.mesh = mesh
-                self.rebinds += 1
-
-        viewer = ViewerGL.__new__(ViewerGL)
-        viewer.objects = {}
-        viewer.device = wp.get_device("cpu")
-        viewer._enable_cuda_interop = ViewerGL.CudaInterop.DYNAMIC_MESH
-        viewer._qualify = lambda name: name
-        points = wp.zeros(3, dtype=wp.vec3)
-        indices = wp.zeros(3, dtype=wp.int32)
-
-        with (
-            patch("newton._src.viewer.viewer_gl.MeshGL", FakeMesh),
-            patch("newton._src.viewer.viewer_gl.MeshInstancerGL", FakeInstancer),
-        ):
-            viewer.log_mesh("mesh", points, indices, dynamic=True)
-            original = viewer.objects["mesh"]
-            self.assertTrue(original.enable_cuda_interop)
-            viewer.log_mesh("static", points, indices)
-            self.assertFalse(viewer.objects["static"].enable_cuda_interop)
-            viewer._enable_cuda_interop = ViewerGL.CudaInterop.STATIC_MESH
-            viewer.log_mesh("all", points, indices)
-            self.assertTrue(viewer.objects["all"].enable_cuda_interop)
-            instancer = FakeInstancer(original)
-            viewer.objects["instances"] = instancer
-
-            viewer.log_mesh("mesh", points[:2], indices, dynamic=True)
-            self.assertIs(viewer.objects["mesh"], original)
-            self.assertEqual(instancer.rebinds, 0)
-
-            viewer.log_mesh("mesh", wp.zeros(7, dtype=wp.vec3), indices, dynamic=True)
-
-        self.assertTrue(original.destroyed)
-        self.assertIs(instancer.mesh, viewer.objects["mesh"])
-        self.assertEqual(instancer.rebinds, 1)
-        self.assertGreaterEqual(viewer.objects["mesh"].max_points, 7)
-
-    def test_points_interop_is_selected_independently(self):
-        class FakeInstancer:
-            def __init__(self, num_instances, mesh, *, enable_cuda_interop=False):
-                self.num_instances = num_instances
-                self.mesh = mesh
-                self.enable_cuda_interop = enable_cuda_interop
-                self.hidden = False
-
-            def update_from_points(self, points, radii, colors):
-                pass
-
-        viewer = ViewerGL.__new__(ViewerGL)
-        viewer.objects = {}
-        viewer.device = wp.get_device("cpu")
-        viewer._point_mesh = object()
-        viewer._qualify = lambda name: name
-        points = wp.zeros(3, dtype=wp.vec3)
-        radii = wp.ones(3, dtype=wp.float32)
-        colors = wp.ones(3, dtype=wp.vec3)
-
-        with patch("newton._src.viewer.viewer_gl.MeshInstancerGL", FakeInstancer):
-            viewer._enable_cuda_interop = ViewerGL.CudaInterop.POINTS
-            viewer.log_points("interop", points, radii, colors)
-            viewer._enable_cuda_interop = ViewerGL.CudaInterop.INSTANCES
-            viewer.log_points("host", points, radii, colors)
-
-        self.assertTrue(viewer.objects["interop"].enable_cuda_interop)
-        self.assertFalse(viewer.objects["host"].enable_cuda_interop)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_viewer_layers.py
+++ b/newton/tests/test_viewer_layers.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import inspect
 import unittest
 from unittest.mock import Mock, patch
 
@@ -85,56 +84,6 @@ class _MinimalRTXViewer(ViewerRTX):
 
 
 class TestViewerLayers(unittest.TestCase):
-    def test_rtx_log_mesh_accepts_dynamic_topology_flag(self):
-        self.assertIn("dynamic", inspect.signature(ViewerRTX.log_mesh).parameters)
-
-    def test_rtx_log_mesh_queues_dynamic_topology(self):
-        viewer = _MinimalRTXViewer()
-        viewer._phase = viewer._PHASE_RENDER
-        viewer._mesh_prim_paths = {"surface": "/surface"}
-        viewer._pending_mesh_points = {}
-        viewer._pending_mesh_normals = {}
-        viewer._pending_mesh_topology = {}
-        viewer._pending_mesh_visibility = {}
-
-        points = wp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=wp.vec3)
-        indices = wp.array([0, 1, 2], dtype=wp.int32)
-        viewer.log_mesh("surface", points, indices, dynamic=True)
-
-        face_counts, face_indices = viewer._pending_mesh_topology["surface"]
-        self.assertEqual(face_counts.tolist(), [3])
-        self.assertEqual(face_indices.tolist(), [0, 1, 2])
-        self.assertIsNone(viewer._pending_mesh_normals["surface"])
-        self.assertTrue(viewer._pending_mesh_visibility["surface"])
-
-    def test_rtx_runtime_mesh_updates_visibility(self):
-        viewer = _MinimalRTXViewer()
-        viewer._phase = viewer._PHASE_RENDER
-        viewer._mesh_prim_paths = {"surface": "/surface"}
-        viewer._pending_mesh_points = {}
-        viewer._pending_mesh_normals = {}
-        viewer._pending_mesh_topology = {}
-        viewer._pending_mesh_visibility = {}
-        viewer._rtx = Mock()
-
-        points = wp.empty(0, dtype=wp.vec3)
-        indices = wp.empty(0, dtype=wp.int32)
-        viewer.log_mesh("surface", points, indices, hidden=True, dynamic=True)
-        with patch.object(viewer, "_make_point3f_dltensor", return_value=Mock()):
-            viewer._update_ovrtx_mesh_points()
-
-        viewer._rtx.write_attribute.assert_called_once_with(
-            prim_paths=["/surface"],
-            attribute_name="visibility",
-            tensor=["invisible"],
-        )
-        normals_write = [
-            call
-            for call in viewer._rtx.write_array_attribute.call_args_list
-            if call.kwargs.get("attribute_name") == "normals"
-        ]
-        self.assertEqual(len(normals_write), 1)
-
     def test_default_layer_uses_unprefixed_names(self):
         """Without activate(), object names remain unprefixed (legacy behavior)."""
         viewer = _RecordingViewer()

--- a/newton/tests/test_viewer_rerun_hidden.py
+++ b/newton/tests/test_viewer_rerun_hidden.py
@@ -6,6 +6,7 @@ import warnings
 from unittest.mock import Mock, patch
 
 import numpy as np
+import warp as wp
 
 # ruff: noqa: PLC0415
 
@@ -83,13 +84,16 @@ class TestViewerRerunHidden(unittest.TestCase):
         self.mock_rr.log.assert_not_called()
 
     def test_log_mesh_hidden_clears_previously_visible_entity(self):
+        """Clear a mesh entity when a visible mesh becomes hidden."""
         viewer = self._create_viewer()
-        viewer._meshes["mesh"] = {"visible": True}
 
-        points = self._make_mock_wp_array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
-        indices = self._make_mock_wp_array([0, 1, 2])
+        points = wp.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=wp.vec3)
+        indices = wp.array([0, 1, 2], dtype=wp.int32)
 
         with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
+            viewer.log_mesh("mesh", points, indices)
+            self.mock_rr.log.reset_mock()
+            self.mock_rr.Clear.reset_mock()
             viewer.log_mesh("mesh", points, indices, hidden=True)
 
         self.mock_rr.Clear.assert_called_once_with(recursive=False)

--- a/newton/tests/test_viewer_usd.py
+++ b/newton/tests/test_viewer_usd.py
@@ -330,6 +330,7 @@ class TestViewerUSD(unittest.TestCase):
         self.assertEqual(visibility, "invisible")
 
     def test_log_mesh_dynamic_time_samples_topology(self):
+        """Time-sample changing mesh topology when dynamic is enabled."""
         viewer = self._make_viewer()
 
         points0 = wp.array(
@@ -358,6 +359,7 @@ class TestViewerUSD(unittest.TestCase):
         self.assertEqual(list(face_indices.Get(1)), [0, 1, 2, 0, 2, 3])
 
     def test_log_mesh_dynamic_clears_stale_normals(self):
+        """Clear normals when a later dynamic mesh update omits them."""
         viewer = self._make_viewer()
         points = wp.array(
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],


### PR DESCRIPTION
## Description

Simplify only the tests introduced by the particle-surface PR.

- Replace assertions on private workspaces, buffers, allocation counts, pointers, launch sizes, and intermediate anisotropy state with checks of public mesh, sparse-field, status, solver, and viewer behavior.
- Retain targeted diagnostics for sparse spans, multi-world packing and halo isolation, exact/fixed-capacity parity, overflow reporting, CUDA graph replay, non-finite inputs, particle filtering, collider extrapolation, and dynamic viewer topology.
- Reduce unit-test fixed capacities to 32,768 cells, or 49,152 cells for multi-world coverage.
- Match the lower-resolution dam-break CI setup with a 300,000-cell preallocation instead of 4,000,000 cells.

No production code or pre-existing tests are changed.

GPU sizing notes: 100,000 through 250,000 cells overflowed in the selected lower-resolution dam-break test, while 300,000 passed. That test peaked at 519 MiB total framebuffer usage on an RTX 3080 Ti, including the idle device allocation.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] This is test-only and does not require a changelog fragment

## Test plan

```bash
uv run python -m unittest newton.tests.test_particle_surface
CUDA_VISIBLE_DEVICES=1 uv run python -m unittest newton.tests.test_particle_surface
uv run python -m unittest newton.tests.test_viewer_controls newton.tests.test_viewer_layers newton.tests.test_viewer_rerun_hidden newton.tests.test_viewer_usd
CUDA_VISIBLE_DEVICES=1 uv run python -m unittest newton.tests.test_examples.TestMPMExamples -k water_dam_break -v
uvx pre-commit run -a
```

Results:

- Particle-surface module: 21 CPU tests passed with 2 CUDA-only skips.
- Particle-surface module with CUDA: 41 tests passed with 1 expected skip.
- Viewer modules: 67 tests passed.
- Lower-resolution dam-break example: passed with a 300,000-cell capacity.
- Pre-commit: all hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the maximum grid size used by the water dam-break surface test to improve test reliability and resource usage.
  * Expanded validation for particle-surface extraction, including empty, invalid, distant, inactive, and nonfinite particle data.
  * Improved coverage for viewer particle visibility, cleanup, dynamic meshes, CUDA interoperability, and hidden mesh updates.
* **Tests**
  * Added coverage for particle-surface capacity, topology, resurfacing, SDF behavior, and solver integration.
  * Updated viewer and USD tests with clearer scenarios and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->