### PR TITLE
Fix actuator fixture warnings

### DIFF
--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -437,28 +437,6 @@ def _ignore_torchscript_deprecation(test_case: unittest.TestCase) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Fixture validation
-# ---------------------------------------------------------------------------
-
-
-class TestActuatorFixtures(unittest.TestCase):
-    """Validate the shared actuator model fixtures."""
-
-    def test_model_builders_do_not_warn(self):
-        """Keep actuator fixture finalization warning-free."""
-        device = wp.get_device()
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            _build_pendulum(device)
-            _build_pendulum(device, worlds=2)
-            _build_two_link(device)
-            _build_two_link(device, dummy_body=True, worlds=2)
-
-        self.assertFalse(caught, [str(warning.message) for warning in caught])
-
-
-# ---------------------------------------------------------------------------
 # 1. Controllers
 # ---------------------------------------------------------------------------
 

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -201,6 +201,11 @@ def _build_lstm_onnx(
 # ---------------------------------------------------------------------------
 
 
+# Regularize the fixtures' idealized point masses without changing their
+# effective dynamics from the inertia that validation previously synthesized.
+_POINT_MASS_INERTIA = wp.mat33(1.0e-6, 0.0, 0.0, 0.0, 1.0e-6, 0.0, 0.0, 0.0, 1.0e-6)
+
+
 def _write_dof_values(
     model: newton.Model,
     array: wp.array[float],
@@ -222,8 +227,7 @@ def _build_pendulum(device: wp.Device, worlds: int = 1) -> newton.Model:
         worlds: Number of identical worlds to replicate the pendulum into.
     """
     template = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
-    body = template.add_link(mass=1.0)
-    template.body_com[body] = wp.vec3(0.5, 0.0, 0.0)
+    body = template.add_link(com=wp.vec3(0.5, 0.0, 0.0), inertia=_POINT_MASS_INERTIA, mass=1.0)
     joint = template.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z)
     template.add_articulation([joint])
     if worlds == 1:
@@ -244,11 +248,10 @@ def _two_link_builder(armature: float = 0.0, dummy_body: bool = False) -> newton
     """
     builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
     if dummy_body:
-        builder.add_joint_revolute(parent=-1, child=builder.add_link(mass=1.0), axis=newton.Axis.Z)
-    base = builder.add_link(mass=2.0)
-    tip = builder.add_link(mass=1.0)
-    builder.body_com[base] = wp.vec3(0.3, 0.0, 0.0)
-    builder.body_com[tip] = wp.vec3(0.25, 0.0, 0.0)
+        dummy = builder.add_link(inertia=_POINT_MASS_INERTIA, mass=1.0)
+        builder.add_joint_revolute(parent=-1, child=dummy, axis=newton.Axis.Z)
+    base = builder.add_link(com=wp.vec3(0.3, 0.0, 0.0), inertia=_POINT_MASS_INERTIA, mass=2.0)
+    tip = builder.add_link(com=wp.vec3(0.25, 0.0, 0.0), inertia=_POINT_MASS_INERTIA, mass=1.0)
     j0 = builder.add_joint_revolute(parent=-1, child=base, axis=newton.Axis.Z, armature=armature)
     j1 = builder.add_joint_revolute(
         parent=base,
@@ -431,6 +434,28 @@ def _ignore_torchscript_deprecation(test_case: unittest.TestCase) -> None:
         message=r"Loading (TorchScript|dict) checkpoints .* is deprecated",
         category=DeprecationWarning,
     )
+
+
+# ---------------------------------------------------------------------------
+# Fixture validation
+# ---------------------------------------------------------------------------
+
+
+class TestActuatorFixtures(unittest.TestCase):
+    """Validate the shared actuator model fixtures."""
+
+    def test_model_builders_do_not_warn(self):
+        """Keep actuator fixture finalization warning-free."""
+        device = wp.get_device()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _build_pendulum(device)
+            _build_pendulum(device, worlds=2)
+            _build_two_link(device)
+            _build_two_link(device, dummy_body=True, worlds=2)
+
+        self.assertFalse(caught, [str(warning.message) for warning in caught])
 
 
 # ---------------------------------------------------------------------------

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -43,15 +43,21 @@ except ImportError:
 # The following variables are NVIDIA Modifications
 START_DIRECTORY = os.path.dirname(__file__)  # The directory to start test discovery
 
+# Add warning-clean test modules incrementally. Eventually this should cover
+# the entire test_* surface and be replaced by a single test_.* filter.
+_STRICT_WARNING_TEST_MODULES = ("test_actuators",)
+
 
 def _enable_strict_warnings():
-    """Escalate DeprecationWarnings and any newton.* warning to errors.
+    """Escalate actionable and caller-attributed cleaned-test warnings to errors.
 
     Installed before discovery and in each worker initializer so import-time
     warnings from test modules are escalated too, not just runtime ones.
     """
     warnings.filterwarnings("error", category=DeprecationWarning)
     warnings.filterwarnings("error", module=r"newton(\.|$)")
+    for module in _STRICT_WARNING_TEST_MODULES:
+        warnings.filterwarnings("error", module=rf"{module}$")
 
 
 def _use_coord_layout_targets():


### PR DESCRIPTION
## Description

Part of #1724. This is one incremental warning-cleanup step and intentionally
does not close the issue; other warning categories remain.

This PR makes the shared actuator test fixtures warning-free and enrolls
`test_actuators` in strict warning coverage:

- Give the idealized point-mass fixtures explicit positive-definite inertias.
- Treat caller-attributed warnings from `test_actuators` as errors whenever the
  test runner uses `--strict-warnings`.
- Establish an incremental cleaned-test-module list that can grow toward the
  complete `test_*` surface.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] No changelog fragment is needed because this only changes test fixtures
      and test-runner warning enforcement

## Test plan

```console
uv run --extra dev -m newton.tests --strict-warnings -k test_actuators
uv run --with pre-commit pre-commit run -a
```

The actuator suite passes 102 tests; 19 optional-Torch tests are skipped in the
local environment.

## Bug fix

**Steps to reproduce:**

1. Finalize one of the shared actuator fixtures before this change.
2. Observe `Inertia validation corrected ... bodies` in the test output.
3. Run the actuator module with `--strict-warnings` and observe that the
   caller-attributed warning is not promoted to an error.

With this change, the fixtures no longer warn. Restoring the invalid fixture
data makes an existing actuator test fail under `--strict-warnings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved physics test fixtures for more consistent actuator and articulated-body behavior.
  * Added stricter warning checks for actuator-related tests, helping detect regressions and deprecated behavior earlier.
  * Preserved existing effective dynamics while improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->