### PR TITLE
Fix sparse topology dilation loop in particle surfacing

### DIFF
--- a/newton/_src/geometry/particle_surface_sparse_kernels.py
+++ b/newton/_src/geometry/particle_surface_sparse_kernels.py
@@ -755,12 +755,12 @@ def dilate_topology_axis_hash(
                 neighbor = coordinate
                 neighbor[axis] += offset
                 source_address = _candidate_voxel_bit_address_hash(keys, neighbor)
-                source_word = source_address[0]
+                source_address_word = source_address[0]
                 source_bit = source_address[1]
                 if (
-                    source_word >= 0
-                    and source_word < source.shape[0]
-                    and (source[source_word] & wp.uint32(1 << source_bit)) != wp.uint32(0)
+                    source_address_word >= 0
+                    and source_address_word < source.shape[0]
+                    and (source[source_address_word] & wp.uint32(1 << source_bit)) != wp.uint32(0)
                 ):
                     occupied = wp.int32(1)
             if occupied != 0:

--- a/newton/tests/test_particle_surface.py
+++ b/newton/tests/test_particle_surface.py
@@ -377,6 +377,27 @@ def test_sparse_grid_handles_distant_particles(test, device):
     test.assertTrue(np.all(_sample_sparse_field(surface, [[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]]) > 0.0))
 
 
+def test_fixed_capacity_single_thread_update(test, device):
+    """Complete a fixed-capacity field update with one grid-stride thread."""
+    positions = wp.zeros(1, dtype=wp.vec3, device=device)
+    radii = wp.array([0.1], dtype=wp.float32, device=device)
+    surface = ParticleSurface(
+        voxel_size=0.25,
+        kernel_radius=0.5,
+        smooth_lambda=0.0,
+        padding=0,
+        max_grid_cells=512,
+        device=device,
+    )
+    surface._workspace.launch_threads = 1
+
+    sparse_field = surface.update_field(positions, radii)
+
+    test.assertIsInstance(sparse_field, ParticleSurface.SparseField)
+    np.testing.assert_array_equal(sparse_field.per_world_status.numpy(), [0])
+    test.assertGreater(float(_sample_sparse_field(surface, [[0.0, 0.0, 0.0]])[0]), 0.0)
+
+
 def test_empty_particles(test, device):
     """Return an empty result for an empty particle set."""
     positions = wp.empty(0, dtype=wp.vec3, device=device)
@@ -744,6 +765,12 @@ add_function_test(
     TestParticleSurface,
     "test_sparse_grid_handles_distant_particles",
     test_sparse_grid_handles_distant_particles,
+    devices=devices,
+)
+add_function_test(
+    TestParticleSurface,
+    "test_fixed_capacity_single_thread_update",
+    test_fixed_capacity_single_thread_update,
     devices=devices,
 )
 add_function_test(TestParticleSurface, "test_empty_particles", test_empty_particles, devices=devices)


### PR DESCRIPTION
## Description

Keep the grid-stride traversal cursor separate from sparse hash lookup
addresses during topology dilation. Reusing the cursor could jump backward
or reset after a missing lookup, producing incomplete fields or hanging the
update.

This pull request is based on the merged #4076 and contains exactly one
commit beyond current `main`. The affected feature has not been released, so
this fix does not need a changelog fragment.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] No changelog fragment is needed because the affected feature is unreleased

## Test plan

- Regression without the fix:
  `python -m unittest newton.tests.test_particle_surface.TestParticleSurface.test_fixed_capacity_single_thread_update_cpu -v` fails.
- Regression with the fix passes on CPU and CUDA.
- The individual particle-surface test module passes on CPU: 20 passed, 2 skipped.
- `uvx pre-commit run --files newton/_src/geometry/particle_surface_sparse_kernels.py newton/tests/test_particle_surface.py`

## Bug fix

**Steps to reproduce:**

1. Create a fixed-capacity `ParticleSurface`.
2. Run its sparse topology dilation with fewer launch threads than candidate
   words, including a single-thread launch.
3. Observe that hash lookups overwrite the grid-stride cursor, which may revisit
   work indefinitely or leave the field incomplete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of sparse-field topology updates in limited-thread workspace configurations.
  * Fixed an internal naming conflict that could affect topology processing.

* **Tests**
  * Added regression coverage confirming successful field creation, valid world status, and sampled output under single-thread execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->