### PR TITLE
Raise named error for unmappable MuJoCo shape types

### DIFF
--- a/changelog/4064.fixed.md
+++ b/changelog/4064.fixed.md
@@ -1,0 +1,1 @@
+Raise a named `ValueError` when `SolverMuJoCo` encounters a shape type it cannot map to a MuJoCo geom (e.g. cones), instead of failing with a bare `KeyError`.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -6361,6 +6361,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
                 if stype == GeoType.PLANE and newton_body_id != -1:
                     raise ValueError("Planes can only be attached to static bodies")
+                if stype not in geom_type_mapping:
+                    raise ValueError(
+                        f"MuJoCo solver does not support shape type '{GeoType(stype).name}' "
+                        f"for shape {model.shape_label[shape]!r} (shape {shape}). "
+                        "Replace it with a supported primitive (sphere, capsule, cylinder, box, "
+                        "ellipsoid) or a convex mesh."
+                    )
                 geom_params = {
                     "type": geom_type_mapping[stype],
                     "name": name,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -5872,6 +5872,22 @@ class TestMuJoCoValidation(unittest.TestCase):
             SolverMuJoCo(model, separate_worlds=True)
         self.assertIn("shape types mismatch at position", str(ctx.exception).lower())
 
+    def test_unsupported_shape_type_raises(self):
+        """Test that a shape type without a MuJoCo geom mapping raises a named ValueError."""
+        builder = newton.ModelBuilder()
+        b1 = builder.add_link(mass=1.0, com=wp.vec3(0, 0, 0), inertia=wp.mat33(np.eye(3)))
+        j1 = builder.add_joint_free(b1)
+        builder.add_articulation([j1])
+        builder.add_shape_cone(b1, radius=0.2, half_height=0.3)
+
+        model = builder.finalize()
+
+        with self.assertRaises(ValueError) as ctx:
+            SolverMuJoCo(model)
+        message = str(ctx.exception)
+        self.assertIn("does not support shape type 'CONE'", message)
+        self.assertIn("convex mesh", message)
+
     def test_global_body_fails(self):
         """Test that a body in global world (-1) raises ValueError."""
         builder = newton.ModelBuilder()


### PR DESCRIPTION
﻿## Description

`GeoType.CONE` is a valid Newton shape (`ModelBuilder.add_shape_cone()`), but it has no entry in `geom_type_mapping`, so building a `SolverMuJoCo` over a model containing one crashed with a bare `KeyError: np.int32(9)` raised from inside a dict lookup at solver construction. The caller gets nothing actionable, and because the failure happens at solver construction, the model ends up with no solver at all.

This PR raises a named `ValueError` instead, stating the unsupported shape type, the shape label and index, and the supported alternatives (primitives or a convex mesh). Sites already fall back to spheres, so only collision geoms are affected.

The check is generic (membership in `geom_type_mapping`), so it also covers any future Newton shape types without a MuJoCo mapping, not just cones.

Closes #4064

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- New regression test `test_unsupported_shape_type_raises` (in `TestMuJoCoValidation`) builds a model with a cone and asserts `SolverMuJoCo` raises a named `ValueError`.
- Verified the test fails without the fix (fails with `KeyError: np.int32(9)`, the exact error from the issue) and passes with it.
- Full class run: `uv run --extra dev -m newton.tests -k TestMuJoCoValidation` — 16/16 OK.

## Bug fix

**Steps to reproduce:**

1. Build a Newton model containing a cone shape (`builder.add_shape_cone(...)`).
2. Construct `newton.solvers.SolverMuJoCo(model)`.
3. Observe a bare `KeyError: np.int32(9)` from `geom_type_mapping[stype]` instead of a diagnosable error.

**Minimal reproduction:**

```python
import newton, warp as wp

builder = newton.ModelBuilder()
body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 1.0), wp.quat_identity()))
builder.add_shape_cone(body, radius=0.2, half_height=0.3)
builder.add_ground_plane()
model = builder.finalize()
newton.solvers.SolverMuJoCo(model)  # KeyError: np.int32(9)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported shape types in the MuJoCo solver now produce a clear `ValueError` identifying the shape and recommending a supported primitive or convex mesh.
* **Documentation**
  * Documented the updated error behavior for unsupported geometry types.
* **Tests**
  * Added coverage to verify that unsupported cone shapes raise the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->