### PR TITLE
Stabilize Panda hydro cup placement

### DIFF
--- a/changelog/+panda-hydro-placement-a4c1e8f2.fixed.md
+++ b/changelog/+panda-hydro-placement-a4c1e8f2.fixed.md
@@ -1,0 +1,1 @@
+Keep the Panda hydroelastic example's cup placement stable by enabling deterministic contact generation by default and using compliant finger actuator gains.

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -149,10 +149,13 @@ class Example:
         builder.joint_q[:9] = [*init_q, 0.05, 0.05]
         builder.joint_target_q[:9] = [*init_q, 1.0, 1.0]
 
-        builder.joint_target_ke[:9] = [650.0] * 9
-        builder.joint_target_kd[:9] = [100.0] * 9
+        # Compliant finger drives avoid releasing stored squeeze energy into lightweight objects.
+        builder.joint_target_ke[:7] = [650.0] * 7
+        builder.joint_target_ke[7:9] = [100.0] * 2
+        builder.joint_target_kd[:7] = [100.0] * 7
+        builder.joint_target_kd[7:9] = [20.0] * 2
         builder.joint_effort_limit[:7] = [80.0] * 7
-        builder.joint_effort_limit[7:9] = [20.0] * 2
+        builder.joint_effort_limit[7:9] = [5.0] * 2
         builder.joint_armature[:7] = [0.1] * 7
         builder.joint_armature[7:9] = [0.5] * 2
 
@@ -221,6 +224,7 @@ class Example:
 
         # Object to manipulate
         self.put_in_cup = True
+        self.cup_body_local = None
 
         if self.scene == SceneType.PEN:
             radius = 0.005
@@ -268,8 +272,8 @@ class Example:
                 wp.vec3(self.cup_pos),
                 wp.quat_identity(),
             )
-            cup_body = builder.add_body(label="cup", xform=cup_xform)
-            builder.add_shape_mesh(body=cup_body, mesh=cup_mesh, cfg=shape_cfg_meshes, opacity=CUP_OPACITY)
+            self.cup_body_local = builder.add_body(label="cup", xform=cup_xform)
+            builder.add_shape_mesh(body=self.cup_body_local, mesh=cup_mesh, cfg=shape_cfg_meshes, opacity=CUP_OPACITY)
 
         # build model for IK
         self.model_single = copy.deepcopy(builder).finalize()
@@ -441,6 +445,7 @@ class Example:
             self.viewer.show_hydro_contact_surface = self.show_isosurface
 
     def test_final(self):
+        """Verify that the object is lifted and placed in the upright cup."""
         # Verify that the object was picked up by checking the maximum height reached
         initial_z = self.object_pos[2]
         min_lift_height = 0.15  # Object should be lifted at least 15cm above initial position
@@ -455,27 +460,32 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # In-cup placement check remains disabled pending newton-physics/newton#1337.
-        # With --deterministic the placement does succeed (measured 19mm from the
-        # cup center against a 50mm tolerance), but wp.DeterministicMode.RUN_TO_RUN
-        # only guarantees repeatability within one GPU architecture, so that margin
-        # is not established across the CI fleet. Re-enable once determinism is
-        # verified on every target architecture.
-        # # Verify that the object ended up in the cup
-        # if self.put_in_cup:
-        #     body_q = self.state_0.body_q.numpy()
-        #     cup_x, cup_y, cup_z = self.cup_pos
-        #     tolerance_xy = 0.05
-        #     min_z = cup_z - 0.05
-        #
-        #     for world_idx in range(self.world_count):
-        #         object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
-        #         x, y, z = body_q[object_body_idx][:3]
-        #         assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
-        #             f"World {world_idx}: Object is not in the cup. "
-        #             f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
-        #             f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
-        #         )
+        if self.cup_body_local is None:
+            return
+
+        body_q = self.state_0.body_q.numpy()
+        tolerance_xy = 0.02
+        min_cup_up_z = 0.95
+
+        for world_idx in range(self.world_count):
+            body_offset = world_idx * self.bodies_per_world
+            object_position = body_q[body_offset + self.object_body_local][:3]
+            cup_pose = body_q[body_offset + self.cup_body_local]
+            cup_position = cup_pose[:3]
+            cup_rotation = cup_pose[3:]
+            cup_up_z = 1.0 - 2.0 * (cup_rotation[0] ** 2 + cup_rotation[1] ** 2)
+            horizontal_offset = float(np.linalg.norm(object_position[:2] - cup_position[:2]))
+
+            assert cup_up_z > min_cup_up_z, (
+                f"World {world_idx}: Cup fell over. "
+                f"Cup pose={cup_pose.tolist()}, up_z={cup_up_z:.3f} "
+                f"(expected > {min_cup_up_z})"
+            )
+            assert horizontal_offset < tolerance_xy and object_position[2] > cup_position[2] - 0.05, (
+                f"World {world_idx}: Object is not in the cup. "
+                f"Object pos={object_position.tolist()}, cup pos={cup_position.tolist()}, "
+                f"horizontal offset={horizontal_offset:.3f} (expected < {tolerance_xy})"
+            )
 
     def setup_ik(self):
         self.ee_index = 10
@@ -553,10 +563,10 @@ class Example:
         parser.add_argument(
             "--deterministic",
             action=argparse.BooleanOptionalAction,
-            default=False,
+            default=True,
             help=(
                 "Make contact generation and ordering reproducible across runs on the same GPU. "
-                "Costs a few percent of step time."
+                "Enabled by default to keep the pick-and-place sequence stable; costs a few percent of step time."
             ),
         )
         parser.add_argument(

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -686,8 +686,7 @@ add_example_test(
     TestRobotExamples,
     name="robot.example_robot_panda_hydro",
     devices=cuda_test_devices,
-    # Deterministic contacts keep the pick-and-place check from flaking.
-    test_options={"usd_required": True, "num-frames": 720, "deterministic": True},
+    test_options={"usd_required": True, "num-frames": 720},
     use_viewer=True,
 )
 


### PR DESCRIPTION
## Description

Stabilize the Panda hydroelastic pick-and-place sequence so the pen reliably lands inside the cup.

- Give the finger joints compliant gains and a lower effort limit instead of reusing the stiff arm-drive settings. This prevents stored squeeze energy from launching the lightweight pen.
- Enable deterministic hydroelastic contact generation by default while retaining `--no-deterministic` for performance experiments.
- Restore end-state checks that verify the cup remains upright and the object finishes within 20 mm of the cup center.
- Exercise the real example defaults in the generated example test and add a changelog fragment.

Related to #1337.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```console
uv run --extra dev --extra examples -m newton.tests -k test_robot.example_robot_panda_hydro_cuda_0
uv run --extra examples python -m newton.examples.robot.example_robot_panda_hydro --device cuda:0 --test --quiet --viewer null --num-frames 720 --scene cube
uv run --extra examples python -m newton.examples.robot.example_robot_panda_hydro --device cuda:0 --test --quiet --viewer null --num-frames 720 --world-count 2
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-31
```

The generated CUDA example test was verified to fail without the fix: the cup finished horizontal with `up_z=0.000`. It passes with the fix. Five consecutive fresh-process runs also passed the stricter 20 mm placement check, and five runs with `--no-deterministic` passed the original placement check.

## Bug fix

**Steps to reproduce:**

1. Run the Panda hydroelastic example with its default pen scene.
2. Repeat in fresh processes to vary GPU contact and solver ordering.
3. Observe that the stiff finger drives can launch the pen; it lands beside the cup and can tip the cup over.

**Minimal reproduction:**

```console
uv run --extra examples python -m newton.examples.robot.example_robot_panda_hydro --device cuda:0 --test --quiet --viewer null --num-frames 720
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Panda hydroelastic example stability by using deterministic contact generation.
  * Adjusted gripper control settings to support more reliable cup handling.
  * Re-enabled validation that the cup remains upright and the object lands inside it.

* **Tests**
  * Updated the Panda example test to reflect the example’s default deterministic behavior.
  * Added documentation for the final-state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->