### PR TITLE
Prepare Newton 1.6.0rc1

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,8 +15,8 @@
   "default_benchmark_timeout": 600,
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
-    "in-dir={env_dir} python -m pip install warp-lang==1.17.0 mujoco==3.12.0 mujoco-warp==3.12.0 --extra-index-url=https://pypi.nvidia.com/",
-    "in-dir={env_dir} python -m pip install {wheel_file}[examples] --extra-index-url=https://pypi.nvidia.com/",
+    "in-dir={env_dir} python -m pip install warp-lang==1.17.0 mujoco==3.12.0 mujoco-warp==3.12.0",
+    "in-dir={env_dir} python -m pip install {wheel_file}[examples]",
     "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
     "python -m pip install 'asv_runner<0.3.0'"
   ]

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -75,6 +75,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.6.0.dev0``
+     - ``1.6.0rc1``
    * - ``use_coord_layout_targets``
      - ``True``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.6.0rc1"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]
@@ -149,11 +149,6 @@ module-root = ""
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 
-[[tool.uv.index]]
-name = "nvidia"
-url = "https://pypi.nvidia.com/"
-explicit = true
-
 [tool.uv]
 conflicts = [
     [
@@ -163,7 +158,6 @@ conflicts = [
 ]
 
 [tool.uv.sources]
-warp-lang = { index = "nvidia" }
 torch = [
     { index = "pytorch-cu128", extra = "torch-cu12" },
     { index = "pytorch-cu130", extra = "torch-cu13" },

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.6.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },
@@ -3977,7 +3977,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0,<3" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.17.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.17.0" },
     { name = "warp-nn", extras = ["onnx"], marker = "extra == 'onnx'", specifier = "==0.3.1" },
 ]
 provides-extras = ["sim", "onnx", "importers", "remesh", "examples", "rtx", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
@@ -7378,17 +7378,17 @@ wheels = [
 [[package]]
 name = "warp-lang"
 version = "1.17.0"
-source = { registry = "https://pypi.nvidia.com/" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fec43afb81caa2190c0b7fa3aaf4d869f3599839f0c40b9ead84331f91e993" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.17.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:47cd93636828dd16e55eeb4e77a0e3547b5fb0f383000a3d228629df68f28fd8" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.17.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5051271048da956a8b94e2db9771ce60ce9591a3ac5bb49037f3d6812d1eea00" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.17.0-py3-none-win_amd64.whl", hash = "sha256:ca35c82242a7553046f09023bbe56750b5c3d9af72625bd1a905a56d3189771d" },
+    { url = "https://files.pythonhosted.org/packages/be/b0/9b1de407fa10b380f5ca4ed1c3e5b129be55ea26a927c7a49e45cdde14b0/warp_lang-1.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fec43afb81caa2190c0b7fa3aaf4d869f3599839f0c40b9ead84331f91e993", size = 27544218, upload-time = "2026-08-31T05:52:29.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a1/e11aa6898e8bbb6910e89fe31a3338fb2566f038912010875c072e6dafd1/warp_lang-1.17.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:47cd93636828dd16e55eeb4e77a0e3547b5fb0f383000a3d228629df68f28fd8", size = 164347636, upload-time = "2026-08-31T05:53:14.441Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4f/a17b1f0ebfeabe37326f01afb6109961f20a0165c1258242f46d10a554f5/warp_lang-1.17.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5051271048da956a8b94e2db9771ce60ce9591a3ac5bb49037f3d6812d1eea00", size = 172665443, upload-time = "2026-08-31T05:53:52.47Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/7a/36306a503085cbfc79c35a28e441c59dd1d8070d2dd65152345ebf2dfec2/warp_lang-1.17.0-py3-none-win_amd64.whl", hash = "sha256:ca35c82242a7553046f09023bbe56750b5c3d9af72625bd1a905a56d3189771d", size = 151236515, upload-time = "2026-08-31T05:54:27.944Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Prepare `release-1.6` for Newton 1.6.0rc1 from branch point `9595fe4e3bc177e7870683316af4eb18e59d1b9a`.

- Set project metadata to `1.6.0rc1`.
- Regenerate the public API version reference and `uv.lock`.
- Resolve `warp-lang==1.17.0` from public PyPI.
- Remove the NVIDIA package index from release and ASV installs.

PR #4101 is intentionally excluded from this release candidate by maintainer decision.

## Checklist

- [x] New or existing tests cover these changes (release metadata/configuration only)
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added (not applicable; release metadata only)

## Test plan

- `uv run docs/generate_api.py`
- `uv lock --check`
- `uv run --extra dev python -m unittest newton.tests.test_generate_api`
- `uvx pre-commit run -a`
- `uv build --out-dir <temporary-directory>`
- Clean isolated Python 3.12 wheel installation

All checks passed. The source distribution and wheel are named for `1.6.0rc1`. The isolated installation reports `1.6.0rc1` from package metadata and `newton.__version__`, and imports Newton from isolated `site-packages`.

PyPI has no `newton==1.6.0rc1` release and `v1.6.0rc1` was unused locally and on the canonical remote before this PR was opened. Both will be checked again immediately before tagging.