### PR TITLE
Support multi-world MuJoCo CPU simulation and masked reset

### DIFF
--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -597,12 +597,19 @@ Multi-world support
 -------------------
 
 Constructing :class:`~newton.solvers.SolverMuJoCo` with
-``separate_worlds=True`` (the default for GPU mode with multiple
-worlds) builds a MuJoCo model from the **first world** only and
-replicates it across all worlds via ``mujoco_warp``. This requires
+``separate_worlds=True`` (the default for any multi-world model) builds
+a MuJoCo model from the **first world** only. The GPU backend replicates
+it through ``mujoco_warp``. The CPU backend shares that model across one
+independent ``MjData`` per Newton world and steps all of them synchronously.
+This requires
 all Newton worlds to be structurally identical (same bodies, joints,
 and shapes); :class:`~newton.solvers.SolverMuJoCo` validates this at
 construction and raises ``ValueError`` on a mismatch.
+
+Calling :meth:`~newton.solvers.SolverMuJoCo.reset` with a world mask
+resets only the selected CPU or GPU runtime worlds. It does not change
+which worlds the next :meth:`~newton.solvers.SolverMuJoCo.step` advances;
+every step advances the complete batch.
 
 Bodies, joints, equality constraints, and mimic constraints cannot have
 a negative world index — assigning any of them to the global world
@@ -623,7 +630,8 @@ same three-phase cycle:
    converted before the integrator runs. The joint-state re-sync
    frequency can be controlled via the ``update_data_interval``
    kwarg for substepping schemes.
-2. **Integrate.** ``mujoco_warp`` steps the MuJoCo model forward by ``dt``.
+2. **Integrate.** The selected backend steps the MuJoCo model forward by ``dt``.
+   On CPU, each world's ``MjData`` is stepped once in world order.
 3. **Pull MuJoCo → Newton.** ``SolverMuJoCo._update_newton_state``
    populates the output ``State`` from the integrated MuJoCo data.
    Kinematic roots pass through unchanged from ``state_in`` (see

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -760,6 +760,7 @@ def convert_mj_coords_to_warp_kernel(
     qpos: wp.array2d[wp.float32],
     qvel: wp.array2d[wp.float32],
     joints_per_world: int,
+    newton_world_offset: int,
     joint_type: wp.array[wp.int32],
     joint_q_start: wp.array[wp.int32],
     joint_qd_start: wp.array[wp.int32],
@@ -779,8 +780,9 @@ def convert_mj_coords_to_warp_kernel(
     joint_qd: wp.array[wp.float32],
 ):
     worldid, jntid = wp.tid()
+    newton_world = worldid + newton_world_offset
 
-    joint_id = joints_per_world * worldid + jntid
+    joint_id = joints_per_world * newton_world + jntid
 
     # Skip loop joints — they have no MuJoCo qpos/qvel entries
     q_i = mj_q_start[jntid]
@@ -891,6 +893,7 @@ def convert_warp_coords_to_mj_kernel(
     joint_qd: wp.array[wp.float32],
     world_mask: wp.array[wp.bool],
     joints_per_world: int,
+    newton_world_offset: int,
     joint_type: wp.array[wp.int32],
     joint_q_start: wp.array[wp.int32],
     joint_qd_start: wp.array[wp.int32],
@@ -907,11 +910,12 @@ def convert_warp_coords_to_mj_kernel(
     qvel: wp.array2d[wp.float32],
 ):
     worldid, jntid = wp.tid()
+    newton_world = worldid + newton_world_offset
 
-    if world_mask and not world_mask[worldid]:
+    if world_mask and not world_mask[newton_world]:
         return
 
-    joint_id = joints_per_world * worldid + jntid
+    joint_id = joints_per_world * newton_world + jntid
 
     # Skip loop joints — they have no MuJoCo qpos/qvel entries
     q_i = mj_q_start[jntid]
@@ -1587,6 +1591,7 @@ def apply_mjc_control_kernel(
     dofs_per_world: wp.int32,
     ctrls_per_world: wp.int32,
     joints_per_world: wp.int32,
+    newton_world_offset: wp.int32,
     use_coord_layout_targets: bool,
     # outputs
     mj_ctrl: wp.array2d[wp.float32],
@@ -1609,6 +1614,7 @@ def apply_mjc_control_kernel(
     For CTRL_DIRECT (source=1), mjc_actuator_to_newton_idx is the ctrl index.
     """
     world, actuator = wp.tid()
+    newton_world = world + newton_world_offset
     source = mjc_actuator_ctrl_source[actuator]
     idx = mjc_actuator_to_newton_idx[actuator]
 
@@ -1617,7 +1623,7 @@ def apply_mjc_control_kernel(
             target_q_idx = mjc_actuator_to_newton_target_q_idx[actuator]
             if target_q_idx < 0:
                 return
-            world_target_q = world * target_q_per_world + target_q_idx
+            world_target_q = newton_world * target_q_per_world + target_q_idx
             axis_idx = mjc_actuator_to_target_q_axis_idx[actuator]
             if axis_idx < 0:
                 if world_target_q < joint_target_q.shape[0]:
@@ -1650,7 +1656,7 @@ def apply_mjc_control_kernel(
                 jnt = mjc_actuator_to_newton_ball_jnt[actuator]
                 assert jnt >= 0
                 template_jnt = jnt % joints_per_world
-                joint_id = world * joints_per_world + template_jnt
+                joint_id = newton_world * joints_per_world + template_jnt
                 q_cj = joint_X_c[joint_id].q
                 aa_mj = wp.quat_rotate(q_cj, aa_newton)
                 mj_ctrl[world, actuator] = aa_mj[axis_idx]
@@ -1661,16 +1667,16 @@ def apply_mjc_control_kernel(
             newton_axis = -(idx + 2)
             axis_idx = mjc_actuator_to_target_q_axis_idx[actuator]
             if axis_idx < 0:
-                world_dof = world * dofs_per_world + newton_axis
+                world_dof = newton_world * dofs_per_world + newton_axis
                 mj_ctrl[world, actuator] = joint_target_qd[world_dof]
             else:
                 # Ball-joint velocity target: rotate into MuJoCo's current child body frame.
                 qd_start = newton_axis - axis_idx
-                qd_base = world * dofs_per_world + qd_start
+                qd_base = newton_world * dofs_per_world + qd_start
                 # target_q_idx for ball-velocity points at the coord-indexed q_start of the ball
                 # quat in joint_q (which is always coord-indexed regardless of layout).
                 target_q_idx = mjc_actuator_to_newton_target_q_idx[actuator]
-                q_base = world * coords_per_world + target_q_idx
+                q_base = newton_world * coords_per_world + target_q_idx
                 w_newton = wp.vec3(
                     joint_target_qd[qd_base + 0],
                     joint_target_qd[qd_base + 1],
@@ -1685,12 +1691,12 @@ def apply_mjc_control_kernel(
                 jnt = mjc_actuator_to_newton_ball_jnt[actuator]
                 assert jnt >= 0
                 template_jnt = jnt % joints_per_world
-                joint_id = world * joints_per_world + template_jnt
+                joint_id = newton_world * joints_per_world + template_jnt
                 q_cj = joint_X_c[joint_id].q
                 w_mj = wp.quat_rotate(q_cj * wp.quat_inverse(r), w_newton)
                 mj_ctrl[world, actuator] = w_mj[axis_idx]
     else:  # CTRL_SOURCE_CTRL_DIRECT
-        world_ctrl_idx = world * ctrls_per_world + idx
+        world_ctrl_idx = newton_world * ctrls_per_world + idx
         if world_ctrl_idx < mujoco_ctrl.shape[0]:
             mj_ctrl[world, actuator] = mujoco_ctrl[world_ctrl_idx]
 
@@ -1704,6 +1710,7 @@ def apply_mjc_body_f_kernel(
     body_world: wp.array[wp.int32],
     gravity: wp.array[wp.vec3],
     body_gravcomp: wp.array2d[float],
+    newton_world_offset: int,
     # outputs
     xfrc_applied: wp.array2d[wp.spatial_vector],
 ):
@@ -1714,7 +1721,8 @@ def apply_mjc_body_f_kernel(
     MuJoCo world contains both local and global bodies.
     """
     world, mjc_body = wp.tid()
-    newton_body = mjc_body_to_newton[world, mjc_body]
+    newton_world = world + newton_world_offset
+    newton_body = mjc_body_to_newton[newton_world, mjc_body]
     if newton_body < 0 or (body_flags[newton_body] & BodyFlags.KINEMATIC) != 0:
         xfrc_applied[world, mjc_body] = wp.spatial_vector(wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0))
         return
@@ -1744,17 +1752,19 @@ def apply_mjc_qfrc_kernel(
     joint_X_c: wp.array[wp.transform],
     joints_per_world: int,
     mj_qd_start: wp.array[wp.int32],
+    newton_world_offset: int,
     # outputs
     qfrc_applied: wp.array2d[wp.float32],
 ):
     worldid, jntid = wp.tid()
+    newton_world = worldid + newton_world_offset
 
     # Skip loop joints — they have no MuJoCo DOF entries
     qd_i = mj_qd_start[jntid]
     if qd_i < 0:
         return
 
-    joint_id = joints_per_world * worldid + jntid
+    joint_id = joints_per_world * newton_world + jntid
     wq_i = joint_q_start[joint_id]
     wqd_i = joint_qd_start[joint_id]
     jtype = joint_type[joint_id]
@@ -1790,11 +1800,13 @@ def apply_mjc_free_joint_f_to_body_f_kernel(
     body_flags: wp.array[wp.int32],
     body_free_qd_start: wp.array[wp.int32],
     joint_f: wp.array[wp.float32],
+    newton_world_offset: int,
     # outputs
     xfrc_applied: wp.array2d[wp.spatial_vector],
 ):
     worldid, mjc_body = wp.tid()
-    newton_body = mjc_body_to_newton[worldid, mjc_body]
+    newton_world = worldid + newton_world_offset
+    newton_body = mjc_body_to_newton[newton_world, mjc_body]
     if newton_body < 0 or (body_flags[newton_body] & BodyFlags.KINEMATIC) != 0:
         return
 
@@ -2995,13 +3007,15 @@ def convert_rigid_forces_from_mj_kernel(
     mjw_cacc: wp.array2d[wp.spatial_vector],
     mjw_cvel: wp.array2d[wp.spatial_vector],
     mjw_cint: wp.array2d[wp.spatial_vector],
+    newton_world_offset: int,
     # outputs
     body_qdd: wp.array[wp.spatial_vector],
     body_parent_f: wp.array[wp.spatial_vector],
 ):
     """Update RNE-computed rigid forces from mj_warp com-based forces."""
     world, mjc_body = wp.tid()
-    newton_body = mjc_body_to_newton[world, mjc_body]
+    newton_world = world + newton_world_offset
+    newton_body = mjc_body_to_newton[newton_world, mjc_body]
 
     if newton_body < 0:
         return
@@ -3043,6 +3057,7 @@ def convert_qfrc_actuator_from_mj_kernel(
     body_com: wp.array[wp.vec3],
     mj_q_start: wp.array[wp.int32],
     mj_qd_start: wp.array[wp.int32],
+    newton_world_offset: int,
     # output
     qfrc_actuator: wp.array[wp.float32],
 ):
@@ -3057,8 +3072,9 @@ def convert_qfrc_actuator_from_mj_kernel(
     are copied directly.
     """
     worldid, jntid = wp.tid()
+    newton_world = worldid + newton_world_offset
 
-    joint_id = joints_per_world * worldid + jntid
+    joint_id = joints_per_world * newton_world + jntid
 
     # Skip loop joints — they have no MuJoCo DOF entries
     q_i = mj_q_start[jntid]

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3701,7 +3701,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
         Args:
             model: The model to be simulated.
-            separate_worlds: If True, each Newton world is mapped to a separate MuJoCo world. Defaults to `not use_mujoco_cpu`.
+            separate_worlds: If True, each Newton world is mapped to an independent MuJoCo runtime world.
+                Defaults to True for multi-world models on both backends.
             njmax: Maximum number of constraints per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
             nconmax: Number of contact points per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
             iterations: Number of solver iterations. If None, uses model custom attribute or MuJoCo's default (100).
@@ -3971,7 +3972,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         stacklevel=2,
                     )
         if separate_worlds is None:
-            separate_worlds = not use_mujoco_cpu and model.world_count > 1
+            separate_worlds = model.world_count > 1
         # Buffers for the fast-path contact conversion optimisation.
         # See _convert_contacts_to_mjwarp / convert_newton_contacts_to_mjwarp_kernel.
         # Initialised before _convert_to_mjc because notify_model_changed (called
@@ -4074,13 +4075,22 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
     @override
     def step(self, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float) -> None:
         if self.use_mujoco_cpu:
-            self._apply_mjc_control(self.model, state_in, control, self.mj_data)
-            if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
-                # XXX updating the mujoco state at every step may introduce numerical instability
-                self._update_mjc_data(self.mj_data, self.model, state_in)
             self.mj_model.opt.timestep = dt
-            self._mujoco.mj_step(self.mj_model, self.mj_data)
-            self._update_newton_state(self.model, state_out, self.mj_data, state_prev=state_in)
+            for world, data in enumerate(self.mj_data_by_world):
+                self._apply_mjc_control(self.model, state_in, control, data, newton_world_offset=world)
+                if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
+                    # XXX updating the mujoco state at every step may introduce numerical instability
+                    self._update_mjc_data(data, self.model, state_in, newton_world_offset=world)
+                self._mujoco.mj_step(self.mj_model, data)
+                self._update_newton_state(
+                    self.model,
+                    state_out,
+                    data,
+                    state_prev=state_in,
+                    newton_world_offset=world,
+                    evaluate_fk=False,
+                )
+            eval_fk(self.model, state_out.joint_q, state_out.joint_qd, state_out)
         else:
             with wp.ScopedDevice(self.model.device), self._scoped_mujoco_warp_execution():
                 self._enable_rne_postconstraint(state_out)
@@ -4154,7 +4164,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
         world_mask = self._normalize_reset_world_mask(world_mask)
         world_count = self.model.world_count
-        native_template_world_selected = not self.use_mujoco_cpu or world_mask is None or bool(world_mask.numpy()[0])
+        selected_worlds = (
+            np.ones(world_count, dtype=bool) if world_mask is None else world_mask.numpy()[:world_count].astype(bool)
+        )
 
         # Reset joint coordinates/velocities to model defaults for the selected
         # worlds. body_q/body_qd are FK outputs and intentionally not touched.
@@ -4185,26 +4197,23 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 # lost before the next sync. The sleeping path synchronizes
                 # below before rebuilding its cached data.
                 if self.update_data_interval != 1 and not self.enable_sleeping:
-                    data = self.mj_data if self.use_mujoco_cpu else self.mjw_data
-                    if data is not None and native_template_world_selected:
-                        self._update_mjc_data(data, self.model, state, world_mask=world_mask)
+                    if self.use_mujoco_cpu:
+                        for world, data in enumerate(self.mj_data_by_world):
+                            if selected_worlds[world]:
+                                self._update_mjc_data(data, self.model, state, newton_world_offset=world)
+                    elif self.mjw_data is not None:
+                        self._update_mjc_data(self.mjw_data, self.model, state, world_mask=world_mask)
 
         # Clear the internal buffers that persist between steps.
         if self.use_mujoco_cpu:
-            d = self.mj_data
-            if d is None:
-                return
-            # Native MuJoCo owns one template-world MjData instance even when
-            # separate_worlds=True was requested for a multi-world Newton
-            # model. Its persistent buffers therefore belong to local world 0.
-            if not native_template_world_selected:
-                return
-            # Single MjData instance: clear the whole buffers (no per-world mask).
-            d.qacc_warmstart[:] = 0.0
-            d.qfrc_applied[:] = 0.0
-            d.ctrl[:] = 0.0
-            d.act[:] = 0.0
-            d.xfrc_applied[:] = 0.0
+            for world, data in enumerate(self.mj_data_by_world):
+                if not selected_worlds[world]:
+                    continue
+                data.qacc_warmstart[:] = 0.0
+                data.qfrc_applied[:] = 0.0
+                data.ctrl[:] = 0.0
+                data.act[:] = 0.0
+                data.xfrc_applied[:] = 0.0
             return
 
         d = self.mjw_data
@@ -4822,7 +4831,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_model.eq_data[:] = self.mjw_model.eq_data.numpy()[0]
         self.mj_model.eq_solref[:] = self.mjw_model.eq_solref.numpy()[0]
         self.mj_model.eq_solimp[:] = self.mjw_model.eq_solimp.numpy()[0]
-        self.mj_data.eq_active[:] = self.mjw_data.eq_active.numpy()[0]
+        eq_active = self.mjw_data.eq_active.numpy()
+        for world, data in enumerate(self.mj_data_by_world):
+            data.eq_active[:] = eq_active[world]
 
     def _sync_worldbody_geom_xposes(self) -> None:
         """Refresh derived poses that MJWarp leaves fixed after data creation.
@@ -4899,7 +4910,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # Check if the data is a mujoco_warp Data object
         return hasattr(data, "nworld")
 
-    def _apply_mjc_control(self, model: Model, state: State, control: Control | None, mj_data: MjWarpData | MjData):
+    def _apply_mjc_control(
+        self,
+        model: Model,
+        state: State,
+        control: Control | None,
+        mj_data: MjWarpData | MjData,
+        *,
+        newton_world_offset: int = 0,
+    ):
         if control is None or control.joint_f is None:
             if state.body_f is None:
                 return
@@ -4917,22 +4936,21 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             qfrc = wp.zeros((1, len(mj_data.qfrc_applied)), dtype=wp.float32, device=model.device)
             xfrc = wp.zeros((1, len(mj_data.xfrc_applied)), dtype=wp.spatial_vector, device=model.device)
             nworld = 1
-        joints_per_world = (
-            model.joint_count // model.world_count if single_world_template else model.joint_count // nworld
-        )
+        newton_world_count = model.world_count if single_world_template else nworld
+        joints_per_world = model.joint_count // newton_world_count
         if control is not None:
             # Use instance arrays (built during MuJoCo model construction)
             if self.mjc_actuator_ctrl_source is not None and self.mjc_actuator_to_newton_idx is not None:
                 nu = self.mjc_actuator_ctrl_source.shape[0]
-                dofs_per_world = model.joint_dof_count // nworld if nworld > 0 else model.joint_dof_count
+                dofs_per_world = model.joint_dof_count // newton_world_count
                 target_q_total = control.joint_target_q.shape[0] if control.joint_target_q is not None else 0
-                target_q_per_world = target_q_total // nworld if nworld > 0 else target_q_total
-                coords_per_world = model.joint_coord_count // nworld if nworld > 0 else model.joint_coord_count
+                target_q_per_world = target_q_total // newton_world_count
+                coords_per_world = model.joint_coord_count // newton_world_count
 
                 # Get mujoco.ctrl (None if not available - won't be accessed if no CTRL_DIRECT actuators)
                 mujoco_ctrl_ns = getattr(control, "mujoco", None)
                 mujoco_ctrl = getattr(mujoco_ctrl_ns, "ctrl", None) if mujoco_ctrl_ns is not None else None
-                ctrls_per_world = mujoco_ctrl.shape[0] // nworld if mujoco_ctrl is not None and nworld > 0 else 0
+                ctrls_per_world = mujoco_ctrl.shape[0] // newton_world_count if mujoco_ctrl is not None else 0
 
                 wp.launch(
                     apply_mjc_control_kernel,
@@ -4953,6 +4971,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         dofs_per_world,
                         ctrls_per_world,
                         joints_per_world,
+                        newton_world_offset,
                         model.use_coord_layout_targets,
                     ],
                     outputs=[
@@ -4975,6 +4994,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     model.joint_X_c,
                     joints_per_world,
                     self.mj_qd_start,
+                    newton_world_offset,
                 ],
                 outputs=[
                     qfrc,
@@ -4996,6 +5016,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     model.body_world,
                     model.gravity,
                     self.mjw_model.body_gravcomp,
+                    newton_world_offset,
                 ],
                 outputs=[
                     xfrc,
@@ -5013,6 +5034,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     model.body_flags,
                     self.body_free_qd_start,
                     control.joint_f,
+                    newton_world_offset,
                 ],
                 outputs=[
                     xfrc,
@@ -5030,6 +5052,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         model: Model,
         state: State | None = None,
         world_mask: wp.array[wp.bool] | None = None,
+        *,
+        newton_world_offset: int = 0,
     ):
         is_mjwarp = SolverMuJoCo._data_is_mjwarp(mj_data)
         single_world_template = False
@@ -5070,6 +5094,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 joint_qd,
                 world_mask,
                 joints_per_world,
+                newton_world_offset,
                 model.joint_type,
                 model.joint_q_start,
                 model.joint_qd_start,
@@ -5117,6 +5142,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         state: State,
         mj_data: MjWarpData | MjData,
         state_prev: State,
+        *,
+        newton_world_offset: int = 0,
+        evaluate_fk: bool = True,
     ):
         """Update a Newton state from MuJoCo coordinates and kinematics.
 
@@ -5154,6 +5182,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 qpos,
                 qvel,
                 joints_per_world,
+                newton_world_offset,
                 model.joint_type,
                 model.joint_q_start,
                 model.joint_qd_start,
@@ -5173,7 +5202,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             device=model.device,
         )
 
-        eval_fk(model, state.joint_q, state.joint_qd, state)
+        if evaluate_fk:
+            eval_fk(model, state.joint_q, state.joint_qd, state)
 
         # Update rigid force fields on state.
         if state.body_qdd is not None or state.body_parent_f is not None:
@@ -5191,6 +5221,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     self.mjw_data.cacc,
                     self.mjw_data.cvel,
                     self.mjw_data.cfrc_int,
+                    newton_world_offset,
                 ],
                 outputs=[state.body_qdd, state.body_parent_f],
                 device=model.device,
@@ -5221,6 +5252,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     model.body_com,
                     self.mj_q_start,
                     self.mj_qd_start,
+                    newton_world_offset,
                 ],
                 outputs=[qfrc_actuator],
                 device=model.device,
@@ -5503,7 +5535,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         Args:
             model: The Newton model to convert.
             state: The Newton state to convert (optional).
-            separate_worlds: If True, each world is a separate MuJoCo simulation. If None, defaults to True for GPU mode (not use_mujoco_cpu).
+            separate_worlds: If True, each world has independent MuJoCo runtime state. If None, defaults to
+                True for multi-world models.
             iterations: Maximum solver iterations. If None, uses model custom attribute or MuJoCo's default (100).
             ls_iterations: Maximum line search iterations. If None, uses model custom attribute or MuJoCo's default (50).
             njmax: Maximum number of constraints per world.
@@ -7351,6 +7384,12 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             self.mj_model.actuator_biasprm[actuator_id, 2] = dampratio
         self.mj_data = mujoco.MjData(self.mj_model)
         mujoco.mj_setConst(self.mj_model, self.mj_data)
+        cpu_world_count = model.world_count if self.use_mujoco_cpu and separate_worlds else 1
+        self.mj_data_by_world = (
+            self.mj_data,
+            *(mujoco.MjData(self.mj_model) for _ in range(cpu_world_count - 1)),
+        )
+        """Native MuJoCo runtime state for each synchronously stepped Newton world."""
 
         # Build MuJoCo qpos/qvel start index arrays for coordinate conversion kernels.
         # These map Newton template joint index → MuJoCo qpos/qvel start.
@@ -7388,13 +7427,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 qpos_treeid_np[qpos_start:qpos_end] = int(self.mj_model.body_treeid[bodyid])
             self._sleep_qpos_treeid = wp.array(qpos_treeid_np, dtype=wp.int32, device=model.device)
 
-        self._update_mjc_data(self.mj_data, model, state)
+        for world, data in enumerate(self.mj_data_by_world):
+            self._update_mjc_data(data, model, state, newton_world_offset=world)
 
         # fill some MjWarp model fields that are outdated after _update_mjc_data.
         # just setting qpos0 to d.qpos leads to weird behavior here, needs
         # to be investigated.
 
-        mujoco.mj_forward(self.mj_model, self.mj_data)
+        for data in self.mj_data_by_world:
+            mujoco.mj_forward(self.mj_model, data)
 
         # now that the model is compiled, get the actual geom indices and compute
         # shape transform corrections
@@ -7740,6 +7781,10 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             # so far we have only defined the first world,
             # now complete the data from the Newton model
             self.notify_model_changed(ModelFlags.ALL)
+            if self.use_mujoco_cpu:
+                for world, data in enumerate(self.mj_data_by_world):
+                    self._update_mjc_data(data, model, state, newton_world_offset=world)
+                    mujoco.mj_forward(self.mj_model, data)
 
             if target_filename:
                 # Only persist ``solreflimit`` for ``SOLREF_MODE_RAW`` joints
@@ -8052,7 +8097,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         has_kinematic_bodies = bool(np.any((self.model.body_flags.numpy() & int(BodyFlags.KINEMATIC)) != 0))
         if not has_kinematic_bodies:
             if self.use_mujoco_cpu:
-                self._mujoco.mj_setConst(self.mj_model, self.mj_data)
+                self._set_const_cpu_data()
             else:
                 self._mujoco_warp.set_const_0(self.mjw_model, self.mjw_data)
             return
@@ -8062,13 +8107,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         if self.use_mujoco_cpu:
             actuator_biasprm = self.mj_model.actuator_biasprm.copy()
             self.mj_model.dof_armature[:] = self.mjw_model.dof_armature.numpy()[0]
-            self._mujoco.mj_setConst(self.mj_model, self.mj_data)
+            self._set_const_cpu_data()
             physical_meaninertia = float(self.mj_model.stat.meaninertia)
 
             self._update_body_properties()
             self.mj_model.actuator_biasprm[:] = actuator_biasprm
             self.mj_model.dof_armature[:] = self.mjw_model.dof_armature.numpy()[0]
-            self._mujoco.mj_setConst(self.mj_model, self.mj_data)
+            self._set_const_cpu_data()
             self.mj_model.stat.meaninertia = physical_meaninertia
         else:
             actuator_biasprm = wp.clone(self.mjw_model.actuator_biasprm)
@@ -8079,6 +8124,11 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             wp.copy(self.mjw_model.actuator_biasprm, actuator_biasprm)
             self._mujoco_warp.set_const_0(self.mjw_model, self.mjw_data)
             wp.copy(self.mjw_model.stat.meaninertia, physical_meaninertia)
+
+    def _set_const_cpu_data(self) -> None:
+        """Recompute shared model constants and refresh every native world."""
+        for data in self.mj_data_by_world:
+            self._mujoco.mj_setConst(self.mj_model, data)
 
     def _update_body_properties(self, apply_kinematic_armature: bool = True):
         """Update body-property dependent MuJoCo DOF parameters.

--- a/newton/tests/test_mujoco_reset.py
+++ b/newton/tests/test_mujoco_reset.py
@@ -13,7 +13,7 @@ from newton import StateFlags
 from newton.solvers import SolverMuJoCo
 
 
-def _build_two_world_model(world_count: int = 2) -> newton.Model:
+def _build_two_world_model(world_count: int = 2, device=None) -> newton.Model:
     """Build a model of ``world_count`` identical free + revolute articulations."""
     template = newton.ModelBuilder()
     body0 = template.add_link(mass=0.2, xform=wp.transform((0.0, 0.0, 1.0), wp.quat_identity()))
@@ -35,7 +35,7 @@ def _build_two_world_model(world_count: int = 2) -> newton.Model:
     builder.add_ground_plane()
     for i in range(world_count):
         builder.add_world(template, xform=wp.transform((i * 2.0, 0.0, 0.0), wp.quat_identity()))
-    return builder.finalize()
+    return builder.finalize(device=device)
 
 
 class TestMuJoCoReset(unittest.TestCase):
@@ -103,39 +103,44 @@ class TestMuJoCoReset(unittest.TestCase):
             self.assertTrue(np.all(values[0] == 0.0), f"{name} not cleared in masked world 0")
             self.assertTrue(np.all(values[1] == 7.0), f"{name} wrongly cleared in unmasked world 1")
 
-    def test_native_cpu_reset_honors_template_world_mask(self):
-        """Reset native MuJoCo buffers only when local world 0 is selected."""
+    def test_native_cpu_reset_honors_each_world_mask(self):
+        """Reset only the selected native MuJoCo world's persistent buffers."""
         solver = SolverMuJoCo(self.model, separate_worlds=True, use_mujoco_cpu=True)
-        data = solver.mj_data
-        buffers = tuple(
-            buffer
-            for buffer in (
-                data.qacc_warmstart,
-                data.qfrc_applied,
-                data.ctrl,
-                data.act,
-                data.xfrc_applied,
+        self.assertEqual(len(solver.mj_data_by_world), 2)
+
+        def buffers(data):
+            return tuple(
+                buffer
+                for buffer in (
+                    data.qacc_warmstart,
+                    data.qfrc_applied,
+                    data.ctrl,
+                    data.act,
+                    data.xfrc_applied,
+                )
+                if buffer.size > 0
             )
-            if buffer.size > 0
-        )
-        for mask_values, expected in (
-            ((False, False, True), 7.0),
-            ((False, True, False), 7.0),
-            ((True, False, False), 0.0),
+
+        for mask_values, expected_by_world in (
+            ((False, False, True), (7.0, 7.0)),
+            ((False, True, False), (7.0, 0.0)),
+            ((True, False, False), (0.0, 7.0)),
         ):
             with self.subTest(mask=mask_values):
-                for buffer in buffers:
-                    buffer[:] = 7.0
+                for data in solver.mj_data_by_world:
+                    for buffer in buffers(data):
+                        buffer[:] = 7.0
                 solver.reset(
                     self.model.state(),
                     world_mask=wp.array(mask_values, dtype=wp.bool, device=self.model.device),
                     flags=0,
                 )
-                for buffer in buffers:
-                    np.testing.assert_array_equal(buffer, expected)
+                for data, expected in zip(solver.mj_data_by_world, expected_by_world, strict=True):
+                    for buffer in buffers(data):
+                        np.testing.assert_array_equal(buffer, expected)
 
-    def test_native_cpu_masked_joint_reset_preserves_template_state(self):
-        """Preserve native MuJoCo coordinates when local world 0 is unselected."""
+    def test_native_cpu_masked_joint_reset_updates_only_selected_world(self):
+        """Synchronize reset coordinates to one native world without changing the other."""
         solver = SolverMuJoCo(
             self.model,
             separate_worlds=True,
@@ -148,33 +153,66 @@ class TestMuJoCoReset(unittest.TestCase):
         dofs_per_world = self.model.joint_dof_count // self.model.world_count
         default_q = self.model.joint_q.numpy()
         default_qd = self.model.joint_qd.numpy()
+        native_defaults = tuple((data.qpos.copy(), data.qvel.copy()) for data in solver.mj_data_by_world)
 
-        for mask_values in ((False, True, False), (False, False, True)):
-            with self.subTest(mask=mask_values):
-                joint_q_before = np.arange(self.model.joint_coord_count, dtype=np.float32) + 30.0
-                joint_qd_before = np.arange(self.model.joint_dof_count, dtype=np.float32) + 40.0
-                state.joint_q.assign(joint_q_before)
-                state.joint_qd.assign(joint_qd_before)
-                solver.mj_data.qpos[:] = np.arange(solver.mj_data.qpos.size) + 10.0
-                solver.mj_data.qvel[:] = np.arange(solver.mj_data.qvel.size) + 20.0
-                qpos_before = solver.mj_data.qpos.copy()
-                qvel_before = solver.mj_data.qvel.copy()
+        joint_q_before = np.arange(self.model.joint_coord_count, dtype=np.float32) + 30.0
+        joint_qd_before = np.arange(self.model.joint_dof_count, dtype=np.float32) + 40.0
+        state.joint_q.assign(joint_q_before)
+        state.joint_qd.assign(joint_qd_before)
+        for world, data in enumerate(solver.mj_data_by_world):
+            data.qpos[:] = np.arange(data.qpos.size) + 10.0 + world * 100.0
+            data.qvel[:] = np.arange(data.qvel.size) + 20.0 + world * 100.0
+        world0_qpos = solver.mj_data_by_world[0].qpos.copy()
+        world0_qvel = solver.mj_data_by_world[0].qvel.copy()
 
-                solver.reset(
-                    state,
-                    world_mask=wp.array(mask_values, dtype=wp.bool, device=self.model.device),
-                    flags=flags,
-                )
+        solver.reset(
+            state,
+            world_mask=wp.array([False, True, False], dtype=wp.bool, device=self.model.device),
+            flags=flags,
+        )
 
-                np.testing.assert_array_equal(solver.mj_data.qpos, qpos_before)
-                np.testing.assert_array_equal(solver.mj_data.qvel, qvel_before)
-                expected_q = joint_q_before.copy()
-                expected_qd = joint_qd_before.copy()
-                if mask_values[1]:
-                    expected_q[coords_per_world:] = default_q[coords_per_world:]
-                    expected_qd[dofs_per_world:] = default_qd[dofs_per_world:]
-                np.testing.assert_array_equal(state.joint_q.numpy(), expected_q)
-                np.testing.assert_array_equal(state.joint_qd.numpy(), expected_qd)
+        np.testing.assert_array_equal(solver.mj_data_by_world[0].qpos, world0_qpos)
+        np.testing.assert_array_equal(solver.mj_data_by_world[0].qvel, world0_qvel)
+        expected_q = joint_q_before.copy()
+        expected_qd = joint_qd_before.copy()
+        expected_q[coords_per_world:] = default_q[coords_per_world:]
+        expected_qd[dofs_per_world:] = default_qd[dofs_per_world:]
+        np.testing.assert_array_equal(state.joint_q.numpy(), expected_q)
+        np.testing.assert_array_equal(state.joint_qd.numpy(), expected_qd)
+        np.testing.assert_allclose(solver.mj_data_by_world[1].qpos, native_defaults[1][0], atol=1.0e-6)
+        np.testing.assert_allclose(solver.mj_data_by_world[1].qvel, native_defaults[1][1], atol=1.0e-6)
+
+    def _assert_native_cpu_steps_all_worlds_with_row_local_forces(self, model: newton.Model):
+        solver = SolverMuJoCo(
+            model,
+            use_mujoco_cpu=True,
+            disable_contacts=True,
+        )
+        state_in = model.state()
+        state_out = model.state()
+        control = model.control()
+        forces = np.zeros(model.joint_dof_count, dtype=np.float32)
+        dofs_per_world = model.joint_dof_count // model.world_count
+        revolute_dof = dofs_per_world - 1
+        forces[revolute_dof] = 1.0
+        forces[dofs_per_world + revolute_dof] = -2.0
+        control.joint_f.assign(forces)
+        newton.eval_fk(model, state_in.joint_q, state_in.joint_qd, state_in)
+
+        solver.step(state_in, state_out, control, None, 0.01)
+
+        qd = state_out.joint_qd.numpy()
+        self.assertGreater(qd[revolute_dof], 0.0)
+        self.assertLess(qd[dofs_per_world + revolute_dof], 0.0)
+        self.assertEqual(solver._step, 1)
+
+    def test_native_cpu_steps_all_worlds_with_row_local_forces(self):
+        """Advance every native world once and apply each CUDA row's force independently."""
+        self._assert_native_cpu_steps_all_worlds_with_row_local_forces(self.model)
+
+    def test_native_cpu_steps_all_worlds_with_cpu_state(self):
+        """Advance the complete batch when Newton state also resides on CPU."""
+        self._assert_native_cpu_steps_all_worlds_with_row_local_forces(_build_two_world_model(device="cpu"))
 
     def test_reset_all_worlds(self):
         """A ``None`` mask clears every world."""


### PR DESCRIPTION
## Summary

- share one compiled MuJoCo model across one independent `MjData` per Newton world
- synchronously step every CPU world while preserving row-local state, control, and force mapping
- apply `SolverMuJoCo.reset(..., world_mask=...)` only to selected native CPU worlds
- keep `mj_data` as the first-world debug handle and expose `mj_data_by_world` for the complete native batch

Closes #4102.

## Semantics

`step()` always advances the full batch. The mask is a reset selection only; this PR does not add selected-row CPU stepping. Multi-world CPU mode still requires the existing homogeneous-world topology contract.

## Tests

- public two-world CPU stepping with opposite row-local joint forces, with Newton state on CUDA and CPU
- selected native buffer reset and joint-state synchronization while unselected worlds remain exact
- full `test_mujoco_reset` suite
- CPU body-force and equality/loop-constraint suites
- broad MuJoCo solver/reset/equality run (the sole initial error was a missing optional `pxr`; the importer test passed after installing the `importers` extra)
- pre-commit hooks on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPU support for independently simulated multi-world MuJoCo models.
  * Multi-world models now separate worlds by default across CPU and GPU backends.
  * Added per-world stepping, state synchronization, and masked resets.
  * Improved support for mapping and simulating selected world ranges.

* **Bug Fixes**
  * Fixed CPU resets and force application to correctly affect only selected worlds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->