### PR TITLE
Default `use_coord_layout_targets` to True

### DIFF
--- a/changelog/+coord-layout-default-7f3ac142.changed.md
+++ b/changelog/+coord-layout-default-7f3ac142.changed.md
@@ -1,0 +1,1 @@
+Default `newton.use_coord_layout_targets` to `True`: `Model.joint_target_q` and `Control.joint_target_q` are now shaped `(joint_coord_count,)`, matching `joint_q`. Index them via `Model.joint_target_q_start`. Set the flag to `False` before building models to restore the deprecated DOF-shaped layout.

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -77,4 +77,4 @@ newton
    * - ``__version__``
      - ``1.6.0.dev0``
    * - ``use_coord_layout_targets``
-     - ``False``
+     - ``True``

--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -402,11 +402,10 @@ properties defined via :class:`newton.ModelBuilder.JointDofConfig`, and the
 velocity targets at :attr:`newton.Control.joint_target_qd`.
 
 The position targets at :attr:`newton.Control.joint_target_q` instead match
-:attr:`newton.Model.joint_q` (coord layout) when
-:attr:`newton.use_coord_layout_targets` is ``True``; index those with
-:attr:`newton.Model.joint_q_start`. Under the legacy default
-(``use_coord_layout_targets = False``) the array is still DOF-shaped and
-indexed via :attr:`newton.Model.joint_qd_start` — see the
+:attr:`newton.Model.joint_q` (coord layout) by default; index those with
+:attr:`newton.Model.joint_q_start`. Under the deprecated legacy layout
+(``use_coord_layout_targets = False``) the array is DOF-shaped and indexed
+via :attr:`newton.Model.joint_qd_start` — see the
 :ref:`migration guide <joint-target-layout>` for details.
 
 For every generalized-coordinate joint, these per-DOF arrays are stored

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -79,8 +79,11 @@ to locate a joint's slice in the per-DOF arrays.
 
 For free and D6 joints, Newton stores linear DOFs before angular DOFs in per-axis arrays. In
 particular, floating-base slices of :attr:`newton.State.joint_qd`, :attr:`newton.Control.joint_f`,
-:attr:`newton.Control.joint_target_q`, and :attr:`newton.Control.joint_target_qd` use
+and :attr:`newton.Control.joint_target_qd` use
 ``(linear, angular)`` ordering, whereas ``warp.sim`` used ``(ang_vel, lin_vel)``.
+:attr:`newton.Control.joint_target_q` keeps that ordering but follows :attr:`newton.State.joint_q`:
+a free joint occupies 7 coordinates ``(position, quaternion)``, not 6 DOFs. It is DOF-shaped like
+the others only under the deprecated layout; see :ref:`joint-target-layout`.
 For public ``FREE`` and ``DISTANCE`` joints, :attr:`newton.State.joint_qd`
 stores the child-COM twist in the joint parent frame, while
 :attr:`newton.Control.joint_f` stores the world-frame COM wrench

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -152,14 +152,11 @@ position semantically is: the two layouts diverge whenever an articulation conta
 distance joint (7 coords vs. 6 DOFs) or ball joint (4 coords vs. 3 DOFs), and under the DOF layout
 every actuated DOF downstream of such a joint is indexed with the wrong stride.
 
-New code should opt into the coordinate layout, which will become the only layout in a future
-release:
+The coordinate layout is the default and will become the only layout in a future release:
 
 .. code-block:: python
 
    import newton
-
-   newton.use_coord_layout_targets = True  # set once, before building any model
 
    builder = newton.ModelBuilder()
    # ... build articulation ...
@@ -181,11 +178,11 @@ translation for free joints), matching ``joint_q``. Migration notes coming from 
 - When constructing an :class:`Actuator` with a custom ``pos_indices``, drop the
   ``target_pos_indices`` argument: with the coord layout it defaults to ``pos_indices``.
 
-The default is still the legacy DOF-shaped layout for backward compatibility with existing Newton
-code, but it is deprecated: building a model whose joint coordinate and DOF counts differ
-(free/ball/distance joints) under ``use_coord_layout_targets = False`` emits a
-:class:`DeprecationWarning` from ``finalize()``. For models without such joints the two layouts
-are identical, so no warning is emitted and the switch is invisible.
+Code that is not migrated yet can restore the legacy DOF-shaped layout with
+``newton.use_coord_layout_targets = False``, set once before building any model. That layout is
+deprecated: building a model whose joint coordinate and DOF counts differ (free/ball/distance
+joints) under it emits a :class:`DeprecationWarning` from ``finalize()``. For models without such
+joints the two layouts are identical, so no warning is emitted and the switch is invisible.
 
 
 ``ModelBuilder``

--- a/docs/tutorials/01_robotics.ipynb
+++ b/docs/tutorials/01_robotics.ipynb
@@ -83,9 +83,6 @@
     "import newton.ik as ik\n",
     "import newton.utils\n",
     "\n",
-    "# Opt in to the coord-aligned target layout so joint_target_q matches joint_q.\n",
-    "newton.use_coord_layout_targets = True\n",
-    "\n",
     "wp.config.log_level = wp.LOG_WARNING"
    ]
   },

--- a/newton/__init__.py
+++ b/newton/__init__.py
@@ -11,18 +11,17 @@ from ._src.core import (
 )
 from ._version import __version__
 
-use_coord_layout_targets: bool = False
+use_coord_layout_targets: bool = True
 """Use :attr:`joint_q`-aligned layout for joint position targets.
 
 Controls the shape of :attr:`~newton.Model.joint_target_q` and
 :attr:`~newton.Control.joint_target_q`:
 
-- ``True``: shape ``(joint_coord_count,)``, matching
+- ``True`` (the default): shape ``(joint_coord_count,)``, matching
   :attr:`~newton.State.joint_q`.
-- ``False`` (the default): legacy shape ``(joint_dof_count,)``, which is
-  misaligned with :attr:`~newton.State.joint_q` whenever an articulation
-  contains a free, ball, or distance joint upstream of a position-controlled
-  DOF.
+- ``False``: legacy shape ``(joint_dof_count,)``, which is misaligned with
+  :attr:`~newton.State.joint_q` whenever an articulation contains a free,
+  ball, or distance joint upstream of a position-controlled DOF.
 
 :attr:`joint_target_qd` is shaped ``(joint_dof_count,)`` in both layouts,
 matching :attr:`~newton.State.joint_qd`.
@@ -34,8 +33,7 @@ it before constructing a :class:`~newton.ModelBuilder`.
     The legacy DOF-shaped layout is deprecated. In a future release the
     coordinate layout becomes the only layout and this flag is removed;
     ``finalize()`` warns when building an affected model (one whose joint
-    coordinate and DOF counts differ) under ``False``. Set the flag to
-    ``True`` now to migrate.
+    coordinate and DOF counts differ) under ``False``.
 """
 
 __all__ = [

--- a/newton/examples/basic/example_basic_conveyor.py
+++ b/newton/examples/basic/example_basic_conveyor.py
@@ -152,7 +152,6 @@ def advance_time(sim_time: wp.array[wp.float32], dt: float):
 
 class Example:
     def __init__(self, viewer, args=None):
-        newton.use_coord_layout_targets = True
         self.fps = 100
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/basic/example_basic_conveyor_forces.py
+++ b/newton/examples/basic/example_basic_conveyor_forces.py
@@ -757,7 +757,6 @@ class Example:
     """Conveyor circuit whose static belts carry rigid boxes with contact forces."""
 
     def __init__(self, viewer, args=None):
-        newton.use_coord_layout_targets = True
         self.solver_type = getattr(args, "solver", "xpbd") if args is not None else "xpbd"
 
         self.fps = 60

--- a/newton/examples/basic/example_basic_dzhanibekov.py
+++ b/newton/examples/basic/example_basic_dzhanibekov.py
@@ -32,7 +32,6 @@ _BAR_DENSITY = 100.0
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/basic/example_basic_joints.py
+++ b/newton/examples/basic/example_basic_joints.py
@@ -32,7 +32,6 @@ def _slider_constrained_motion_has_stopped(q: wp.transform, qd: wp.spatial_vecto
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 100
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/basic/example_basic_plotting.py
+++ b/newton/examples/basic/example_basic_plotting.py
@@ -32,7 +32,6 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/basic/example_basic_shapes.py
+++ b/newton/examples/basic/example_basic_shapes.py
@@ -24,7 +24,6 @@ import newton.usd
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 100
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/basic/example_basic_urdf.py
+++ b/newton/examples/basic/example_basic_urdf.py
@@ -23,7 +23,6 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 100
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/basic/example_recording.py
+++ b/newton/examples/basic/example_recording.py
@@ -23,7 +23,6 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # Setup simulation parameters
         self.fps = 60
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/cable/example_cable_bundle_hysteresis.py
+++ b/newton/examples/cable/example_cable_bundle_hysteresis.py
@@ -150,7 +150,6 @@ class Example:
         return positions
 
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # Store viewer and arguments
         self.viewer = viewer
         self.args = args

--- a/newton/examples/cable/example_cable_cross_slide_table.py
+++ b/newton/examples/cable/example_cable_cross_slide_table.py
@@ -422,7 +422,6 @@ def add_visual_bar(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # Store viewer and configure simulation cadence.
         self.viewer = viewer
 

--- a/newton/examples/cloth/example_cloth_poker_cards.py
+++ b/newton/examples/cloth/example_cloth_poker_cards.py
@@ -39,7 +39,6 @@ CARD_COLOR_PALETTE = (
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
 

--- a/newton/examples/cloth/example_cloth_style3d.py
+++ b/newton/examples/cloth/example_cloth_style3d.py
@@ -14,7 +14,6 @@ from newton.solvers import style3d
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 60
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/contacts/example_balance_bird.py
+++ b/newton/examples/contacts/example_balance_bird.py
@@ -38,7 +38,6 @@ NATIVE_CONTACT_SOLVERS = {"mujoco", "kamino"}
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.solver_name = str(getattr(args, "solver", "xpbd")).lower()
 

--- a/newton/examples/contacts/example_brick_stacking.py
+++ b/newton/examples/contacts/example_brick_stacking.py
@@ -390,7 +390,6 @@ def advance_task_kernel(
 
 class Example:
     def __init__(self, viewer, args=None):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/contacts/example_domino_spiral.py
+++ b/newton/examples/contacts/example_domino_spiral.py
@@ -65,7 +65,6 @@ def _domino_spiral_pose(index: int) -> tuple[wp.vec3, wp.quat]:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.solver_name = str(getattr(args, "solver", "xpbd")).lower()
 

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -149,7 +149,6 @@ def load_mesh_with_sdf(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 120
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/contacts/example_nut_bolt_sdf.py
+++ b/newton/examples/contacts/example_nut_bolt_sdf.py
@@ -91,7 +91,6 @@ def load_mesh_with_sdf(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 120
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/contacts/example_pyramid.py
+++ b/newton/examples/contacts/example_pyramid.py
@@ -36,7 +36,6 @@ XPBD_CONTACT_RELAXATION = 0.8
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 100
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/diffsim/example_diffsim_drone.py
+++ b/newton/examples/diffsim/example_diffsim_drone.py
@@ -438,7 +438,6 @@ class Drone:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.args = args
 
         # setup simulation parameters first

--- a/newton/examples/ik/example_ik_cube_stacking.py
+++ b/newton/examples/ik/example_ik_cube_stacking.py
@@ -184,7 +184,6 @@ def advance_task_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/kamino/example_kamino_basic_dr_testmech.py
+++ b/newton/examples/kamino/example_kamino_basic_dr_testmech.py
@@ -18,7 +18,6 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer: newton.viewer.ViewerBase, args=None):
-        newton.use_coord_layout_targets = True
         # Set simulation run-time configurations
         self.fps = 50
         self.sim_dt = 0.001

--- a/newton/examples/kamino/example_kamino_basic_heterogeneous.py
+++ b/newton/examples/kamino/example_kamino_basic_heterogeneous.py
@@ -20,7 +20,6 @@ from newton.tests.utils import basics
 
 class Example:
     def __init__(self, viewer: newton.viewer.ViewerBase, args=None):
-        newton.use_coord_layout_targets = True
         # Set simulation run-time configurations
         self.fps = 50
         self.sim_dt = 0.0025

--- a/newton/examples/kamino/example_kamino_robot_anymal_d.py
+++ b/newton/examples/kamino/example_kamino_robot_anymal_d.py
@@ -18,7 +18,6 @@ import newton.examples
 
 class Example:
     def __init__(self, viewer: newton.viewer.ViewerBase, args=None):
-        newton.use_coord_layout_targets = True
         # Set simulation run-time configurations
         self.fps = 50
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -31,7 +31,6 @@ from newton.solvers import SolverImplicitMPM
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         voxel_size = args.voxel_size
         particles_per_cell = args.particles_per_cell
         tolerance = args.tolerance

--- a/newton/examples/mpm/example_mpm_snow_ball.py
+++ b/newton/examples/mpm/example_mpm_snow_ball.py
@@ -32,7 +32,6 @@ class Example:
     """Snow ball rolling down a heightfield slope with per-particle snow rheology."""
 
     def __init__(self, viewer, options):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = options.fps
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/mpm/example_mpm_twoway_coupling.py
+++ b/newton/examples/mpm/example_mpm_twoway_coupling.py
@@ -87,7 +87,6 @@ def subtract_body_force(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 100
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/mujoco/example_mujoco_sleeping.py
+++ b/newton/examples/mujoco/example_mujoco_sleeping.py
@@ -128,7 +128,6 @@ def build_stack() -> newton.ModelBuilder:
 class Example:
     def __init__(self, viewer, args):
         """Build the articulation stacks, sleeping solver, and island-color mapping."""
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.fps = 60
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/multiphysics/example_admm_contact_solver.py
+++ b/newton/examples/multiphysics/example_admm_contact_solver.py
@@ -39,7 +39,6 @@ def _gather_particles(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
+++ b/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
@@ -108,7 +108,6 @@ def _quat_from_x_axis(direction: np.ndarray) -> wp.quat:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
@@ -108,7 +108,6 @@ def _find_label_index(labels: list[str], suffix: str) -> int:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/multiphysics/example_mujoco_mpm_coupled_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_mpm_coupled_solver.py
@@ -91,7 +91,6 @@ def _launch_frame_graph(model: newton.Model, graph) -> bool:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 100

--- a/newton/examples/multiphysics/example_mujoco_vbd_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_vbd_admm_solver.py
@@ -100,7 +100,6 @@ def _launch_frame_graph(model: newton.Model, graph) -> bool:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/multiphysics/example_mujoco_vbd_coupled_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_vbd_coupled_solver.py
@@ -99,7 +99,6 @@ def _launch_frame_graph(model: newton.Model, graph) -> bool:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.args = args
         self.viewer = viewer
         self.sim_time = 0.0

--- a/newton/examples/multiphysics/example_mujoco_xpbd_coupled_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_xpbd_coupled_solver.py
@@ -96,7 +96,6 @@ def _launch_frame_graph(model: newton.Model, graph) -> bool:
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.sim_time = 0.0
         self.fps = 60

--- a/newton/examples/multiphysics/example_rigid_soft_contact.py
+++ b/newton/examples/multiphysics/example_rigid_soft_contact.py
@@ -98,7 +98,6 @@ def _soft_solver_entry_args(soft_solver: str, args):
 
 class Example:
     def __init__(self, viewer: ViewerBase, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.solver_type = args.solver
         self.rigid_solver = _normalized_rigid_solver_name(args.rigid_solver)

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -60,7 +60,6 @@ def move_hand(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 50
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -84,7 +84,6 @@ def _compute_obs_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.viewer = viewer
         self.device = wp.get_device()
 

--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -21,7 +21,6 @@ from newton.solvers import SolverMuJoCo
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 50
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -21,7 +21,6 @@ from newton import JointTargetMode
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0

--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -21,7 +21,6 @@ from newton import JointTargetMode
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 50
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/robot/example_robot_omniwheel.py
+++ b/newton/examples/robot/example_robot_omniwheel.py
@@ -309,7 +309,6 @@ class Example:
     """Drive a mecanum robot and a self-balancing ballbot."""
 
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_substeps = 6

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -58,7 +58,6 @@ def broadcast_ik_solution_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.scene = SceneType(args.scene)
         self.test_mode = args.test
         self.deterministic = args.deterministic

--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -185,7 +185,6 @@ def find_physx_mjwarp_mapping(mjwarp_joint_names, physx_joint_names):
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         if args.robot not in ROBOT_CONFIGS:
             raise ValueError(f"Unknown robot: {args.robot}. Available: {list(ROBOT_CONFIGS.keys())}")
         robot_config = ROBOT_CONFIGS[args.robot]

--- a/newton/examples/robot/example_robot_ur10.py
+++ b/newton/examples/robot/example_robot_ur10.py
@@ -49,7 +49,6 @@ def update_joint_target_trajectory_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 50
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/selection/example_selection_articulations.py
+++ b/newton/examples/selection/example_selection_articulations.py
@@ -76,7 +76,6 @@ def random_forces_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/selection/example_selection_materials.py
+++ b/newton/examples/selection/example_selection_materials.py
@@ -54,7 +54,6 @@ def reset_materials_kernel(mu: wp.array3d[float], seed: int, shape_count: int):
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/selection/example_selection_multiple.py
+++ b/newton/examples/selection/example_selection_multiple.py
@@ -81,7 +81,6 @@ def random_forces_kernel(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
 

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -28,7 +28,6 @@ from newton.tests.unittest_utils import find_nonfinite_members
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 120
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/sensors/example_sensor_imu.py
+++ b/newton/examples/sensors/example_sensor_imu.py
@@ -36,7 +36,6 @@ def acc_to_color(
 
 class Example:
     def __init__(self, viewer, args):
-        newton.use_coord_layout_targets = True
         # setup simulation parameters first
         self.fps = 200
         self.frame_dt = 1.0 / self.fps

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -80,7 +80,6 @@ def animate_franka(
 
 class Example:
     def __init__(self, viewer: ViewerGL, args):
-        newton.use_coord_layout_targets = True
         self.worlds_per_row = 6
         self.worlds_per_col = 4
         self.world_count_total = self.worlds_per_row * self.worlds_per_col

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -1211,7 +1211,7 @@ class TestControllerNeuralMLPTorchFormats(_TorchCheckpointTestMixin, unittest.Te
         object as pos_indices. This matters in practice for a floating-base robot: the
         free joint occupies 7 coordinate ("q", position-layout) DOFs but only 6 velocity
         ("qd") DOFs, so ``pos_indices`` (coord layout) and ``indices``/``target_pos_indices``
-        (default legacy DOF layout, see ``newton.use_coord_layout_targets``) are offset
+        (legacy DOF layout, see ``newton.use_coord_layout_targets``) are offset
         differently for the two actuated joints that follow it, and neither equals a plain
         ``arange(n)``.
         """
@@ -1376,7 +1376,7 @@ class TestControllerNeuralLSTMTorchFormats(_TorchCheckpointTestMixin, unittest.T
         object as pos_indices. This matters in practice for a floating-base robot: the
         free joint occupies 7 coordinate ("q", position-layout) DOFs but only 6 velocity
         ("qd") DOFs, so ``pos_indices`` (coord layout) and ``indices``/``target_pos_indices``
-        (default legacy DOF layout, see ``newton.use_coord_layout_targets``) are offset
+        (legacy DOF layout, see ``newton.use_coord_layout_targets``) are offset
         differently for the two actuated joints that follow it, and neither equals a plain
         ``arange(n)``.
         """

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -2446,6 +2446,65 @@ class TestModelJoints(unittest.TestCase):
         finally:
             newton.use_coord_layout_targets = previous_flag
 
+    def test_legacy_target_layout_shapes_and_values(self):
+        """Verify legacy DOF target layout behavior."""
+        lin_targets = (1.5, -2.5, 3.5)
+        ang_targets = (0.1, 0.2, -0.3)
+
+        def _axes(targets):
+            return [
+                ModelBuilder.JointDofConfig(axis=axis, target_pos=target)
+                for axis, target in zip((newton.Axis.X, newton.Axis.Y, newton.Axis.Z), targets, strict=True)
+            ]
+
+        previous_flag = newton.use_coord_layout_targets
+        newton.use_coord_layout_targets = False
+        try:
+            builder = ModelBuilder()
+            b_free = builder.add_link(mass=1.0)
+            j_free = builder.add_joint(
+                newton.JointType.FREE,
+                parent=-1,
+                child=b_free,
+                linear_axes=_axes(lin_targets),
+                angular_axes=_axes(ang_targets),
+            )
+            b_ball = builder.add_link(mass=1.0)
+            j_ball = builder.add_joint(
+                newton.JointType.BALL,
+                parent=b_free,
+                child=b_ball,
+                angular_axes=_axes(ang_targets),
+            )
+            b_rev = builder.add_link(mass=1.0)
+            j_rev = builder.add_joint_revolute(parent=b_ball, child=b_rev, axis=newton.Axis.Z, target_pos=0.7)
+            builder.add_articulation([j_free, j_ball, j_rev])
+            with self.assertWarnsRegex(DeprecationWarning, "legacy DOF-shaped joint_target_q layout"):
+                model = builder.finalize()
+        finally:
+            newton.use_coord_layout_targets = previous_flag
+
+        self.assertEqual(model.joint_coord_count, 7 + 4 + 1)
+        self.assertEqual(model.joint_dof_count, 6 + 3 + 1)
+        self.assertEqual(model.joint_target_q.shape[0], model.joint_dof_count)
+        self.assertEqual(model.joint_target_qd.shape[0], model.joint_dof_count)
+
+        control = model.control()
+        self.assertEqual(control.joint_target_q.shape[0], model.joint_dof_count)
+        self.assertEqual(control.joint_target_qd.shape[0], model.joint_dof_count)
+
+        np.testing.assert_array_equal(model.joint_target_q_start.numpy(), model.joint_qd_start.numpy())
+
+        # The quat-w padding slot is dropped: angular targets stay raw per-axis angles.
+        target_q = model.joint_target_q.numpy()
+        qd_starts = model.joint_qd_start.numpy()
+        f = int(qd_starts[j_free])
+        np.testing.assert_allclose(target_q[f : f + 3], lin_targets, rtol=0, atol=1e-6)
+        np.testing.assert_allclose(target_q[f + 3 : f + 6], ang_targets, rtol=0, atol=1e-6)
+        b = int(qd_starts[j_ball])
+        np.testing.assert_allclose(target_q[b : b + 3], ang_targets, rtol=0, atol=1e-6)
+        self.assertAlmostEqual(float(target_q[int(qd_starts[j_rev])]), 0.7, places=6)
+
     def test_ball_free_per_axis_target_pos_preserved(self):
         """``JointDofConfig.target_pos`` on BALL/FREE angular axes must flow
         into the ``joint_target_q`` coord slice: the 3 angular scalars are

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -60,20 +60,6 @@ def _enable_strict_warnings():
         warnings.filterwarnings("error", module=rf"{module}$")
 
 
-def _use_coord_layout_targets():
-    """Run the suite under the coordinate target layout (the future default).
-
-    Set here — in the runner entry points and worker initializers — rather than
-    at unittest_utils import time: newton.examples imports unittest_utils, so an
-    import-time assignment would leak the flag into production example runs.
-    Tests that exercise the deprecated DOF layout set the flag to False locally
-    and restore it afterwards.
-    """
-    import newton  # noqa: PLC0415
-
-    newton.use_coord_layout_targets = True
-
-
 def main(argv=None):
     """
     unittest-parallel command-line script main entry point
@@ -248,7 +234,6 @@ def main(argv=None):
         # the serial-fallback path, which runs here.
         if args.strict_warnings:
             _enable_strict_warnings()
-        _use_coord_layout_targets()
 
         # Discover tests
         with _coverage(args, temp_dir):
@@ -567,7 +552,6 @@ class ParallelTestManager:
         newton.tests.unittest_utils.strict_warnings = self.args.strict_warnings
         if self.args.strict_warnings:
             _enable_strict_warnings()
-        _use_coord_layout_targets()
 
         if self.args.junit_report_xml:
             resultclass = ParallelJunitTestResult
@@ -682,7 +666,6 @@ def initialize_test_process(lock, shared_index, args, temp_dir):
     # unpickle, before run_tests).
     if args.strict_warnings:
         _enable_strict_warnings()
-    _use_coord_layout_targets()
 
     with lock:
         shared_index.value += 1


### PR DESCRIPTION
## Description
`Model.joint_target_q` and `Control.joint_target_q` are now coord-shaped `(joint_coord_count,)`, matching `joint_q`, unless a caller opts back into the deprecated DOF layout with `newton.use_coord_layout_targets = False`.

resolves #3621

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan
```
uv run --extra dev -m newton.tests --strict-warnings
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Joint position targets now use the coordinate-aligned layout by default, matching joint position data.
  * Applications can temporarily restore the deprecated DOF-shaped layout by setting the configuration option before model construction.

* **Bug Fixes**
  * Models using the deprecated layout now receive a deprecation warning when coordinate and degree-of-freedom counts differ.

* **Documentation**
  * Updated API references, migration guidance, tutorials, and examples to reflect the new default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->