### PR TITLE
Warn when free joint has non-NONE drive targets in SolverMuJoCo

### DIFF
--- a/changelog/3701.fixed.md
+++ b/changelog/3701.fixed.md
@@ -1,0 +1,1 @@
+Warn when joint drive targets are set on a free joint under `SolverMuJoCo`. MuJoCo does not support actuators on free joints, so `joint_target_mode`, `joint_target_ke`, and `joint_target_kd` were silently ignored. A `UserWarning` is now emitted at solver construction time pointing at `Control.joint_f` as the supported workaround.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -6668,6 +6668,17 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 num_dofs += 6
                 num_qpos += 7
                 num_mjc_joints += 1
+                for i in range(6):
+                    if joint_target_mode[qd_start + i] != int(JointTargetMode.NONE):
+                        warnings.warn(
+                            f"Free joint '{model.joint_label[j]}' has a non-NONE joint_target_mode but "
+                            "SolverMuJoCo cannot create actuators on free joints. "
+                            "Drive targets (joint_target_ke, joint_target_kd, joint_target_q) are silently ignored. "
+                            "Apply the desired wrench directly via Control.joint_f instead.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                        break
             elif j_type == JointType.BALL:
                 ball_params = {
                     "name": name,


### PR DESCRIPTION
## Description

`SolverMuJoCo` cannot create actuators on free joints — MuJoCo does not
permit it — so `joint_target_mode`, `joint_target_ke`, and
`joint_target_kd` set on a free joint's DOFs were silently ignored. The
body simply fell under gravity with no indication that the drive was
inert.

This PR emits a `UserWarning` at solver construction time when any DOF
of a free joint carries a non-`NONE` `joint_target_mode`, naming the
affected joint and pointing at `Control.joint_f` as the supported
workaround.

Closes #3701

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev newton/tests/test_mujoco_solver.py
```

276 tests passed, 7 skipped, 0 failures.

## Bug fix

**Steps to reproduce (without this PR):**

1. Create a free-joint body with `joint_target_mode = POSITION` and non-zero `ke`/`kd`.
2. Construct `SolverMuJoCo`.
3. Step the simulation — the body falls under gravity with no warning.

**Minimal reproduction:**

```python
import newton
import numpy as np
import warp as wp

newton.use_coord_layout_targets = True
b = newton.ModelBuilder()
body = b.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 1.0), wp.quat_identity()))
b.add_shape_box(body, hx=0.05, hy=0.05, hz=0.05)
model = b.finalize()

model.joint_target_ke.assign(wp.array(np.full(model.joint_dof_count, 1.0e4), dtype=float))
model.joint_target_kd.assign(wp.array(np.full(model.joint_dof_count, 2.0e2), dtype=float))
model.joint_target_mode.assign(
    wp.array(np.full(model.joint_dof_count, int(newton.JointTargetMode.POSITION), dtype=np.int32), dtype=wp.int32)
)

# Before: no warning, body silently falls
# After: UserWarning naming the joint and pointing at Control.joint_f
solver = newton.solvers.SolverMuJoCo(model, njmax=64, nconmax=64, use_mujoco_contacts=False)
```

## Out of scope / follow-up

- MJCF import path: actuators targeting joints that become free joints should also be reported (#3701 validation point 3).
- Implementing the drive by injecting a 6-DOF wrench via `Control.joint_f` automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when drive targets are configured for free joints, since these settings are not supported and would otherwise be ignored.
  * The warning directs users to apply wrenches through the supported joint-force control option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->