### PR TITLE
Handle empty mesh decomposition results

### DIFF
--- a/changelog/3507.fixed.md
+++ b/changelog/3507.fixed.md
@@ -1,0 +1,1 @@
+Treat empty CoACD and V-HACD decompositions as failures so mesh approximation raises or uses the documented fallbacks.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -7600,6 +7600,8 @@ class ModelBuilder:
         remeshed_shapes = set()
 
         if method == "coacd" or method == "vhacd":
+            empty_decomposition_shape = None
+            decomposition_failed = False
             try:
                 if method == "coacd":
                     # convex decomposition using CoACD
@@ -7653,6 +7655,15 @@ class ModelBuilder:
                                 decomposition.extend((d["vertices"], d["faces"]) for d in component_decomposition)
                         decompositions[hash_m] = decomposition
                     if len(decomposition) == 0:
+                        if raise_on_failure:
+                            empty_decomposition_shape = shape
+                            break
+                        warnings.warn(
+                            f"Remeshing with method '{method}' failed for shape {shape}: the backend returned no "
+                            "convex parts. Falling back to convex_hull.",
+                            stacklevel=2,
+                        )
+                        decomposition_failed = True
                         continue
                     # note we need to copy the mesh to avoid modifying the original mesh
                     replacement_mesh = self.shape_source[shape].copy(
@@ -7721,6 +7732,15 @@ class ModelBuilder:
                     method = "convex_hull"
                     # kwargs were addressed to the failed decomposition method
                     remeshing_kwargs = {}
+            if empty_decomposition_shape is not None:
+                raise RuntimeError(
+                    f"Remeshing with method '{method}' failed for shape {empty_decomposition_shape}: "
+                    "the backend returned no convex parts."
+                )
+            if decomposition_failed:
+                method = "convex_hull"
+                # kwargs were addressed to the failed decomposition method
+                remeshing_kwargs = {}
 
         if method in RemeshingMethod.__args__:
             # remeshing of the individual meshes

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -216,6 +216,23 @@ class TestModelBuilderBvhConstructor(unittest.TestCase):
 
 
 class TestModelMesh(unittest.TestCase):
+    class _FakeDecompositionMesh:
+        """Store mesh data passed to a fake decomposition backend."""
+
+        def __init__(self, vertices, faces):
+            self.vertices = vertices
+            self.faces = faces
+
+    @classmethod
+    def _make_fake_decomposition_backend(cls, method, decompose):
+        """Create a stub module and import name for a decomposition backend."""
+        if method == "coacd":
+            return "coacd", SimpleNamespace(Mesh=cls._FakeDecompositionMesh, run_coacd=decompose)
+        return "trimesh", SimpleNamespace(
+            Trimesh=cls._FakeDecompositionMesh,
+            decomposition=SimpleNamespace(convex_decomposition=decompose),
+        )
+
     def test_mesh_rejects_invalid_triangle_indices(self):
         """Reject malformed and out-of-range mesh triangle indices."""
         vertices = np.array(
@@ -1010,6 +1027,115 @@ class TestModelMesh(unittest.TestCase):
             builder.approximate_meshes(method="coacd", shape_indices=[shape], threshold=0.5)
         # the documented threshold migration must keep working without coacd installed
         self.assertEqual(builder.shape_type[shape], newton.GeoType.CONVEX_MESH)
+
+    def test_mesh_approximation_empty_convex_decomposition_raises(self):
+        """Raise when a convex decomposition backend returns no parts."""
+
+        mesh = newton.Mesh.create_box(
+            1.0,
+            duplicate_vertices=False,
+            compute_normals=False,
+            compute_uvs=False,
+            compute_inertia=False,
+        )
+        for method in ("coacd", "vhacd"):
+            with self.subTest(method=method):
+                builder = ModelBuilder()
+                shape = builder.add_shape_mesh(body=-1, mesh=mesh)
+                module_name, fake_backend = self._make_fake_decomposition_backend(method, lambda _mesh, **_kwargs: [])
+                with (
+                    patch_sys_module(module_name, fake_backend),
+                    self.assertRaisesRegex(RuntimeError, rf"Remeshing with method '{method}' failed"),
+                ):
+                    builder.approximate_meshes(method=method, shape_indices=[shape], raise_on_failure=True)
+
+                self.assertEqual(builder.shape_type[shape], newton.GeoType.MESH)
+
+    def test_mesh_approximation_empty_convex_decomposition_falls_back_per_shape(self):
+        """Fall back only empty-result shapes while preserving successful decompositions."""
+
+        empty_mesh = newton.Mesh.create_box(
+            1.0,
+            duplicate_vertices=False,
+            compute_normals=False,
+            compute_uvs=False,
+            compute_inertia=False,
+        )
+        successful_mesh = newton.Mesh.create_box(
+            2.0,
+            duplicate_vertices=False,
+            compute_normals=False,
+            compute_uvs=False,
+            compute_inertia=False,
+        )
+        for method in ("coacd", "vhacd"):
+            with self.subTest(method=method):
+                builder = ModelBuilder()
+                empty_shape = builder.add_shape_mesh(body=-1, mesh=empty_mesh)
+                successful_shape = builder.add_shape_mesh(body=-1, mesh=successful_mesh)
+                fallback_meshes = []
+
+                def fake_decompose(backend_mesh, _method=method, **_kwargs):
+                    vertices = np.asarray(backend_mesh.vertices)
+                    if np.isclose(np.ptp(vertices[:, 0]), 2.0):
+                        return []
+                    faces = np.asarray(backend_mesh.faces)
+                    if _method == "coacd":
+                        return [(vertices.copy(), faces.copy())]
+                    return [{"vertices": vertices.copy(), "faces": faces.copy()}]
+
+                def fake_convex_hull(mesh, _fallback_meshes=fallback_meshes, **_kwargs):
+                    _fallback_meshes.append(mesh)
+                    return mesh.copy()
+
+                module_name, fake_backend = self._make_fake_decomposition_backend(method, fake_decompose)
+                with (
+                    patch_sys_module(module_name, fake_backend),
+                    mock.patch("newton._src.sim.builder.remesh_mesh", side_effect=fake_convex_hull),
+                    self.assertWarnsRegex(
+                        UserWarning,
+                        rf"Remeshing with method '{method}' failed for shape {empty_shape}.*Falling back to convex_hull",
+                    ),
+                ):
+                    remeshed = builder.approximate_meshes(
+                        method=method,
+                        shape_indices=[empty_shape, successful_shape],
+                    )
+
+                self.assertEqual(remeshed, {empty_shape, successful_shape})
+                self.assertEqual(builder.shape_type[empty_shape], newton.GeoType.CONVEX_MESH)
+                self.assertEqual(builder.shape_type[successful_shape], newton.GeoType.CONVEX_MESH)
+                self.assertEqual(fallback_meshes, [empty_mesh])
+
+    def test_mesh_approximation_empty_convex_decomposition_reaches_bounding_box_fallback(self):
+        """Reach the bounding-box fallback when an empty decomposition is followed by a hull failure."""
+
+        mesh = newton.Mesh.create_box(
+            1.0,
+            duplicate_vertices=False,
+            compute_normals=False,
+            compute_uvs=False,
+            compute_inertia=False,
+        )
+        for method in ("coacd", "vhacd"):
+            with self.subTest(method=method):
+                builder = ModelBuilder()
+                shape = builder.add_shape_mesh(body=-1, mesh=mesh)
+                module_name, fake_backend = self._make_fake_decomposition_backend(method, lambda _mesh, **_kwargs: [])
+                with (
+                    patch_sys_module(module_name, fake_backend),
+                    mock.patch("newton._src.sim.builder.remesh_mesh", side_effect=RuntimeError("qhull failed")),
+                    warnings.catch_warnings(record=True) as caught,
+                ):
+                    warnings.simplefilter("always")
+                    remeshed = builder.approximate_meshes(method=method, shape_indices=[shape])
+
+                self.assertEqual(len(caught), 2)
+                self.assertRegex(str(caught[0].message), "the backend returned no convex parts")
+                self.assertRegex(str(caught[1].message), "Falling back to bounding_box")
+                self.assertEqual(remeshed, {shape})
+                self.assertEqual(builder.shape_type[shape], newton.GeoType.BOX)
+                self.assertIsNone(builder.shape_source[shape])
 
     def test_mesh_approximation_ignores_non_mesh_shapes(self):
         builder = ModelBuilder()


### PR DESCRIPTION
## Description

Treat empty CoACD and V-HACD decomposition results as backend failures instead of silently leaving the source mesh unchanged. Strict callers now receive a shape-specific `RuntimeError`; non-strict callers warn and route only affected shapes through the existing convex-hull and bounding-box fallbacks.

Successful decompositions in a mixed batch are preserved, and every shape handled by decomposition or fallback is included in the returned set.

Closes #3507.

### Behavior change

| Case | Previously | With this fix |
|---|---|---|
| Backend returns one or more parts | Mesh becomes a convex decomposition | Unchanged |
| Backend throws | Raise, or warn and fall back | Unchanged |
| Empty result, `raise_on_failure=True` | Silently leaves `GeoType.MESH`; returns no shape | Raises a shape-specific `RuntimeError` |
| Empty result, default mode | Silently leaves the original mesh unchanged | Warns and tries `convex_hull` |
| Hull also fails | Never reached | Warns again and uses `bounding_box` |
| Mixed batch | Successful shapes are decomposed; empty-result shapes silently remain meshes | Successful shapes remain decomposed; only empty-result shapes use fallback |

This is an intentional correction to the existing public failure contract. Workflows that relied on the silent no-op may now observe a warning, an exception in strict mode, a changed collision approximation, and inclusion of the handled shape in the returned set. No method signatures, defaults, dependencies, or successful-decomposition paths change.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev -m newton.tests -k mesh_approximation
uv run --extra dev -m newton.tests -k test_model
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-27
git diff --check
```

- Mesh-approximation group: 15 passed.
- Broader model-filtered run: 176 passed, 109 skipped.
- Pre-commit and Towncrier draft: passed.
- `$code-review-newton`: Standards clean, Spec clean, Fit: `Fits`.

## Bug fix

**Steps to reproduce:**

1. Add a non-empty mesh shape to a `ModelBuilder`.
2. Stub CoACD or V-HACD to return no convex parts.
3. Call `approximate_meshes()` for that shape.
4. Observe that the original implementation returns an empty set, leaves the shape as `GeoType.MESH`, emits no warning, and ignores `raise_on_failure=True`.

**Minimal reproduction:**

```python
import sys
from types import SimpleNamespace
from unittest.mock import patch

import newton

mesh = newton.Mesh.create_box(1.0)
fake_coacd = SimpleNamespace(
    Mesh=lambda vertices, faces: (vertices, faces),
    run_coacd=lambda _mesh, **_kwargs: [],
)

builder = newton.ModelBuilder()
shape = builder.add_shape_mesh(body=-1, mesh=mesh)

with patch.dict(sys.modules, {"coacd": fake_coacd}):
    result = builder.approximate_meshes(method="coacd", shape_indices=[shape])

assert result == set()
assert builder.shape_type[shape] == newton.GeoType.MESH
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mesh approximation now correctly detects when CoACD or V-HACD produces no convex parts.
  * Configured failure behavior is now honored: operations can raise an error or continue with a warning.
  * Failed decompositions automatically fall back to convex hull generation, with bounding-box fallback available when needed.
  * Successful decompositions within the same request are preserved while only failed shapes use fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->