### PR TITLE
Fix stale Gaussian splat handles after set_visible_worlds()

### DIFF
--- a/changelog/4020.fixed.md
+++ b/changelog/4020.fixed.md
@@ -1,0 +1,1 @@
+Fix `set_visible_worlds()` leaving stale, still-visible Gaussian splat handles behind. Gaussian shape names now use the stable global shape index instead of a sequential counter that reset on every visibility change, and handles for worlds that are no longer visible are hidden during repopulation.

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -712,6 +712,7 @@ class ViewerBase(ABC):
 
         # Clear shape instance batches but preserve geometry cache
         self._shape_instances = {}
+        prev_gaussian_instances = list(self._gaussian_instances)
         self._gaussian_instances = []
         self._sdf_isomesh_instances = {}
         self._sdf_isomesh_populated = False
@@ -722,6 +723,12 @@ class ViewerBase(ABC):
         self._shape_to_batch = None
 
         self._populate_shapes()
+
+        # Hide Gaussian handles for worlds that are no longer visible.
+        new_gaussian_names = {name for name, *_ in self._gaussian_instances}
+        for name, gaussian, *_ in prev_gaussian_instances:
+            if name not in new_gaussian_names:
+                self.log_gaussian(name, gaussian, hidden=True)
         if self._user_spacing is not None:
             self.set_world_offsets(self._user_spacing)
         else:
@@ -2331,7 +2338,7 @@ class ViewerBase(ABC):
                 if isinstance(geo_src, newton.Gaussian):
                     parent = shape_body[s]
                     xform = wp.transform_expand(shape_transform[s])
-                    gname = self._qualify(f"/model/gaussians/gaussian_{len(self._gaussian_instances)}")
+                    gname = self._qualify(f"/model/gaussians/gaussian_{s}")
                     self._gaussian_instances.append(
                         (gname, geo_src, int(parent), xform, int(shape_world[s]), int(shape_flags[s]), parent == -1)
                     )


### PR DESCRIPTION
## Description

`set_visible_worlds()` left stale, still-visible Gaussian splat handles
behind in `ViewerViser` (and any other backend that tracks handles by
name).

Gaussian shape names were generated using `len(_gaussian_instances)` as
a sequential counter. That counter resets to zero every time
`set_visible_worlds()` rebuilds the list, so world N's shape would steal
world 0's old backend name. World N's *original* name became an orphan
in `_scene_handles` — its handle was never visited again, so it was
never hidden or removed. The result was a frozen duplicate rendering at
the shape's last known position alongside the live copy.

Two changes fix this:

1. **Stable names** — use the global shape index `s` (its position in
   the model's fixed shape array) as the name suffix instead of
   `len(_gaussian_instances)`. Each shape's name is now invariant across
   `set_visible_worlds()` calls.
2. **Cleanup** — after repopulating `_gaussian_instances`, hide handles
   for any Gaussian name that is no longer in the active set.

Closes #4020

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev newton/tests/test_viewer_log_shapes.py
uv run --extra dev newton/tests/test_viewer_visible_worlds.py
uv run --extra dev newton/tests/test_viewer_geometry_batching.py
```

All pass with no failures.

## Bug fix

**Steps to reproduce (without this PR):**

1. Build a model with two worlds, each containing one Gaussian shape.
2. Render one frame with both worlds visible.
3. Call `set_visible_worlds([1])` and render another frame.
4. World 1 now renders twice: once live at its current position, and
   once as a frozen duplicate stuck at its prior position.

**Minimal reproduction:** see the script in issue #4020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale Gaussian visualization handles remaining visible after changing the set of visible worlds.
  - Ensured Gaussian shape identifiers remain stable across visibility updates.
  - Improved cleanup when worlds are hidden or removed from the current view.

- **Documentation**
  - Added a changelog entry describing the visibility-handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->