### PR TITLE
Preserve explicit mass for small MJCF geoms

### DIFF
--- a/changelog/+mjcf-explicit-small-mass-9c3a2f.fixed.md
+++ b/changelog/+mjcf-explicit-small-mass-9c3a2f.fixed.md
@@ -1,0 +1,1 @@
+Preserve explicit MJCF geom mass and inertia for small primitive geoms.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -50,6 +50,10 @@ from .import_utils import (
 )
 from .mesh import load_meshes_from_file
 
+# Inertia helpers are evaluated at 1 kg/m³, so this is the reference mass
+# of a cube measuring 0.1 mm on each side.
+_MIN_EXPLICIT_MASS_REFERENCE_MASS = 1.0e-12
+
 
 def _default_path_resolver(base_dir: str | None, file_path: str) -> str:
     """Default path resolver - joins base_dir with file_path.
@@ -1451,7 +1455,7 @@ def parse_mjcf(
                 if geom_type == "sphere":
                     r = geom_size[0]
                     m_computed, com, inertia_tensor = compute_inertia_sphere(1.0, r)
-                    if m_computed > 1e-6:
+                    if m_computed >= _MIN_EXPLICIT_MASS_REFERENCE_MASS:
                         inertia_tensor = inertia_tensor * (geom_mass_explicit / m_computed)
                         inertia_computed = True
                 elif geom_type == "box":
@@ -1462,18 +1466,18 @@ def parse_mjcf(
                     inertia_computed = True
                 elif geom_type == "cylinder":
                     m_computed, com, inertia_tensor = compute_inertia_cylinder(1.0, geom_radius, geom_height)
-                    if m_computed > 1e-6:
+                    if m_computed >= _MIN_EXPLICIT_MASS_REFERENCE_MASS:
                         inertia_tensor = inertia_tensor * (geom_mass_explicit / m_computed)
                         inertia_computed = True
                 elif geom_type == "capsule":
                     m_computed, com, inertia_tensor = compute_inertia_capsule(1.0, geom_radius, geom_height)
-                    if m_computed > 1e-6:
+                    if m_computed >= _MIN_EXPLICIT_MASS_REFERENCE_MASS:
                         inertia_tensor = inertia_tensor * (geom_mass_explicit / m_computed)
                         inertia_computed = True
                 elif geom_type == "ellipsoid":
                     rx, ry, rz = geom_size[0], geom_size[1], geom_size[2]
                     m_computed, com, inertia_tensor = compute_inertia_ellipsoid(1.0, rx, ry, rz)
-                    if m_computed > 1e-6:
+                    if m_computed >= _MIN_EXPLICIT_MASS_REFERENCE_MASS:
                         inertia_tensor = inertia_tensor * (geom_mass_explicit / m_computed)
                         inertia_computed = True
                 else:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -1705,6 +1705,29 @@ class TestImportMjcfGeometry(unittest.TestCase):
         # Body 6: mass="0" should also have zero inertia
         self.assertAlmostEqual(np.trace(body_inertia[6]), 0.0, places=6, msg="Body 6 (mass=0) should have zero inertia")
 
+    def test_explicit_geom_mass_for_small_primitives(self):
+        """Apply explicit mass above a (0.1 mm)^3 reference-volume cutoff."""
+        mjcf_content = """
+<mujoco model="small_explicit_mass_test">
+    <worldbody>
+        <body name="sphere"><freejoint/><geom type="sphere" size="0.005" mass="0.1"/></body>
+        <body name="cylinder"><freejoint/><geom type="cylinder" size="0.003 0.005" mass="0.2"/></body>
+        <body name="capsule"><freejoint/><geom type="capsule" size="0.003 0.005" mass="0.3"/></body>
+        <body name="ellipsoid"><freejoint/><geom type="ellipsoid" size="0.004 0.005 0.006" mass="0.4"/></body>
+        <body name="above_cutoff"><freejoint/><geom type="sphere" size="0.00007" mass="0.5"/></body>
+        <body name="below_cutoff"><freejoint/><geom type="sphere" size="0.00005" mass="0.6"/></body>
+    </worldbody>
+</mujoco>
+"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content)
+        model = builder.finalize()
+
+        np.testing.assert_allclose(model.body_mass.numpy(), [0.1, 0.2, 0.3, 0.4, 0.5, 0.0], rtol=1e-6)
+        for body_index, inertia in enumerate(model.body_inertia.numpy()[:5]):
+            self.assertGreater(np.trace(inertia), 0.0, msg=f"Body {body_index} should have non-zero inertia")
+        self.assertEqual(np.trace(model.body_inertia.numpy()[5]), 0.0)
+
     def test_explicit_small_mesh_geom_mass(self):
         """Test that a positive mass on a solid or hollow mesh sets body mass and inertia."""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Context
  Using a sphere collider the size of a human finger tip fails in the MJCF pipeline. This PR tries to resolve this.

  [This PR is AI generated, but human reviewed]

## Description

  Preserve authored mass and inertia for small MJCF sphere, cylinder, capsule, and ellipsoid geoms.

  The previous one-cubic-centimeter unit-density cutoff incorrectly discarded explicit mass for realistic small primitives. Lower the cutoff to the volume of a cube measuring 0.1 mm on each side while retaining protection against effectively degenerate geometry.

  Add regression coverage for small primitives and values immediately above and below the new cutoff.

  ## Checklist

  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

  ## Test plan

  - `uv run --extra dev -m newton.tests -k test_explicit_geom_mass_for_small_primitives`


  ## Bug fix

  **Steps to reproduce:**

  1. Import an MJCF body containing a 5 mm-radius sphere with an explicit mass.
  2. Finalize the model.
  3. Observe that the explicit mass and inertia are discarded.

  **Minimal reproduction:**

  ```python
  import newton

  mjcf = """
  <mujoco>
      <worldbody>
          <body>
              <freejoint/>
              <geom type="sphere" size="0.005" mass="0.1"/>
          </body>
      </worldbody>
  </mujoco>
  """

  builder = newton.ModelBuilder()
  builder.add_mjcf(mjcf)
  model = builder.finalize()

  print(model.body_mass.numpy()[0])
  print(model.body_inertia.numpy()[0])
  ```

  Before this change, the mass and inertia are zero. Afterward, the authored mass is `0.1` and the inertia is nonzero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicit mass and inertia values are now preserved for very small MJCF sphere, cylinder, capsule, and ellipsoid geoms when their reference mass is above the supported cutoff.
  - Extremely small geoms below the cutoff continue to receive zero mass and inertia.

- **Tests**
  - Added coverage for explicit mass handling across small primitive geometries and cutoff boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->