### PR TITLE
Scale contact visualizations to contact geometry

### DIFF
--- a/changelog/+contact-viz-scale-8f31c2a4.fixed.md
+++ b/changelog/+contact-viz-scale-8f31c2a4.fixed.md
@@ -1,0 +1,1 @@
+Scale contact normals, mode disks, and force arrows relative to the smaller contacting shape, preventing oversized glyphs in global-only and mixed-scale scenes.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -698,6 +698,12 @@ The viewer's ``show_contacts`` flag (toggled in the :class:`~newton.viewer.Viewe
 
     viewer.log_contacts(contacts, state)
 
+Contact normals, mode disks, and force arrows are sized relative to the smaller
+shape in each contact pair. Use the ``Contact Relative Scale`` control to adjust
+all contact glyphs while preserving their proportions across differently sized
+contacts. Contact mode coloring and force arrows require the ``"force"``
+extended contact attribute.
+
 **Transform gizmos:**
 
 Use :meth:`~newton.viewer.ViewerBase.log_gizmo` to display a coordinate-frame gizmo at a given transform:

--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -257,6 +257,7 @@ def compute_contact_lines(
     body_q: wp.array[wp.transform],
     shape_body: wp.array[int],
     shape_world: wp.array[int],
+    shape_collision_radius: wp.array[float],
     world_offsets: wp.array[wp.vec3],
     layer_xform: wp.transform,
     visible_worlds_mask: wp.array[int],
@@ -316,9 +317,10 @@ def compute_contact_lines(
     contact_center = wp.transform_point(layer_xform, contact_center)
     normal = wp.quat_rotate(wp.transform_get_rotation(layer_xform), contact_normal[tid])
 
-    # Create line along normal direction
+    # Create line along the normal, relative to the smaller shape in the pair.
     # Normal points from shape0 to shape1, draw from center in normal direction
-    line_vector = normal * line_scale
+    pair_radius = wp.min(shape_collision_radius[shape_a], shape_collision_radius[shape_b])
+    line_vector = normal * (line_scale * pair_radius)
 
     line_start[tid] = contact_center
     line_end[tid] = contact_center + line_vector
@@ -344,6 +346,7 @@ def compute_contact_disk_transforms(
     body_com: wp.array[wp.vec3],
     shape_body: wp.array[int],
     shape_world: wp.array[int],
+    shape_collision_radius: wp.array[float],
     world_offsets: wp.array[wp.vec3],
     visible_worlds_mask: wp.array[int],
     contact_count: wp.array[int],
@@ -354,8 +357,8 @@ def compute_contact_disk_transforms(
     contact_offset0: wp.array[wp.vec3],
     contact_normal: wp.array[wp.vec3],
     contact_force: wp.array[wp.spatial_vector],
-    disk_radius: float,
-    disk_thickness: float,
+    disk_radius_scale: float,
+    disk_thickness_scale: float,
     eps_force: float,
     eps_velocity: float,
     color_open: wp.vec3,
@@ -370,7 +373,8 @@ def compute_contact_disk_transforms(
 
     A thin oriented disk (rendered via a unit cylinder mesh whose local +Z
     axis is the cylinder axis) is placed at each active contact, oriented so
-    that its axis matches ``contact_normal``.
+    that its axis matches ``contact_normal``. Its dimensions are scaled from
+    the smaller shape's collision radius.
 
     When ``contact_force`` is provided (non-null), the disk is colored by an
     inferred contact mode computed from the linear contact force magnitude and
@@ -463,6 +467,10 @@ def compute_contact_disk_transforms(
                 color = color_slip
                 thickness_scaling = 1.01
 
+    pair_radius = wp.min(shape_collision_radius[shape_a], shape_collision_radius[shape_b])
+    disk_radius = disk_radius_scale * pair_radius
+    disk_thickness = disk_thickness_scale * pair_radius
+
     transforms[tid] = wp.transform(contact_center, q)
     scales[tid] = wp.vec3(disk_radius, disk_radius, disk_thickness * thickness_scaling)
     colors[tid] = color
@@ -473,6 +481,7 @@ def compute_contact_force_arrows(
     body_q: wp.array[wp.transform],
     shape_body: wp.array[int],
     shape_world: wp.array[int],
+    shape_collision_radius: wp.array[float],
     world_offsets: wp.array[wp.vec3],
     visible_worlds_mask: wp.array[int],
     contact_count: wp.array[int],
@@ -490,8 +499,9 @@ def compute_contact_force_arrows(
 
     The arrow starts at the world contact point on shape 0 and points along
     ``F = wp.spatial_top(contact_force[i])`` (the world-frame linear force on
-    body 0), with length ``force_scale * |F|``.  Inactive slots produce
-    degenerate (NaN) line segments that the renderer culls.
+    body 0). Its length is relative to the smaller shape's collision radius.
+    Inactive slots produce degenerate (NaN) line segments that the renderer
+    culls.
     """
     tid = wp.tid()
     nan_line = wp.vec3(wp.nan, wp.nan, wp.nan)
@@ -531,7 +541,8 @@ def compute_contact_force_arrows(
 
     f_lin = -wp.spatial_top(contact_force[tid])  # Flip sign so positive force is along normal
     line_start[tid] = contact_center
-    line_end[tid] = contact_center + force_scale * f_lin
+    pair_radius = wp.min(shape_collision_radius[shape_a], shape_collision_radius[shape_b])
+    line_end[tid] = contact_center + (force_scale * pair_radius) * f_lin
 
 
 @wp.kernel

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -591,8 +591,8 @@ class ViewerBase(ABC):
         layer.contact_mode_eps_velocity = 1e-3
 
         # Scaling parameters for the contact visualization
-        # Note: these are auto-set in :meth:`set_model`, below are fallback defaults.
-        layer.contact_viz_scale = 1.0  # Length of contact normal arrows (contact disks/forces scale relatively)
+        # Note: contact_viz_scale is relative to the smaller shape in each contact pair.
+        layer.contact_viz_scale = 1.0
         layer.contact_force_scale = 0.5  # Length of contact force arrows, w.r.t. contact normal arrows
         layer._contact_viz_scale_default = layer.contact_viz_scale
         layer._contact_force_scale_default = layer.contact_force_scale
@@ -915,9 +915,13 @@ class ViewerBase(ABC):
         bounds_min_np = world_bounds_min.numpy()
         bounds_max_np = world_bounds_max.numpy()
 
-        # Find maximum extents across all worlds
-        # Mask out invalid bounds (inf values)
-        valid_mask = ~np.isinf(bounds_min_np[:, 0])
+        # Find maximum extents across all worlds. Empty worlds retain the
+        # finite MAXVAL/-MAXVAL sentinels used to initialize the buffers.
+        valid_mask = (
+            np.all(np.isfinite(bounds_min_np), axis=1)
+            & np.all(np.isfinite(bounds_max_np), axis=1)
+            & np.all(bounds_min_np <= bounds_max_np, axis=1)
+        )
 
         if not valid_mask.any():
             # No valid worlds found
@@ -950,8 +954,8 @@ class ViewerBase(ABC):
     def _auto_compute_contact_scales(self):
         """Adapt contact-visualization scales to the current model.
 
-        Sets ``contact_viz_scale`` and ``contact_force_scale``, based on
-        aggregate model dimensions.
+        Sets the relative ``contact_viz_scale`` default and adapts
+        ``contact_force_scale`` to the aggregate model weight.
 
         Falls back to the literal defaults if the relevant model data is
         unavailable (e.g. no shapes / no dynamic bodies / zero gravity).
@@ -960,14 +964,6 @@ class ViewerBase(ABC):
         # before the model was attached (rare but possible).
         prev_default_scale = self._contact_viz_scale_default
         prev_default_force_scale = self._contact_force_scale_default
-
-        # Characteristic length L_char: 10% of the maximal extent.
-        L_char = 0.0
-        max_extents = self._get_world_extents()
-        if max_extents is not None:
-            L_char = float(0.1 * np.linalg.norm(max_extents))
-        if not np.isfinite(L_char) or L_char <= 0.0:
-            L_char = 1.0
 
         # Characteristic force F_char = sum(dynamic body mass) * |gravity|.
         F_char = 0.0
@@ -993,8 +989,9 @@ class ViewerBase(ABC):
         if not np.isfinite(F_char) or F_char <= 0.0:
             F_char = 1.0
 
-        # Set contact scales based on L_char and F_char
-        self._contact_viz_scale_default = 1.0 * L_char
+        # Normal arrows use half the smaller shape's collision radius when
+        # contact_viz_scale is at its default value of 1.0.
+        self._contact_viz_scale_default = 1.0
         self._contact_force_scale_default = 5.0 / F_char if F_char > 0.0 else 0.5
 
         # Reset live attributes to new defaults, if values were still default
@@ -1218,6 +1215,10 @@ class ViewerBase(ABC):
             self.log_arrows(self._qualify("/contacts/forces"), None, None, None)
             return
 
+        # Base glyph size as a multiplier of the smaller shape's collision
+        # radius. Disks and force arrows preserve their existing proportions.
+        contact_scale = 0.5 * float(self.contact_viz_scale)
+
         # ---- Contact-normal arrows -------------------------------
         if self.show_contact_normals:
             if self._contact_points0 is None or len(self._contact_points0) < max_contacts:
@@ -1233,6 +1234,7 @@ class ViewerBase(ABC):
                     state.body_q,
                     self.model.shape_body,
                     self.model.shape_world,
+                    self.model.shape_collision_radius,
                     self.world_offsets,
                     self.layer.xform,
                     self._visible_worlds_mask,
@@ -1242,7 +1244,7 @@ class ViewerBase(ABC):
                     contacts.rigid_contact_point0,
                     contacts.rigid_contact_offset0,
                     contacts.rigid_contact_normal,
-                    float(self.contact_viz_scale),
+                    contact_scale,
                 ],
                 outputs=[
                     self._contact_points0,  # line start points
@@ -1288,6 +1290,7 @@ class ViewerBase(ABC):
                     self.model.body_com,
                     self.model.shape_body,
                     self.model.shape_world,
+                    self.model.shape_collision_radius,
                     self.world_offsets,
                     self._visible_worlds_mask,
                     contacts.rigid_contact_count,
@@ -1298,8 +1301,8 @@ class ViewerBase(ABC):
                     contacts.rigid_contact_offset0,
                     contacts.rigid_contact_normal,
                     contacts.force,  # may be None — kernel falls back to default color
-                    float(self.contact_viz_scale * 0.2),
-                    float(self.contact_viz_scale * 0.004),  # cylinder half-height
+                    contact_scale * 0.2,
+                    contact_scale * 0.004,  # cylinder half-height
                     float(self.contact_mode_eps_force),
                     float(self.contact_mode_eps_velocity),
                     wp.vec3(0.1, 0.1, 0.1),  # open: black
@@ -1339,6 +1342,7 @@ class ViewerBase(ABC):
                     state.body_q,
                     self.model.shape_body,
                     self.model.shape_world,
+                    self.model.shape_collision_radius,
                     self.world_offsets,
                     self._visible_worlds_mask,
                     contacts.rigid_contact_count,
@@ -1347,7 +1351,7 @@ class ViewerBase(ABC):
                     contacts.rigid_contact_point0,
                     contacts.rigid_contact_offset0,
                     contacts.force,
-                    float(self.contact_viz_scale * self.contact_force_scale),
+                    contact_scale * float(self.contact_force_scale),
                 ],
                 outputs=[self._contact_force_starts, self._contact_force_ends],
                 device=self.device,

--- a/newton/_src/viewer/viewer_gui.py
+++ b/newton/_src/viewer/viewer_gui.py
@@ -818,7 +818,7 @@ class ViewerGui:
                         log_flag = imgui.SliderFlags_.logarithmic.value
                         base = float(viewer._contact_viz_scale_default) or 1.0
                         _, viewer.contact_viz_scale = imgui.slider_float(
-                            "Contact Scale",
+                            "Contact Relative Scale",
                             float(viewer.contact_viz_scale),
                             base * 0.01,
                             base * 100.0,

--- a/newton/tests/test_viewer_log_shapes.py
+++ b/newton/tests/test_viewer_log_shapes.py
@@ -119,5 +119,29 @@ class TestLogShapesBroadcast(unittest.TestCase):
         )
 
 
+class TestLogContacts(unittest.TestCase):
+    def test_glyphs_scale_with_smaller_contact_shape(self):
+        builder = newton.ModelBuilder()
+        for radius in (0.2, 2.0, 1.0):
+            builder.add_shape_sphere(body=-1, radius=radius)
+        model = builder.finalize(device="cpu")
+
+        contacts = newton.Contacts(2, 0, device=model.device)
+        contacts.rigid_contact_count.assign([2])
+        contacts.rigid_contact_shape0.assign([0, 1])
+        contacts.rigid_contact_shape1.assign([1, 2])
+        contacts.rigid_contact_normal.assign([wp.vec3(0.0, 0.0, 1.0)] * 2)
+
+        viewer = ViewerNull(num_frames=1)
+        viewer.set_model(model)
+        viewer.show_contacts = True
+        viewer.log_contacts(contacts, model.state())
+
+        self.assertIsNone(viewer._get_world_extents())
+        normal_lengths = np.linalg.norm(viewer._contact_points1.numpy() - viewer._contact_points0.numpy(), axis=1)
+        assert_np_equal(normal_lengths, np.array([0.1, 0.5]), tol=1.0e-6)
+        assert_np_equal(viewer._contact_disk_scales.numpy()[:, 0], np.array([0.02, 0.1]), tol=1.0e-6)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Scale contact normal arrows, contact-mode disks, and contact-force arrows from half the collision radius of the smaller shape in each contact pair. The existing contact scale remains available as a dimensionless relative multiplier, so glyphs stay readable in scenes that mix very small and very large geometry.

Also reject the finite MAXVAL/-MAXVAL bounds left by empty global worlds. Those sentinels previously produced an automatic contact scale of roughly 3.46e9 in global-only models.

Related to the broader visualization scaling request in #2359 and follows the contact visualization work in #3615.

<img width="1824" height="2294" alt="image" src="https://github.com/user-attachments/assets/b481a342-0863-493d-83a3-e8ef10f6fa1e" />


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- uv run --extra dev -m newton.tests -k test_viewer_log_shapes
- uv run --extra dev -m newton.tests -k test_viewer_world_offsets
- uvx --from pre-commit==4.2.0 pre-commit run -a
- uvx --from towncrier==25.8.0 towncrier build --draft --version 0.0.0 --date 2026-08-28

The new global-world regression test was also run against the old bounds filter and failed with an invalid (-2e10, -2e10, -2e10) extent before the fix.

## Bug fix

**Steps to reproduce:**

1. Build a model with a small colliding shape and a large static support shape in the global world.
2. Enable contact-normal or contact-mode rendering in a viewer.
3. Observe glyphs scaled from the full scene extent, or enormously scaled when the model has no indexed worlds.

**Minimal reproduction:**

    import warp as wp
    import newton
    from newton.viewer import ViewerNull

    builder = newton.ModelBuilder()
    body = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.1)))
    builder.add_shape_sphere(body, radius=0.02)
    builder.add_shape_box(body=-1, hx=0.5, hy=0.5, hz=0.1)

    viewer = ViewerNull()
    viewer.set_model(builder.finalize())
    print(viewer.contact_viz_scale)

Before this change, the printed automatic scale is approximately 3.46e9. After this change, it is the dimensionless default 1.0; each rendered contact then derives its physical glyph size from the smaller contacting shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact normals, mode disks, and force arrows now scale relative to the smaller shape in each contact pair.
  * The **Contact Relative Scale** control adjusts contact glyph sizes while preserving their proportions.
* **Bug Fixes**
  * Prevented oversized contact visualizations in scenes with differently sized shapes.
  * Improved handling of empty or invalid world bounds.
* **Documentation**
  * Updated the visualization guide with contact scaling behavior and force-attribute requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
