### PR TITLE
Expose Viser viewer extension context

### DIFF
--- a/changelog/4091.added.md
+++ b/changelog/4091.added.md
@@ -1,0 +1,1 @@
+Add `ViewerViser.extension_context` for application-owned Viser scene and GUI extensions without exposing the viewer's server.

--- a/docs/api/newton_viewer.rst
+++ b/docs/api/newton_viewer.rst
@@ -22,3 +22,4 @@ newton.viewer
    ViewerRerun
    ViewerUSD
    ViewerViser
+   ViewerViserExtensionContext

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -562,6 +562,27 @@ providing web-based 3D visualization that works in any browser and has native Ju
     # Close the viewer when done
     viewer.close()
 
+**Application extensions**
+
+Use :attr:`~newton.viewer.ViewerViser.extension_context` to add application-owned
+scene nodes and GUI controls to the viewer's Viser session:
+
+.. code-block:: python
+
+    context = viewer.extension_context
+    origin = context.scene.add_frame("/editor/origin")
+    visible = context.gui.add_checkbox("Show editor origin", initial_value=True)
+
+    @visible.on_update
+    def _(_event):
+        origin.visible = visible.value
+
+    context.initial_camera.position = (3.0, 3.0, 2.0)
+
+The context does not expose the underlying Viser server. Newton owns the server
+and its lifecycle; the application owns the nodes, controls, callbacks, and
+background work that it creates through the context.
+
 **Recording and playback**
 
 ViewerViser can record simulations to ``.viser`` files for later playback:

--- a/newton/_src/viewer/__init__.py
+++ b/newton/_src/viewer/__init__.py
@@ -46,7 +46,7 @@ from .viewer_null import ViewerNull
 from .viewer_rerun import ViewerRerun
 from .viewer_rtx import ViewerRTX
 from .viewer_usd import ViewerUSD
-from .viewer_viser import ViewerViser
+from .viewer_viser import ViewerViser, ViewerViserExtensionContext
 
 __all__ = [
     "Layer",
@@ -58,4 +58,5 @@ __all__ = [
     "ViewerRerun",
     "ViewerUSD",
     "ViewerViser",
+    "ViewerViserExtensionContext",
 ]

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -7,8 +7,9 @@ import collections
 import inspect
 import os
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 
 import numpy as np
@@ -19,6 +20,27 @@ import newton
 from ..core.types import override
 from ..utils.texture import load_texture, normalize_texture
 from .viewer import ViewerBase, is_jupyter_notebook
+
+if TYPE_CHECKING:
+    import viser
+
+
+@dataclass(frozen=True, slots=True)
+class ViewerViserExtensionContext:
+    """Public Viser handles for application-owned scene and GUI content.
+
+    The context deliberately omits the underlying Viser server so extensions
+    cannot take over its lifecycle or other viewer-owned facilities.
+    """
+
+    scene: viser.SceneApi
+    """Viser scene interface used to add and update scene nodes."""
+
+    gui: viser.GuiApi
+    """Viser GUI interface used to add and update controls."""
+
+    initial_camera: viser.InitialCameraConfig
+    """Viser initial-camera configuration for newly connected clients."""
 
 
 class ViewerViser(ViewerBase):
@@ -158,6 +180,11 @@ class ViewerViser(ViewerBase):
 
         # Initialize viser server
         self._server = viser.ViserServer(port=port, label=label or "Newton Viewer")
+        self._extension_context = ViewerViserExtensionContext(
+            scene=self._server.scene,
+            gui=self._server.gui,
+            initial_camera=self._server.initial_camera,
+        )
         self._camera_request: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
         self._pending_camera_clients: set[int] = set()
         self._server.on_client_connect(self._handle_client_connect)
@@ -187,6 +214,19 @@ class ViewerViser(ViewerBase):
 
         if self._serializer is not None and verbose:
             print(f"Recording to: {record_to_viser}")
+
+    @property
+    def extension_context(self) -> ViewerViserExtensionContext:
+        """Return public Viser handles for installing an application extension.
+
+        Newton retains ownership of the Viser server and its lifecycle. The
+        caller owns any nodes, controls, callbacks, and background work it adds
+        through this context.
+
+        Returns:
+            Stable scene, GUI, and initial-camera handles for this viewer.
+        """
+        return self._extension_context
 
     @override
     def clear_model(self):

--- a/newton/tests/test_viewer_viser_extension_context.py
+++ b/newton/tests/test_viewer_viser_extension_context.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import Mock, patch
+
+from newton.viewer import ViewerViser, ViewerViserExtensionContext
+
+
+class TestViewerViserExtensionContext(unittest.TestCase):
+    def test_extension_context_exposes_public_viser_handles(self):
+        """Expose stable scene, GUI, and initial-camera handles without the server."""
+        server = Mock()
+        server.scene = Mock()
+        server.gui = Mock()
+        server.initial_camera = Mock()
+        server.get_scene_serializer.return_value = None
+
+        fake_viser = Mock()
+        fake_viser.ViserServer.return_value = server
+
+        with (
+            patch.object(ViewerViser, "_get_viser", return_value=fake_viser),
+            patch("newton._src.viewer.viewer_viser.is_jupyter_notebook", return_value=False),
+        ):
+            viewer = ViewerViser(verbose=False)
+
+        self.addCleanup(viewer.close)
+        context = viewer.extension_context
+
+        self.assertIsInstance(context, ViewerViserExtensionContext)
+        self.assertIs(context.scene, server.scene)
+        self.assertIs(context.gui, server.gui)
+        self.assertIs(context.initial_camera, server.initial_camera)
+        self.assertIs(viewer.extension_context, context)
+        self.assertFalse(hasattr(context, "server"))
+
+        context.scene.add_frame("/editor/origin")
+        context.gui.add_button("Apply")
+        context.initial_camera.position = (3.0, 3.0, 2.0)
+
+        server.scene.add_frame.assert_called_once_with("/editor/origin")
+        server.gui.add_button.assert_called_once_with("Apply")
+        self.assertEqual(server.initial_camera.position, (3.0, 3.0, 2.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/viewer.py
+++ b/newton/viewer.py
@@ -12,6 +12,7 @@ from ._src.viewer import (
     ViewerRTX,
     ViewerUSD,
     ViewerViser,
+    ViewerViserExtensionContext,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "ViewerRerun",
     "ViewerUSD",
     "ViewerViser",
+    "ViewerViserExtensionContext",
 ]


### PR DESCRIPTION
## Description

Expose a typed, non-owning context from `ViewerViser` for applications that add scene nodes and GUI controls to the existing Viser session.

The context contains only the scene API, GUI API, and initial-camera configuration. It deliberately omits the `ViserServer`: Newton continues to own the server and viewer lifecycle, while the application owns the nodes, controls, callbacks, and background work it creates.

This is intentionally narrower than #4039. It does not discover or load third-party viewer classes; callers construct the normal `ViewerViser` and extend that instance through capability-limited handles.

Closes #4091.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the changelog fragment instructions

## Test plan

```console
uv run --extra dev -m newton.tests -k viewer_viser_extension_context
uv run --extra dev -m newton.tests -k viewer_layers
uvx pre-commit run -a
```

Results: 1 extension-context test passed, 22 viewer-layer tests passed, and every pre-commit hook passed.

## New feature / API change

```python
from newton.viewer import ViewerViser

viewer = ViewerViser()
context = viewer.extension_context

origin = context.scene.add_frame("/application/origin")
visible = context.gui.add_checkbox("Show origin", initial_value=True)

@visible.on_update
def _(_event):
    origin.visible = visible.value

context.initial_camera.position = (3.0, 3.0, 2.0)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications can now extend Viser scenes with custom scene nodes, GUI controls, and callbacks through a dedicated extension context.
  * The extension context provides access to scene, GUI, and initial-camera controls without exposing the underlying viewer server.
  * The new extension context is publicly available through the viewer API.

* **Documentation**
  * Added usage guidance and API reference documentation for application extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->