### PR TITLE
Start Newton 1.7 development

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -75,6 +75,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.6.0.dev0``
+     - ``1.7.0.dev0``
    * - ``use_coord_layout_targets``
      - ``True``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.7.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.6.0.dev0"
+version = "1.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Start Newton 1.7 development after cutting the `release-1.6` branch.

This advances the project version to `1.7.0.dev0` and regenerates the public
API version reference and lock metadata so every version source agrees.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

No changelog fragment is needed because this is release-development metadata.

## Test plan

```console
uv run docs/generate_api.py
uv lock --check
uv run --extra dev -m newton.tests -k test_generate_api
uvx --python 3.12 pre-commit run -a
uv build --out-dir /tmp/newton-release-1.7-build
```

The built wheel was also installed into an isolated environment; both its
metadata and `newton.__version__` reported `1.7.0.dev0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to **1.7.0.dev0**.
  * Synchronized the documented version with the current project release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->