### PR TITLE
Use stable Warp 1.17.0 in ASV

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,7 +15,7 @@
   "default_benchmark_timeout": 600,
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
-    "in-dir={env_dir} python -m pip install warp-lang==1.17.0.dev20260807 mujoco==3.12.0 mujoco-warp==3.12.0 --extra-index-url=https://pypi.nvidia.com/",
+    "in-dir={env_dir} python -m pip install warp-lang==1.17.0 mujoco==3.12.0 mujoco-warp==3.12.0 --extra-index-url=https://pypi.nvidia.com/",
     "in-dir={env_dir} python -m pip install {wheel_file}[examples] --extra-index-url=https://pypi.nvidia.com/",
     "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
     "python -m pip install 'asv_runner<0.3.0'"


### PR DESCRIPTION
## Description

Pin ASV to the published `warp-lang==1.17.0` release before cutting the Newton 1.6 release branch.

The NVIDIA extra index remains on `main` as required by the release guide so development can move back to nightly builds later. The release branch will remove that index in its own preparation change.

## Checklist

- [x] New or existing tests cover these changes (not applicable; release configuration only)
- [x] The documentation is up to date with these changes (no documentation change required)
- [x] For user-facing changes, a fragment has been added (not applicable; release configuration only)

## Test plan

- `uv lock --check`
- `uv run docs/generate_api.py` (generated API files already current)
- `uvx pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Warp dependency to stable release 1.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->