### PR TITLE
Remove deprecated collision filter mutation

### DIFF
--- a/changelog/+model-collision-filters-2f6c8a1d.removed.md
+++ b/changelog/+model-collision-filters-2f6c8a1d.removed.md
@@ -1,0 +1,1 @@
+Remove `ModelBuilder.find_shape_contact_pairs()` and support for mutating `Model.shape_collision_filter_pairs`; update `ModelBuilder.shape_collision_filter_pairs` before calling `finalize()` and rebuild the model instead.

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -708,14 +708,10 @@ Filter pairs are automatically populated in several cases:
 - **USD filtered pairs**: Pairs defined by ``physics:filteredPairs`` relationships in USD files
 - **USD collision disabled**: Shapes with ``physics:collisionEnabled=false`` (filtered against all other shapes)
 
-The resulting filter pairs are stored in :attr:`~Model.shape_collision_filter_pairs` as a set of
-``(shape_index_a, shape_index_b)`` tuples (canonical order: ``a < b``).
-
-.. deprecated:: 1.4
-   Mutating this finalized-model set is deprecated; update
-   :attr:`~ModelBuilder.shape_collision_filter_pairs` before calling ``finalize()`` and rebuild the
-   model instead, because the precomputed :attr:`~Model.shape_contact_pairs` array is not rebuilt by
-   post-finalize filter edits.
+The resulting filter pairs are stored in :attr:`~Model.shape_collision_filter_pairs` as a read-only
+set of ``(shape_index_a, shape_index_b)`` tuples (canonical order: ``a < b``). Update
+:attr:`~ModelBuilder.shape_collision_filter_pairs` before calling ``finalize()`` and rebuild the
+model to change collision filters.
 
 **USD Import Example**
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -13197,9 +13197,7 @@ class ModelBuilder:
             m.mujoco.equality_constraint_world_start = wp.array(self._equality_constraint_world_start, dtype=wp.int32)
             m.constraint_mimic_count = len(self.constraint_mimic_joint0)
 
-            # The packed array was just installed on the model, so builder and
-            # model filters are known to match without rebuilding it.
-            self._find_shape_contact_pairs(m, allow_filter_blocks=True)
+            self._find_shape_contact_pairs(m)
 
             # enable ground plane
             m.up_axis = self.up_axis
@@ -13511,43 +13509,7 @@ class ModelBuilder:
                     )
             validated_templates.add(template_key)
 
-    def find_shape_contact_pairs(self, model: Model):
-        """Deprecated method for rebuilding explicit shape contact pairs.
-
-        .. deprecated:: 1.4
-            Shape contact pairs are generated automatically by :meth:`finalize`.
-            Configure collision filters before finalization instead of rebuilding
-            contact pairs manually.
-
-        Identifies and stores all potential shape contact pairs for collision detection.
-
-        This method examines the collision groups and collision masks of all shapes in the model
-        to determine which pairs of shapes should be considered for contact generation. It respects
-        any user-specified collision filter pairs to avoid redundant or undesired contacts.
-
-        The resulting contact pairs are stored in the model as a 2D array of shape indices.
-
-        Uses the exact same filtering logic as the broad phase kernels (test_world_and_group_pair)
-        to ensure consistency between EXPLICIT mode (precomputed pairs) and NXN/SAP modes.
-
-        Args:
-            model: The simulation model to which the contact pairs will be assigned.
-
-        Side Effects:
-            - Sets `model.shape_contact_pairs` to a wp.array of shape pairs (wp.vec2i).
-            - Sets `model.shape_contact_pair_count` to the number of contact pairs found.
-        """
-        warnings.warn(
-            "ModelBuilder.find_shape_contact_pairs() is deprecated; shape contact pairs are generated "
-            + "automatically by ModelBuilder.finalize(). Configure collision filters before finalization instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Deprecated calls may supply an unrelated model or a builder that has
-        # changed since finalization, so always query filters from the model.
-        self._find_shape_contact_pairs(model, allow_filter_blocks=False)
-
-    def _find_shape_contact_pairs(self, model: Model, *, allow_filter_blocks: bool) -> None:
+    def _find_shape_contact_pairs(self, model: Model) -> None:
         filter_pairs = self._shape_collision_filter_pairs
         world_filter_blocks: tuple[_ShapeCollisionFilterBlock, ...] = ()
         explicit_filter_pairs: tuple[tuple[int, int], ...] = ()
@@ -13570,11 +13532,7 @@ class ModelBuilder:
                 self._iter_validated_shape_collision_filter_pairs((*filter_pairs.explicit_pairs, *floating_block_pairs))
             )
 
-        # Builder-side storage is valid only while it describes the model's
-        # filters exactly; otherwise the general path queries the model.
-        use_world_templates = (
-            allow_filter_blocks and self.world_count > 0 and isinstance(filter_pairs, _BuilderShapeCollisionFilterPairs)
-        )
+        use_world_templates = self.world_count > 0 and isinstance(filter_pairs, _BuilderShapeCollisionFilterPairs)
         if use_world_templates:
             shape_world_np = np.asarray(self.shape_world, dtype=np.int32)
             starts = self.shape_world_start

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, SupportsIndex
 import numpy as np
 import warp as wp
 
-from ..core.types import Devicelike, override
+from ..core.types import Devicelike
 from ..geometry.flags import ShapeFlags
 from ..utils.deprecation import RemovedAttribute
 from ..utils.mesh import MeshAdjacency, MeshAdjacencyData
@@ -31,13 +31,6 @@ if TYPE_CHECKING:
     from ..actuators.actuator import Actuator
     from ..utils.heightfield import HeightfieldData
     from .collide import CollisionPipeline
-
-
-_SHAPE_COLLISION_FILTER_MUTATION_DEPRECATION_MSG = (
-    "Mutating Model.shape_collision_filter_pairs after ModelBuilder.finalize() is deprecated. "
-    "Configure collision filters on ModelBuilder before finalizing; post-finalize filter changes "
-    "do not rebuild Model.shape_contact_pairs."
-)
 
 
 def _pack_shape_pair_codes(shape_a: np.ndarray, shape_b: np.ndarray) -> np.ndarray:
@@ -64,61 +57,40 @@ def _unpack_shape_pair_codes(codes: np.ndarray) -> np.ndarray:
     return pairs
 
 
-class _DeprecatedShapeCollisionFilterSet(set[tuple[int, int]]):
-    """Mutation-deprecated compat view over the canonical filter-pair array.
+class _ShapeCollisionFilterPairs(AbstractSet[tuple[int, int]]):
+    """Read-only set view over sorted, unique packed filter-pair codes."""
 
-    The canonical store is ``packed``: a sorted, unique 1-D ``int64`` array of
-    pair codes (see :func:`_pack_shape_pair_codes`). The public
-    :attr:`Model.shape_collision_filter_pairs` descriptor materializes this
-    view into native set contents on access, so plain ``set`` reads work
-    unchanged; internal consumers use :meth:`contains_pair`,
-    :meth:`mask_pairs`, and :meth:`pairs_array`, which query the packed array
-    while it exists and transparently fall back to native set contents after a
-    deprecated mutation drops it.
-    """
-
-    __hash__ = None
-
-    def __init__(self, pairs: Iterable[tuple[int, int]] = (), packed: np.ndarray | None = None):
-        super().__init__((shape_a, shape_b) if shape_a <= shape_b else (shape_b, shape_a) for shape_a, shape_b in pairs)
+    def __init__(self, packed: np.ndarray):
         self._packed = packed
         self._pairs_array: np.ndarray | None = None
-        self._materialized = packed is None
-
-    @staticmethod
-    def _canonical_pair(shape_a: int, shape_b: int) -> tuple[int, int]:
-        return (shape_a, shape_b) if shape_a <= shape_b else (shape_b, shape_a)
 
     @classmethod
-    def _canonical_pair_from_object(cls, pair: object) -> tuple[int, int] | None:
+    def _from_iterable(cls, iterable: Iterable[tuple[int, int]]) -> frozenset[tuple[int, int]]:
+        return frozenset(iterable)
+
+    def __bool__(self) -> bool:
+        return self._packed.shape[0] > 0
+
+    def __contains__(self, pair: object) -> bool:
         if not isinstance(pair, tuple) or len(pair) != 2:
-            return None
-        shape_a, shape_b = pair
-        return cls._canonical_pair(shape_a, shape_b)
+            return False
+        try:
+            shape_a, shape_b = operator.index(pair[0]), operator.index(pair[1])
+            if shape_a > shape_b:
+                return False
+            return self._contains_code((shape_a << 32) | shape_b)
+        except (OverflowError, TypeError, ValueError):
+            return False
 
-    @classmethod
-    def _iter_canonical_pairs(cls, pairs: Iterable[object]) -> Iterator[tuple[int, int]]:
-        for pair in pairs:
-            canonical_pair = cls._canonical_pair_from_object(pair)
-            if canonical_pair is not None:
-                yield canonical_pair
+    def __iter__(self) -> Iterator[tuple[int, int]]:
+        return iter(map(tuple, self.pairs_array().tolist()))
 
-    def _ensure_materialized(self) -> None:
-        if not self._materialized:
-            if self._packed is not None and self._packed.shape[0] > 0:
-                super().update(map(tuple, _unpack_shape_pair_codes(self._packed).tolist()))
-            self._materialized = True
+    def __len__(self) -> int:
+        return self._packed.shape[0]
 
-    @property
-    def is_materialized(self) -> bool:
-        return self._materialized
-
-    def materialize(self) -> None:
-        self._ensure_materialized()
-
-    def packed_pairs(self) -> np.ndarray | None:
-        """Sorted unique packed pair codes, or ``None`` after mutation."""
-        return self._packed
+    def _contains_code(self, code: int) -> bool:
+        index = int(np.searchsorted(self._packed, code))
+        return bool(index < self._packed.shape[0] and self._packed[index] == code)
 
     def contains_pair(self, shape_a: SupportsIndex, shape_b: SupportsIndex) -> bool:
         """Return membership of a shape pair in any argument order."""
@@ -127,22 +99,12 @@ class _DeprecatedShapeCollisionFilterSet(set[tuple[int, int]]):
         shape_a, shape_b = operator.index(shape_a), operator.index(shape_b)
         if shape_a > shape_b:
             shape_a, shape_b = shape_b, shape_a
-        if self._packed is None:
-            return super().__contains__((shape_a, shape_b))
-        code = (shape_a << 32) | shape_b
-        index = int(np.searchsorted(self._packed, code))
-        return bool(index < self._packed.shape[0] and self._packed[index] == code)
+        return self._contains_code((shape_a << 32) | shape_b)
 
     def mask_pairs(self, pairs: np.ndarray) -> np.ndarray:
         """Return a boolean membership mask for shape pairs in any order."""
         if pairs.shape[0] == 0:
             return np.zeros(0, dtype=bool)
-        if self._packed is None:
-            return np.fromiter(
-                (self.contains_pair(shape_a, shape_b) for shape_a, shape_b in pairs),
-                dtype=bool,
-                count=pairs.shape[0],
-            )
         if self._packed.shape[0] == 0:
             return np.zeros(pairs.shape[0], dtype=bool)
         codes = _pack_shape_pair_codes(pairs[:, 0], pairs[:, 1])
@@ -155,145 +117,12 @@ class _DeprecatedShapeCollisionFilterSet(set[tuple[int, int]]):
 
         The returned array is read-only: while the packed store exists it
         aliases the cached canonical pairs, and mutating it would corrupt
-        every later filter query and the materialized public set.
+        every later filter query and public set iteration.
         """
-        if self._packed is None:
-            pairs = np.asarray(sorted(self), dtype=np.int32).reshape((-1, 2))
-        else:
-            if self._pairs_array is None:
-                self._pairs_array = _unpack_shape_pair_codes(self._packed)
-                self._pairs_array.setflags(write=False)
-            return self._pairs_array
-        pairs.setflags(write=False)
-        return pairs
-
-    def _prepare_mutation(self) -> None:
-        self._ensure_materialized()
-        self._packed = None
-        self._pairs_array = None
-        warnings.warn(_SHAPE_COLLISION_FILTER_MUTATION_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
-
-    def __bool__(self) -> bool:
-        if self._packed is not None and self._packed.shape[0] > 0:
-            return True
-        return super().__len__() != 0
-
-    # Generic consumers (viewer-file serialization, deepcopy) iterate the raw
-    # __dict__ value without the materializing descriptor; keep iteration and
-    # length lazy-safe so they never observe a half-empty set.
-    @override
-    def __iter__(self) -> Iterator[tuple[int, int]]:
-        self._ensure_materialized()
-        return super().__iter__()
-
-    @override
-    def __len__(self) -> int:
-        self._ensure_materialized()
-        return super().__len__()
-
-    @override
-    def add(self, element: tuple[int, int]) -> None:
-        self._prepare_mutation()
-        shape_a, shape_b = element
-        super().add(self._canonical_pair(shape_a, shape_b))
-
-    @override
-    def clear(self) -> None:
-        self._prepare_mutation()
-        super().clear()
-
-    @override
-    def discard(self, element: object) -> None:
-        self._prepare_mutation()
-        canonical_pair = self._canonical_pair_from_object(element)
-        if canonical_pair is not None:
-            super().discard(canonical_pair)
-
-    @override
-    def pop(self) -> tuple[int, int]:
-        self._prepare_mutation()
-        return super().pop()
-
-    @override
-    def remove(self, element: tuple[int, int]) -> None:
-        self._prepare_mutation()
-        shape_a, shape_b = element
-        super().remove(self._canonical_pair(shape_a, shape_b))
-
-    @override
-    def update(self, *others: Iterable[tuple[int, int]]) -> None:
-        self._prepare_mutation()
-        super().update(self._canonical_pair(shape_a, shape_b) for other in others for shape_a, shape_b in other)
-
-    @override
-    def difference_update(self, *others: Iterable[object]) -> None:
-        self._prepare_mutation()
-        for other in others:
-            for canonical_pair in self._iter_canonical_pairs(other):
-                super().discard(canonical_pair)
-
-    @override
-    def intersection_update(self, *others: Iterable[object]) -> None:
-        self._prepare_mutation()
-        canonical_others = [set(self._iter_canonical_pairs(other)) for other in others]
-        super().intersection_update(*canonical_others)
-
-    @override
-    def symmetric_difference_update(self, other: Iterable[tuple[int, int]]) -> None:
-        self._prepare_mutation()
-        super().symmetric_difference_update(self._canonical_pair(shape_a, shape_b) for shape_a, shape_b in other)
-
-    @override
-    def __ior__(self, other: Iterable[tuple[int, int]]):
-        self._prepare_mutation()
-        super().update(self._canonical_pair(shape_a, shape_b) for shape_a, shape_b in other)
-        return self
-
-    @override
-    def __iand__(self, other: AbstractSet[object]):
-        self._prepare_mutation()
-        super().intersection_update(set(self._iter_canonical_pairs(other)))
-        return self
-
-    @override
-    def __isub__(self, other: AbstractSet[object]):
-        self._prepare_mutation()
-        super().difference_update(set(self._iter_canonical_pairs(other)))
-        return self
-
-    @override
-    def __ixor__(self, other: Iterable[tuple[int, int]]):
-        self._prepare_mutation()
-        super().symmetric_difference_update({self._canonical_pair(shape_a, shape_b) for shape_a, shape_b in other})
-        return self
-
-
-class _ShapeCollisionFilterPairsAttribute:
-    """Set of canonical shape index pairs that should not collide.
-
-    Mutating or reassigning this finalized-model set is deprecated. Configure
-    collision filters on :class:`ModelBuilder` before calling
-    :meth:`ModelBuilder.finalize` instead; post-finalize changes do not rebuild
-    :attr:`Model.shape_contact_pairs`.
-    """
-
-    def __get__(self, instance: Any, owner: Any = None) -> Any:
-        if instance is None:
-            return self
-        filters = instance.__dict__.get("shape_collision_filter_pairs")
-        if filters is None:
-            filters = _DeprecatedShapeCollisionFilterSet()
-            instance.__dict__["shape_collision_filter_pairs"] = filters
-        if isinstance(filters, _DeprecatedShapeCollisionFilterSet):
-            filters.materialize()
-        return filters
-
-    def __set__(self, instance: Any, value: Iterable[tuple[int, int]]) -> None:
-        if instance.__dict__.get("shape_collision_filter_pairs") is value:
-            return
-        if "shape_collision_filter_pairs" in instance.__dict__:
-            warnings.warn(_SHAPE_COLLISION_FILTER_MUTATION_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-        instance.__dict__["shape_collision_filter_pairs"] = _DeprecatedShapeCollisionFilterSet(value)
+        if self._pairs_array is None:
+            self._pairs_array = _unpack_shape_pair_codes(self._packed)
+            self._pairs_array.setflags(write=False)
+        return self._pairs_array
 
 
 class Model:
@@ -318,11 +147,6 @@ class Model:
         It is strongly recommended to use the :class:`ModelBuilder` to construct a Model.
         Direct instantiation and manual population of Model fields is possible but discouraged.
     """
-
-    if TYPE_CHECKING:
-        shape_collision_filter_pairs: set[tuple[int, int]]
-    else:
-        shape_collision_filter_pairs = _ShapeCollisionFilterPairsAttribute()
 
     class AttributeAssignment(IntEnum):
         """Enumeration of attribute assignment categories.
@@ -875,14 +699,7 @@ class Model:
 
         self.shape_collision_group: wp.array[wp.int32] | None = None
         """Collision group of each shape, shape [shape_count], int. Array populated during finalization."""
-        self.shape_collision_filter_pairs = _DeprecatedShapeCollisionFilterSet()
-        """Set of canonical shape index pairs that should not collide.
-
-        .. deprecated:: 1.4
-            Mutating or reassigning this finalized-model set is deprecated. Configure collision
-            filters on :class:`ModelBuilder` before calling :meth:`ModelBuilder.finalize` instead;
-            post-finalize changes do not rebuild :attr:`shape_contact_pairs`.
-        """
+        self._shape_collision_filter_pairs = _ShapeCollisionFilterPairs(np.empty(0, dtype=np.int64))
         self.shape_collision_radius: wp.array[wp.float32] | None = None
         """Collision radius [m] for bounding sphere broadphase, shape [shape_count], float. Not supported by :class:`~newton.solvers.SolverMuJoCo`."""
         self.shape_contact_pairs: wp.array[wp.vec2i] | None = None
@@ -1443,23 +1260,30 @@ class Model:
 
     def _set_shape_collision_filter_packed(self, packed: np.ndarray) -> None:
         """Install the canonical filter store: sorted unique packed pair codes."""
-        self.__dict__["shape_collision_filter_pairs"] = _DeprecatedShapeCollisionFilterSet(packed=packed)
+        self._shape_collision_filter_pairs = _ShapeCollisionFilterPairs(packed)
 
-    def _shape_collision_filter_store(self) -> _DeprecatedShapeCollisionFilterSet | None:
-        """Return the stored filter view without triggering materialization.
+    def _set_shape_collision_filter_pairs(self, pairs: Iterable[tuple[int, int]]) -> None:
+        """Install canonical filter pairs from a serialized model."""
+        pair_array = np.asarray(tuple(pairs), dtype=np.int64).reshape((-1, 2))
+        if pair_array.shape[0] == 0:
+            self._set_shape_collision_filter_packed(np.empty(0, dtype=np.int64))
+            return
 
-        The store shares the instance-dict slot with the public
-        ``shape_collision_filter_pairs`` descriptor, whose ``__get__``
-        materializes the set; array-backed queries read the slot directly so
-        they stay materialization-free.
-        """
-        return self.__dict__.get("shape_collision_filter_pairs")
+        packed = _pack_shape_pair_codes(pair_array[:, 0], pair_array[:, 1])
+        packed.sort()
+        if packed.shape[0] > 1:
+            packed = packed[np.concatenate(([True], packed[1:] != packed[:-1]))]
+        self._set_shape_collision_filter_packed(packed)
+
+    @property
+    def shape_collision_filter_pairs(self) -> AbstractSet[tuple[int, int]]:
+        """Read-only set of canonical shape index pairs that should not collide."""
+        return self._shape_collision_filter_pairs
 
     def shape_collision_filter_contains(self, shape_a: SupportsIndex, shape_b: SupportsIndex) -> bool:
         """Return whether a canonicalized shape pair is collision-filtered.
 
-        This queries the canonical filter-pair array when available, avoiding
-        materialization of :attr:`shape_collision_filter_pairs`.
+        This queries the canonical filter-pair array without copying it.
 
         Args:
             shape_a: First shape index.
@@ -1471,16 +1295,13 @@ class Model:
         Raises:
             TypeError: If either shape index is not an integer.
         """
-        filters = self._shape_collision_filter_store()
-        if filters is None:
-            return False
-        return filters.contains_pair(shape_a, shape_b)
+        return self._shape_collision_filter_pairs.contains_pair(shape_a, shape_b)
 
     def shape_collision_filter_pairs_array(self) -> np.ndarray:
         """Return the collision-filter pairs as an array.
 
         Array counterpart to :attr:`shape_collision_filter_pairs` that returns
-        the canonical filter-pair array without materializing the public set.
+        the canonical filter-pair array without copying the public set.
         Consumers that need every excluded pair — such as the ``"nxn"`` and
         ``"sap"`` broad-phase exclusion arrays — should prefer this form.
 
@@ -1488,10 +1309,7 @@ class Model:
             Canonical shape index pairs sorted lexicographically, shape
             [pair_count, 2].
         """
-        filters = self._shape_collision_filter_store()
-        if filters is None:
-            return np.empty((0, 2), dtype=np.int32)
-        return filters.pairs_array()
+        return self._shape_collision_filter_pairs.pairs_array()
 
     def shape_collision_filter_mask(self, pairs: np.ndarray) -> np.ndarray:
         """Return a boolean mask of which shape pairs are collision-filtered.
@@ -1518,10 +1336,7 @@ class Model:
                 raise OverflowError("unsigned shape indices must fit in a signed 64-bit integer")
             pairs = pairs.astype(np.int64)
         pairs = pairs.reshape((-1, 2))
-        filters = self._shape_collision_filter_store()
-        if filters is None:
-            return np.zeros(pairs.shape[0], dtype=bool)
-        return filters.mask_pairs(pairs)
+        return self._shape_collision_filter_pairs.mask_pairs(pairs)
 
     def _attribute_spec(self, name: str) -> Model.AttributeSpec | None:
         """Return current metadata, including legacy mapping overrides."""

--- a/newton/_src/solvers/coupled/model_view.py
+++ b/newton/_src/solvers/coupled/model_view.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 
 def _types_compatible(current, value) -> bool:
     """Return True iff *value* is type-compatible with *current* for an override."""
-    if isinstance(current, set):
-        return isinstance(value, set)
     if isinstance(current, wp.array):
         return (
             isinstance(value, wp.array)

--- a/newton/_src/solvers/coupled/solver_coupled.py
+++ b/newton/_src/solvers/coupled/solver_coupled.py
@@ -904,7 +904,7 @@ class SolverCoupled(SolverBase, CouplingInterface):
 
         body_global_to_local = {body_id: body_id for body_id in range(model.body_count)}
         view.body_shapes = self._global_shape_body_shapes(model.body_shapes, body_global_to_local, visible_shapes)
-        view.shape_collision_filter_pairs = set(model.shape_collision_filter_pairs)
+        view.shape_collision_filter_pairs = model.shape_collision_filter_pairs
 
     def _build_entry_index_maps(self, view: ModelView, index_lists: _CompactIndexMaps | None) -> _EntryIndexMaps:
         """Build local/global id maps for a completed entry view."""
@@ -1434,7 +1434,7 @@ class SolverCoupled(SolverBase, CouplingInterface):
             body_global_to_local,
             set(visible_shape_order),
         )
-        view.shape_collision_filter_pairs = set(model.shape_collision_filter_pairs)
+        view.shape_collision_filter_pairs = model.shape_collision_filter_pairs
 
         articulation_starts = self._compact_articulation_starts(joint_order, articulation_order)
         view.articulation_start = wp.array(articulation_starts, dtype=wp.int32, device=device)

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 from collections.abc import Iterable, Mapping
+from collections.abc import Set as AbstractSet
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
@@ -454,7 +454,7 @@ def serialize(obj, callback, _visited=None, _path="", format_type="json", cache:
 
         # Iterables (like list, tuple, set)
         if isinstance(obj, Iterable) and not isinstance(obj, str | bytes | bytearray):
-            type_name = "set" if isinstance(obj, set) else type(obj).__name__
+            type_name = "set" if isinstance(obj, AbstractSet) else type(obj).__name__
             return {
                 "__type__": type_name,
                 "items": [
@@ -655,13 +655,14 @@ def transfer_to_model(source_dict: Mapping[str, Any], target_obj, post_load_init
     target_is_namespace = isinstance(target_obj, Model.AttributeNamespace)
 
     for attr_name, source_value in source_dict.items():
-        if attr_name.startswith("_"):
+        if isinstance(target_obj, Model) and attr_name in {
+            "_shape_collision_filter_pairs",
+            "shape_collision_filter_pairs",
+        }:
+            target_obj._set_shape_collision_filter_pairs(source_value)  # pyright: ignore[reportPrivateUsage]
             continue
 
-        if isinstance(target_obj, Model) and attr_name == "shape_collision_filter_pairs":
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                target_obj.shape_collision_filter_pairs = source_value
+        if attr_name.startswith("_"):
             continue
 
         target_value = getattr(target_obj, attr_name, _MISSING)

--- a/newton/tests/test_coupled_solver.py
+++ b/newton/tests/test_coupled_solver.py
@@ -459,15 +459,6 @@ class TestModelView(unittest.TestCase):
         # Parent unchanged
         self.assertIsNot(self.model.body_inv_mass, new_mass)
 
-    def test_override_accepts_set_subclass_parent(self):
-        """Set overrides should accept a native set when the parent uses a set subclass."""
-        view = ModelView(self.model, "test")
-        filters = set(self.model.shape_collision_filter_pairs)
-
-        view.shape_collision_filter_pairs = filters
-
-        self.assertIs(view.shape_collision_filter_pairs, filters)
-
     def test_count_override_slices_frequency_arrays(self):
         """Frequency-matched arrays should follow view-local counts."""
         view = ModelView(self.model, "test")

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -10,6 +10,7 @@ import types
 import unittest
 import warnings
 from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest import mock
@@ -1613,8 +1614,8 @@ class TestModelMesh(unittest.TestCase):
         self.assertIn((shape0, shape2), model.shape_collision_filter_pairs)
         self.assertIn((shape1, shape2), model.shape_collision_filter_pairs)
 
-    def test_large_replicated_collision_filter_pairs_deprecate_mutation_and_preserve_contacts(self):
-        """Large replicated filters should stay compact while finalized-model mutation warns."""
+    def test_large_replicated_collision_filter_pairs_are_read_only_and_preserve_contacts(self):
+        """Keep large replicated filters compact and read-only while preserving contacts."""
 
         robot = ModelBuilder()
         body0 = robot.add_body()
@@ -1633,33 +1634,30 @@ class TestModelMesh(unittest.TestCase):
 
         model = builder.finalize()
 
-        internal_filters = model._shape_collision_filter_store()  # pyright: ignore[reportPrivateUsage]
-        self.assertFalse(internal_filters.is_materialized)
-        self.assertTrue(internal_filters.contains_pair(1, 2))
-        self.assertFalse(internal_filters.is_materialized)
-
         filters = model.shape_collision_filter_pairs
-        self.assertIsInstance(filters, set)
-        self.assertTrue(internal_filters.is_materialized)
+        self.assertIsInstance(filters, AbstractSet)
+        self.assertNotIsInstance(filters, set)
         self.assertIn((1, 2), filters)
         self.assertIn((3, 4), filters)
         self.assertIn((5, 6), filters)
         expected_filters = {(1, 2), (3, 4), (5, 6)}
         self.assertEqual(filters, expected_filters)
         self.assertEqual(filters | {(ground, 1)}, expected_filters | {(ground, 1)})
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(AttributeError):
             filters.add((ground, 1))
-        self.assertIn((ground, 1), model.shape_collision_filter_pairs)
-        with self.assertWarns(DeprecationWarning):
+        self.assertNotIn((ground, 1), model.shape_collision_filter_pairs)
+        with self.assertRaises(AttributeError):
             model.shape_collision_filter_pairs = set()
-        self.assertEqual(model.shape_collision_filter_pairs, set())
+        self.assertEqual(model.shape_collision_filter_pairs, expected_filters)
 
         shape_contact_pairs = model.shape_contact_pairs
         assert shape_contact_pairs is not None
         contact_pairs = {tuple(pair) for pair in shape_contact_pairs.numpy()}
         self.assertEqual(contact_pairs, {(ground, 1), (ground, 2), (ground, 3), (ground, 4), (ground, 5), (ground, 6)})
 
-    def test_collision_filter_in_place_mutation_warns_at_call_site(self):
+    def test_collision_filter_in_place_mutation_is_rejected(self):
+        """Reject augmented assignment on finalized-model collision filters."""
+
         def union(model: newton.Model) -> None:
             model.shape_collision_filter_pairs |= {(0, 1)}
 
@@ -1676,13 +1674,9 @@ class TestModelMesh(unittest.TestCase):
             with self.subTest(mutation=mutation.__name__):
                 model = ModelBuilder().finalize(device="cpu")
                 filters = model.shape_collision_filter_pairs
-                with warnings.catch_warnings(record=True) as caught:
-                    warnings.simplefilter("always", DeprecationWarning)
+                with self.assertRaises(AttributeError):
                     mutation(model)
 
-                self.assertEqual(len(caught), 1)
-                self.assertEqual(caught[0].filename, __file__)
-                self.assertEqual(caught[0].lineno, mutation.__code__.co_firstlineno + 1)
                 self.assertIs(model.shape_collision_filter_pairs, filters)
 
     def test_builder_collision_filter_pairs_preserve_list_api(self):
@@ -1774,7 +1768,8 @@ class TestModelMesh(unittest.TestCase):
         build_filters.assert_called_once()
 
         filters = model.shape_collision_filter_pairs
-        self.assertIsInstance(filters, set)
+        self.assertIsInstance(filters, AbstractSet)
+        self.assertNotIsInstance(filters, set)
         self.assertIn((1, 2), filters)
         self.assertIn((ground, 1), filters)
 
@@ -1787,7 +1782,7 @@ class TestModelMesh(unittest.TestCase):
         self.assertNotIn((ground, 2), filters)
 
     def test_compact_replicated_collision_filters_roundtrip_viewer_file(self):
-        """ViewerFile should restore compact filters through a native public set."""
+        """Restore compact filters through the read-only public set view."""
 
         robot = ModelBuilder()
         body0 = robot.add_body()
@@ -1803,17 +1798,15 @@ class TestModelMesh(unittest.TestCase):
 
         model = builder.finalize(device="cpu")
         expected_filters = {(1, 2), (3, 4), (ground, 1)}
-        internal_filters = model._shape_collision_filter_store()  # pyright: ignore[reportPrivateUsage]
-        self.assertFalse(internal_filters.is_materialized)
 
         serialized = cast(Mapping[str, Any], pointer_as_key({"model": model}, format_type="json"))
-        self.assertTrue(internal_filters.is_materialized)
         deserialized = depointer_as_key(serialized, format_type="json")
         deserialized_model = cast(Mapping[str, Any], cast(Mapping[str, Any], deserialized)["model"])
         restored_model = newton.Model(device="cpu")
         transfer_to_model(deserialized_model, restored_model)
 
-        self.assertIsInstance(restored_model.shape_collision_filter_pairs, set)
+        self.assertIsInstance(restored_model.shape_collision_filter_pairs, AbstractSet)
+        self.assertNotIsInstance(restored_model.shape_collision_filter_pairs, set)
         self.assertEqual(restored_model.shape_collision_filter_pairs, expected_filters)
 
     def test_collision_filter_array_queries_match_set(self):
@@ -1838,10 +1831,6 @@ class TestModelMesh(unittest.TestCase):
         pair_list = [tuple(pair) for pair in broad_phase_pairs.tolist()]
         self.assertEqual(pair_list, sorted(pair_list))
 
-        internal_filters = model._shape_collision_filter_store()  # pyright: ignore[reportPrivateUsage]
-        assert internal_filters is not None
-        self.assertFalse(internal_filters.is_materialized)
-
         self.assertTrue(model.shape_collision_filter_contains(1, 2))
         self.assertTrue(model.shape_collision_filter_contains(2, 1))
         self.assertTrue(model.shape_collision_filter_contains(ground, 1))
@@ -1854,7 +1843,6 @@ class TestModelMesh(unittest.TestCase):
             model.shape_collision_filter_contains("1", 2)  # pyright: ignore[reportArgumentType]
         with self.assertRaises(TypeError):
             model.shape_collision_filter_contains(1.0, 2)  # pyright: ignore[reportArgumentType]
-        self.assertFalse(internal_filters.is_materialized)
 
         # The canonical array aliases internal state and must be read-only.
         with self.assertRaises(ValueError):
@@ -1871,33 +1859,6 @@ class TestModelMesh(unittest.TestCase):
             model.shape_collision_filter_mask(candidates.astype(str))
 
         self.assertEqual(set(pair_list), set(model.shape_collision_filter_pairs))
-
-        # Rebuilding through the public method must use the model as the filter
-        # source even if this builder has changed since finalization.
-        builder.add_shape_collision_filter_pair(ground, 2)
-        with self.assertWarnsRegex(DeprecationWarning, "generated automatically"):
-            builder.find_shape_contact_pairs(model)
-        shape_contact_pairs = model.shape_contact_pairs
-        assert shape_contact_pairs is not None
-        contact_pairs = {tuple(pair) for pair in shape_contact_pairs.numpy()}
-        self.assertIn((ground, 2), contact_pairs)
-
-        # After deprecated mutation, queries fall back to native set semantics.
-        with self.assertWarns(DeprecationWarning):
-            model.shape_collision_filter_pairs.add((ground, 2))
-        self.assertTrue(model.shape_collision_filter_contains(ground, 2))
-        mask = model.shape_collision_filter_mask(candidates)
-        self.assertEqual(mask.tolist(), [True, True, True, True, True])
-        self.assertEqual(len(model.shape_collision_filter_pairs_array()), 6)
-
-        # Rebuilding contact pairs after a (deprecated) mutation must honor
-        # the mutated model store rather than replaying stale builder filters.
-        with self.assertWarnsRegex(DeprecationWarning, "generated automatically"):
-            builder.find_shape_contact_pairs(model)
-        shape_contact_pairs = model.shape_contact_pairs
-        assert shape_contact_pairs is not None
-        contact_pairs = {tuple(pair) for pair in shape_contact_pairs.numpy()}
-        self.assertNotIn((ground, 2), contact_pairs)
 
     def test_mixed_replicated_and_global_builder_filters_preserve_contacts(self):
         """Blocks without a world (global add_builder) must not disable the fast path."""
@@ -1966,7 +1927,8 @@ class TestModelMesh(unittest.TestCase):
 
         model = builder.finalize()
 
-        self.assertIsInstance(model.shape_collision_filter_pairs, set)
+        self.assertIsInstance(model.shape_collision_filter_pairs, AbstractSet)
+        self.assertNotIsInstance(model.shape_collision_filter_pairs, set)
 
         contact_pairs = {tuple(pair) for pair in model.shape_contact_pairs.numpy()}
         self.assertIn((1, 2), contact_pairs)


### PR DESCRIPTION
## Description

Remove the expired finalized-model collision-filter mutation compatibility layer introduced in #3187.

- Replace `_DeprecatedShapeCollisionFilterSet` with a compact read-only set view.
- Remove `ModelBuilder.find_shape_contact_pairs()` and its deprecation-only fallback path.
- Preserve packed collision-filter queries and ViewerFile round-trips.
- Update collision-filter documentation, regression coverage, and release notes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the changelog fragment instructions

## Test plan

```console
uv run --extra dev -m newton.tests -k collision_filter
uv run --extra dev -m newton.tests -k test_model
uvx pre-commit run -a
uvx --from towncrier==25.8.0 towncrier build --draft --version X.Y.Z --date 2026-09-03
```

The collision-filter suite passed 41 tests. The broader model run passed 177 tests and skipped 109 unavailable or unsupported cases.

## New feature / API change

Configure collision filters before finalizing the model:

```python
builder.add_shape_collision_filter_pair(shape_a, shape_b)
model = builder.finalize()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Finalized models now expose `shape_collision_filter_pairs` as a read-only set-like view. In-place modifications and reassignment are no longer supported.
  * Configure collision filter pairs on `ModelBuilder` before finalizing. Rebuild the model after changing them.
  * Removed `ModelBuilder.find_shape_contact_pairs()`.

* **Compatibility**
  * Collision filter pairs are preserved correctly when saving and restoring models.
  * Solver model views now retain the parent model’s filter-pair representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->