### PR TITLE
Fix camera overshoot for low fps

### DIFF
--- a/changelog/+camera-jitter-fix-a7355d42.fixed.md
+++ b/changelog/+camera-jitter-fix-a7355d42.fixed.md
@@ -1,0 +1,1 @@
+Cap the viewer camera's per-frame damping factor to avoid overshoot-driven oscillation at low framerates.

--- a/newton/_src/viewer/viewer_gui.py
+++ b/newton/_src/viewer/viewer_gui.py
@@ -189,7 +189,7 @@ class ViewerGui:
             desired[:] = 0.0
 
         tau = max(1.0e-4, float(self._cam_damp_tau))
-        self._cam_vel += (desired - self._cam_vel) * (dt / tau)
+        self._cam_vel += (desired - self._cam_vel) * min(1.0, dt / tau)
 
         pos = camera.pos
         camera.pos = type(pos)(

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -78,6 +78,29 @@ class TestViewerCameraSpeed(unittest.TestCase):
         self.assertAlmostEqual(camera.pos.y, 0.0)
         self.assertAlmostEqual(camera.pos.z, 0.0)
 
+    def test_camera_deceleration_is_capped(self):
+        """Check that the camera deceleration is capped to avoid flipping the camera velocity direction."""
+        camera = SimpleNamespace(
+            pos=_Vec3(0.0, 0.0, 0.0),
+            get_front=lambda: (1.0, 0.0, 0.0),
+            get_right=lambda: (0.0, 1.0, 0.0),
+            get_up=lambda: (0.0, 0.0, 1.0),
+        )
+        viewer = SimpleNamespace(camera=camera, camera_speed=2.0)
+        gui = ViewerGui.__new__(ViewerGui)
+        gui._viewer = viewer
+        gui.ui = None
+        velocity_init = np.array([1.0, 0.0, 0.0], dtype=np.float32)  # Non-zero initial velocity
+        gui._cam_vel = velocity_init.copy()
+        gui._cam_damp_tau = 0.1
+
+        key = SimpleNamespace(W=1, UP=2, S=3, DOWN=4, A=5, LEFT=6, D=7, RIGHT=8, Q=9, E=10)
+        pyglet = SimpleNamespace(window=SimpleNamespace(key=key))
+        with patch.dict(sys.modules, {"pyglet": pyglet}):
+            gui.update_camera_from_keys(2.0 * gui._cam_damp_tau, lambda _: False)
+
+        self.assertGreaterEqual(np.dot(camera.pos, velocity_init), 0.0)
+
 
 class TestViewerGLShouldStep(unittest.TestCase):
     """ViewerGL.should_step() state machine: running, paused, and single-step."""


### PR DESCRIPTION
## Description

The camera velocity update is dependent on the viewer frame rate, and currently not capped. For low frame rates, the update can actually flip the camera velocity when going from an accelerated to a non-accelerated state, leading to camera jitter.

This PR caps update step, so that the camera deceleration can at most cancel out the current velocity, but not reverse it.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

A regression test has been added:

```
uv run --extra dev -m newton.tests -k test_camera_deceleration_is_capped
```

## Bug fix

The following example script (showing a box, with a capped frame rate) reproduces the issue. When moving the camera left or right via keyboard, the camera will briefly oscillate when the key is released.

```import time

import warp as wp

import newton
import newton.examples


class Example:
    def __init__(self, viewer, args):
        self.viewer = viewer
        self.time = 0.0

    def step(self):
        time.sleep(0.1)

    def render(self):
        self.viewer.begin_frame(self.time)
        self.viewer.log_shapes(
            name="/box_instance",
            geo_type=newton.GeoType.BOX,
            geo_scale=(0.5, 0.5, 0.5),
            xforms=wp.array([wp.transform([0.0, 0.0, 2.0], wp.quat_identity())], dtype=wp.transform),
        )
        self.viewer.end_frame()
        self.time += 1.0 / 60.0


if __name__ == "__main__":
    viewer, args = newton.examples.init()
    newton.examples.run(Example(viewer, args), args)
```
