### PR TITLE
Start Newton 1.7 development

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -75,6 +75,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.6.0.dev0``
+     - ``1.7.0.dev0``
    * - ``use_coord_layout_targets``
      - ``True``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.7.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Move `main` to `1.7.0.dev0` after cutting `release-1.6` at `9595fe4e3bc177e7870683316af4eb18e59d1b9a`.

- Bump the project version to `1.7.0.dev0`.
- Regenerate the public API version reference.
- Update Newton's editable package version in `uv.lock`.

## Checklist

- [x] New or existing tests cover these changes (version-only change)
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added (not applicable; release metadata only)

## Test plan

- `uv run docs/generate_api.py`
- `uv lock --check`
- `uvx pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented Newton version to 1.7.0.dev0.

- **Release Metadata**
  - Advanced the project version to 1.7.0.dev0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->