### PR TITLE
[Kamino] Fix type alias on reset callbacks on python 3.10

### DIFF
--- a/changelog/+kamino-type-error-008d8f13.fixed.md
+++ b/changelog/+kamino-type-error-008d8f13.fixed.md
@@ -1,0 +1,1 @@
+Fix type alias leading to TypeError on Python 3.10 when using SolverKamino

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -98,7 +98,7 @@ class SolverKaminoImpl(SolverBase):
     options for the linear solver and preconditioning.
     """
 
-    ResetCallbackType = Callable[["SolverKaminoImpl", StateKamino, wp.array[wp.bool] | None], None]
+    ResetCallbackType = Callable[["SolverKaminoImpl", StateKamino, "wp.array[wp.bool] | None"], None]
     """Defines the type signature for reset callback functions."""
 
     StepCallbackType = Callable[["SolverKaminoImpl", StateKamino, StateKamino, ControlKamino, ContactsKamino], None]


### PR DESCRIPTION
## Description

The recent PR #4120 modified a type alias in solver_kamino_impl.py that leads to a TypeError on Python 3.10 (because there wp.array[wp.bool] is not recognized as a type). `from __future__ import annotations` does not help here because it is a type alias rather than an annotation.

Stringifying the wp.array part of the annotation (as how `from __future__ import annotations` would do it if it was an annotation) solves the issue.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)


## Bug fix


**Steps to reproduce:**

Run any unit test or example involving Kamino on a platform with Python 3.10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a `TypeError` affecting Kamino callback type annotations when using Python 3.10.
  * Improved compatibility for callback type annotations without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->