### PR TITLE
Remove deprecated MeshAdjacency dict-based edge API

### DIFF
--- a/changelog/3514.removed.1.md
+++ b/changelog/3514.removed.1.md
@@ -1,0 +1,1 @@
+Remove the deprecated `MeshAdjacency.edges` dict accessor and the `MeshAdjacency.Edge` record class; read the `edge_indices` / `edge_tri_indices` arrays instead.

--- a/changelog/3514.removed.2.md
+++ b/changelog/3514.removed.2.md
@@ -1,0 +1,1 @@
+Remove the deprecated `indices` argument of `MeshAdjacency`; pass `tri_indices` instead.

--- a/changelog/3514.removed.md
+++ b/changelog/3514.removed.md
@@ -1,0 +1,1 @@
+Remove the deprecated `MeshAdjacency.add_edge`; construct a `MeshAdjacency` with `edge_indices` (`[o0, o1, v0, v1]` rows) instead.

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -5,7 +5,6 @@ import os
 import warnings
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import cast, overload
 from urllib.parse import urlparse
 
@@ -376,23 +375,7 @@ class MeshAdjacency:
             :meth:`init_vertex_adjacency` returns early when this is already ``True``.
         indices, spring_indices, tet_indices: The triangle / spring / tetrahedron topology this
             adjacency is built over, kept from the constructor for :meth:`init_vertex_adjacency`.
-
-    .. note::
-        The :attr:`edges` dict is a deprecated compatibility shim (it emits a
-        ``DeprecationWarning``); use the ``edge_indices`` / ``edge_tri_indices`` arrays instead.
     """
-
-    @dataclass(slots=True)
-    class Edge:
-        """Legacy per-edge record: edge ``(v0, v1)`` with opposite vertices
-        ``o0``/``o1`` and adjacent triangles ``f0``/``f1`` (``-1`` if boundary)."""
-
-        v0: int
-        v1: int
-        o0: int
-        o1: int
-        f0: int
-        f1: int
 
     def __init__(
         self,
@@ -400,7 +383,6 @@ class MeshAdjacency:
         edge_indices: Sequence[Sequence[int]] | np.ndarray | None = None,
         spring_indices: Sequence[int] | np.ndarray | None = None,
         tet_indices: Sequence[Sequence[int]] | np.ndarray | None = None,
-        indices: Sequence[Sequence[int]] | np.ndarray | None = None,
     ):
         """Build edge adjacency from triangles and store the element topology as members.
 
@@ -416,19 +398,7 @@ class MeshAdjacency:
                 stored for :meth:`init_vertex_adjacency`.
             tet_indices: Tetrahedron vertex ids, shape ``[tet_count, 4]``; stored for
                 :meth:`init_vertex_adjacency`.
-            indices: Deprecated alias for ``tri_indices``.
         """
-        # `indices` is a deprecated alias for `tri_indices`, kept for backward compatibility.
-        if indices is not None:
-            if tri_indices is not None and not np.array_equal(_numpy_int_array(indices), _numpy_int_array(tri_indices)):
-                raise ValueError("Pass `tri_indices` or the deprecated `indices`, not both with different values.")
-            warnings.warn(
-                "MeshAdjacency `indices` argument is deprecated; use `tri_indices`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            tri_indices = indices
-
         # Element topology kept as members (owned int32 copies, detached from any mutable input
         # list so a finalized model's adjacency can't drift if the builder is modified after
         # finalize()); init_vertex_adjacency builds the CSR from these.
@@ -458,74 +428,6 @@ class MeshAdjacency:
         self.v_adj_tets = None
         self.v_adj_tets_offsets = None
         # Set once init_vertex_adjacency has built the CSR tables; guards recomputation.
-        self.vertex_adjacency_initialized = False
-
-    @property
-    def edges(self) -> dict[tuple[int, int], "MeshAdjacency.Edge"]:
-        """Deprecated legacy edge dict, rebuilt on access from ``edge_indices``.
-
-        Maps ``(min(v0, v1), max(v0, v1))`` to an :class:`Edge`. Recomputed on
-        every access and never cached; prefer the ``edge_indices`` /
-        ``edge_tri_indices`` arrays directly.
-        """
-        warnings.warn(
-            "MeshAdjacency.edges is deprecated; use the edge_indices/edge_tri_indices arrays.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        edge_indices = _numpy_int_rows(self.edge_indices, 4)
-        edge_tri_indices = _numpy_int_rows(self.edge_tri_indices, 2)
-        return {
-            (min(int(v0), int(v1)), max(int(v0), int(v1))): MeshAdjacency.Edge(
-                int(v0), int(v1), int(o0), int(o1), int(f0), int(f1)
-            )
-            for (o0, o1, v0, v1), (f0, f1) in zip(edge_indices, edge_tri_indices, strict=True)
-        }
-
-    def add_edge(self, i0: int, i1: int, o: int, f: int) -> None:
-        """Add or update one edge (deprecated; build via ``edge_indices`` instead).
-
-        Legacy incremental API: edge ``(i0, i1)`` with opposite vertex ``o`` in triangle ``f``.
-        The first call for an edge fills ``o0``/``f0``, the second fills ``o1``/``f1``; a third
-        warns (non-manifold). Updates :attr:`edge_indices` / :attr:`edge_tri_indices` (so
-        :attr:`edges` reflects it) and invalidates the vertex-adjacency CSR. It does **not**
-        update :attr:`tri_edge_indices`, so an edge added this way will not appear in the
-        per-triangle edge map; users can reconstruct via the constructor if they need that. O(edge_count)
-        per call -- a compatibility shim, not a hot path.
-
-        Args:
-            i0: First edge endpoint.
-            i1: Second edge endpoint.
-            o: Opposite vertex in triangle ``f``.
-            f: Triangle containing this edge.
-        """
-        warnings.warn(
-            "MeshAdjacency.add_edge is deprecated; construct with edge_indices ([o0, o1, v0, v1] rows) instead. "
-            "The added edge is not reflected in tri_edge_indices.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        edge_rows = _numpy_int_rows(self.edge_indices, 4)
-        tri_rows = _numpy_int_rows(self.edge_tri_indices, 2)
-        lo, hi = (i0, i1) if i0 <= i1 else (i1, i0)
-        match = -1
-        for e in range(edge_rows.shape[0]):
-            if (
-                min(int(edge_rows[e, 2]), int(edge_rows[e, 3])) == lo
-                and max(int(edge_rows[e, 2]), int(edge_rows[e, 3])) == hi
-            ):
-                match = e
-                break
-        if match == -1:
-            self.edge_indices = np.concatenate((edge_rows, np.array([[o, -1, i0, i1]], dtype=np.int32)))
-            self.edge_tri_indices = np.concatenate((tri_rows, np.array([[f, -1]], dtype=np.int32)))
-        elif int(tri_rows[match, 1]) == -1:
-            edge_rows[match, 1] = o
-            tri_rows[match, 1] = f
-            self.edge_indices, self.edge_tri_indices = edge_rows, tri_rows
-        else:
-            warnings.warn("Detected non-manifold edge", stacklevel=2)
-            return
         self.vertex_adjacency_initialized = False
 
     def to(self, device) -> MeshAdjacencyData:
@@ -2309,7 +2211,7 @@ def validate_triangle_mesh(
     construction and is built by every builder path that accepts a
     triangle mesh, so going through ``add_cloth_mesh`` /
     ``add_soft_mesh`` already covers it. Standalone callers who need a
-    non-manifold check should construct ``MeshAdjacency(indices)``
+    non-manifold check should construct ``MeshAdjacency(tri_indices)``
     themselves. Each detected problem is reported via
     :func:`warnings.warn`.
 

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -831,8 +831,11 @@ class TestModelMesh(unittest.TestCase):
 
     def test_mesh_adjacency_public(self):
         tris = [[0, 1, 2], [0, 2, 3]]
-        # Construction from triangle indices is supported (no warning) and eager.
-        adj = newton.utils.MeshAdjacency(tris)
+        # The supported ctor path must not warn (the deprecated aliases that warned here are gone).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            adj = newton.utils.MeshAdjacency(tris)
+        # Edge tables are populated eagerly by the constructor.
         self.assertEqual(adj.edge_indices.shape, (5, 4))
         self.assertEqual(adj.edge_tri_indices.shape, (5, 2))
         self.assertEqual(adj.tri_edge_indices.shape, (2, 3))

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -829,44 +829,29 @@ class TestModelMesh(unittest.TestCase):
             np.array([[0, -1], [0, -1], [0, 1], [1, -1], [1, -1]], dtype=np.int32),
         )
 
-    def test_mesh_adjacency_public_deprecated(self):
+    def test_mesh_adjacency_public(self):
         tris = [[0, 1, 2], [0, 2, 3]]
         # Construction from triangle indices is supported (no warning) and eager.
         adj = newton.utils.MeshAdjacency(tris)
         self.assertEqual(adj.edge_indices.shape, (5, 4))
         self.assertEqual(adj.edge_tri_indices.shape, (5, 2))
         self.assertEqual(adj.tri_edge_indices.shape, (2, 3))
-        # The legacy .edges dict stays available but is deprecated.
-        with self.assertWarns(DeprecationWarning):
-            edges = adj.edges
-        self.assertEqual(len(edges), 5)
-        shared = edges[(0, 2)]
-        self.assertEqual({shared.f0, shared.f1}, {0, 1})
+        # The shared edge (0, 2) maps to both triangles in edge_tri_indices.
+        (shared,) = np.flatnonzero(
+            (np.minimum(adj.edge_indices[:, 2], adj.edge_indices[:, 3]) == 0)
+            & (np.maximum(adj.edge_indices[:, 2], adj.edge_indices[:, 3]) == 2)
+        )
+        self.assertEqual(set(adj.edge_tri_indices[shared].tolist()), {0, 1})
 
-    def test_mesh_adjacency_indices_deprecated_alias(self):
-        tris = [[0, 1, 2], [0, 2, 3]]
-        # `indices` is a deprecated alias for `tri_indices` and builds the same tables.
-        with self.assertWarns(DeprecationWarning):
-            adj = newton.utils.MeshAdjacency(indices=tris)
-        np.testing.assert_array_equal(adj.edge_indices, newton.utils.MeshAdjacency(tri_indices=tris).edge_indices)
-        # Passing both names with conflicting values is rejected.
-        with self.assertRaises(ValueError):
-            newton.utils.MeshAdjacency(tri_indices=tris, indices=[[0, 1, 2]])
-
-    def test_mesh_adjacency_add_edge_deprecated(self):
-        adj = newton.utils.MeshAdjacency()
-        # add_edge is a deprecated incremental shim; it updates edge_indices / edge_tri_indices.
-        with self.assertWarns(DeprecationWarning):
-            adj.add_edge(0, 1, 2, 0)
-        self.assertEqual(adj.edge_indices.shape, (1, 4))
-        self.assertEqual(adj.edge_tri_indices.shape, (1, 2))
-        with self.assertWarns(DeprecationWarning):
-            adj.add_edge(1, 0, 3, 1)  # second adjacent triangle (endpoints reversed)
-        np.testing.assert_array_equal(adj.edge_indices[0], [2, 3, 0, 1])
-        np.testing.assert_array_equal(adj.edge_tri_indices[0], [0, 1])
-        with self.assertWarns(DeprecationWarning):
-            edges = adj.edges
-        self.assertEqual({edges[(0, 1)].f0, edges[(0, 1)].f1}, {0, 1})
+    def test_mesh_adjacency_legacy_api_removed(self):
+        # The dict-based API deprecated in 1.4 is gone: the `edges` accessor, its
+        # `Edge` record class, the `add_edge` shim, and the ctor `indices` alias.
+        adj = newton.utils.MeshAdjacency([[0, 1, 2], [0, 2, 3]])
+        self.assertFalse(hasattr(adj, "edges"))
+        self.assertFalse(hasattr(adj, "add_edge"))
+        self.assertFalse(hasattr(newton.utils.MeshAdjacency, "Edge"))
+        with self.assertRaises(TypeError):
+            newton.utils.MeshAdjacency(indices=[[0, 1, 2]])
 
     def test_mesh_adjacency_to_without_vertex_adjacency_warns(self):
         # to() before init_vertex_adjacency: uploads the topology maps, leaves v_adj_* None + warns.

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -830,12 +830,12 @@ class TestModelMesh(unittest.TestCase):
         )
 
     def test_mesh_adjacency_public(self):
+        """Assert public construction is warning-free and eagerly builds the vectorized edge tables."""
         tris = [[0, 1, 2], [0, 2, 3]]
         # The supported ctor path must not warn (the deprecated aliases that warned here are gone).
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             adj = newton.utils.MeshAdjacency(tris)
-        # Edge tables are populated eagerly by the constructor.
         self.assertEqual(adj.edge_indices.shape, (5, 4))
         self.assertEqual(adj.edge_tri_indices.shape, (5, 2))
         self.assertEqual(adj.tri_edge_indices.shape, (2, 3))


### PR DESCRIPTION
## Description

Remove the dict-based legacy edge API of `newton.utils.MeshAdjacency`, deprecated in 1.4.0 by #3194 when the class was unified on the vectorized representation:

- `MeshAdjacency.edges` dict accessor and its `MeshAdjacency.Edge` record class. Read the `edge_indices` (`[o0, o1, v0, v1]` rows) and `edge_tri_indices` arrays instead.
- `MeshAdjacency.add_edge` incremental shim. Construct a `MeshAdjacency` with `edge_indices` instead.
- The `indices` constructor argument (alias for `tri_indices`), deprecated in the same batch. Pass `tri_indices` instead.

All internal code already uses the vectorized arrays, so no call sites needed migration. Accessing the removed attributes now raises `AttributeError`, and passing `indices=` raises `TypeError`, matching previous deprecated API removals (e.g. #3623).

Closes #3514

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

```
uv run --extra dev -m newton.tests -k mesh_adjacency            # 8 tests OK, includes new test_mesh_adjacency_legacy_api_removed
uv run --extra dev -m newton.tests -k test_model                # 175 tests OK
uv run --extra dev -m newton.tests -k test_collision_pipeline   # 2 pre-existing failures, see note
```

`test_mesh_adjacency_legacy_api_removed` fails without this change and passes with it. The two `test_collision_pipeline` failures (`TestFullSurfaceSoftContact.test_eval_shape_sdf_mirrored_mesh_scale_preserves_sign_cuda_0` and `test_optimize_against_mesh_texture_sdf_cuda_0`) reproduce on clean `main` at c82ed838 and are unrelated to this change.

## New feature / API change

```python
import newton

adj = newton.utils.MeshAdjacency(tri_indices)

# Before (removed):
#   for (v0, v1), e in adj.edges.items():
#       use e.o0, e.o1, e.f0, e.f1
# Now:
#   rows of adj.edge_indices are [o0, o1, v0, v1]
#   rows of adj.edge_tri_indices are [f0, f1]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated `MeshAdjacency` dictionary access, `Edge` records, and `add_edge` method.
  * Removed the deprecated `indices` constructor argument.
  * Use `edge_indices`, `edge_tri_indices`, and `tri_indices` instead.
* **Documentation**
  * Added changelog entries describing the removed APIs and migration guidance.
* **Tests**
  * Updated coverage to validate the supported array-based API and confirm deprecated interfaces are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->