### PR TITLE
Keep sparse tile flooring correct across Warp versions

### DIFF
--- a/newton/_src/geometry/particle_surface_sparse_kernels.py
+++ b/newton/_src/geometry/particle_surface_sparse_kernels.py
@@ -67,9 +67,9 @@ def _is_finite(position: wp.vec3) -> bool:
 
 @wp.func
 def _floor_tile_coordinate(coordinate: int) -> int:
-    if coordinate < 0:
-        return ((coordinate - (_TILE_SIZE - 1)) // _TILE_SIZE) * _TILE_SIZE
-    return (coordinate // _TILE_SIZE) * _TILE_SIZE
+    # Sparse leaves are fixed at 8^3 voxels. Masking with -_TILE_SIZE clears
+    # the local-coordinate bits, rounding down to the enclosing leaf origin.
+    return coordinate & -_TILE_SIZE
 
 
 @wp.func

--- a/newton/tests/test_particle_surface.py
+++ b/newton/tests/test_particle_surface.py
@@ -7,12 +7,22 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.geometry.particle_surface_sparse_kernels import _floor_tile_coordinate
 from newton.geometry import ParticleSurface, extract_particle_surface
 from newton.solvers import SolverImplicitMPM
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 _TEST_MAX_GRID_CELLS = 32_768
 _TEST_MULTI_WORLD_MAX_GRID_CELLS = 49_152
+
+
+@wp.kernel
+def _floor_tile_coordinates_kernel(
+    coordinates: wp.array[wp.int32],
+    tile_origins: wp.array[wp.int32],
+):
+    index = wp.tid()
+    tile_origins[index] = _floor_tile_coordinate(coordinates[index])
 
 
 @wp.kernel
@@ -88,6 +98,27 @@ def _sorted_vertices(vertices):
     """Return mesh vertices in deterministic lexicographic order."""
     values = vertices.numpy()
     return values[np.lexsort(values.T[::-1])]
+
+
+def test_floor_tile_coordinates(test, device):
+    """Round negative and positive coordinates down to 8-voxel tile boundaries."""
+    coordinates = wp.array(
+        [-17, -16, -15, -9, -8, -7, -2, -1, 0, 1, 7, 8, 9, 15, 16],
+        dtype=wp.int32,
+        device=device,
+    )
+    expected = np.array([-24, -16, -16, -16, -8, -8, -8, -8, 0, 0, 0, 8, 8, 8, 16], dtype=np.int32)
+    tile_origins = wp.empty_like(coordinates)
+
+    wp.launch(
+        _floor_tile_coordinates_kernel,
+        dim=coordinates.shape[0],
+        inputs=[coordinates],
+        outputs=[tile_origins],
+        device=device,
+    )
+
+    np.testing.assert_array_equal(tile_origins.numpy(), expected)
 
 
 def test_one_shot(test, device):
@@ -733,6 +764,7 @@ class TestParticleSurface(unittest.TestCase):
 
 devices = get_test_devices(mode="basic")
 
+add_function_test(TestParticleSurface, "test_floor_tile_coordinates", test_floor_tile_coordinates, devices=devices)
 add_function_test(TestParticleSurface, "test_one_shot", test_one_shot, devices=devices)
 add_function_test(TestParticleSurface, "test_reusable_context", test_reusable_context, devices=devices)
 add_function_test(TestParticleSurface, "test_multi_world_mesh", test_multi_world_mesh, devices=devices)


### PR DESCRIPTION
## Description

Warp commit [7784b3e365](https://github.com/NVIDIA/warp/commit/7784b3e365f0d09abd4d20bacee1ba7f86727696) corrected signed integer `//` so negative quotients floor toward negative infinity instead of truncating toward zero.

Newton's sparse particle surface code currently compensates for the old truncating behavior by subtracting `_TILE_SIZE - 1` before dividing negative coordinates. With Warp's corrected semantics, that adjustment can move a coordinate into the preceding tile. For example, the tile boundary `-8` becomes `-16` instead of remaining `-8`.

This PR replaces the signed floor division with:

```python
coordinate & -_TILE_SIZE
```

Sparse leaves are fixed at 8x8x8 voxels, so this mask clears the local-coordinate bits and rounds down to the enclosing tile origin. It avoids signed floor division altogether, giving the same result with Warp 1.17 and with Warp versions containing the corrected floor-division behavior.

A regression test covers exact tile boundaries and nearby positive and negative coordinates on CPU and CUDA.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md) (Not applicable. This preserves the existing intended behavior.)

## Test plan

Tested the tile-coordinate regression on CPU and CUDA with:

- Warp 1.17.0, which truncates signed integer division toward zero
- Warp 1.18.0.dev3 with the corrected floor-division behavior
- A CUDA particle surface integration test using the corrected Warp build

Tests run:

```text
TestParticleSurface.test_floor_tile_coordinates_cpu
TestParticleSurface.test_floor_tile_coordinates_cuda_0
TestParticleSurface.test_isotropic_particle_sdf_samples_cuda_0
```

All configured pre-commit hooks also pass.

## Bug fix

**Steps to reproduce:**

1. Use Newton from `main` with a Warp build containing commit `7784b3e365`.
2. Evaluate `_floor_tile_coordinate()` for negative coordinates around an 8-voxel tile boundary.
3. Observe that values such as `-8` are assigned to the preceding tile.

**Minimal reproduction:**

```python
import warp as wp

from newton._src.geometry.particle_surface_sparse_kernels import _floor_tile_coordinate


@wp.kernel
def evaluate(output: wp.array[wp.int32]):
    output[0] = _floor_tile_coordinate(-8)


output = wp.empty(1, dtype=wp.int32)
wp.launch(evaluate, dim=1, outputs=[output])

print(output.numpy())  # Before: [-16], after: [-8]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tile boundary calculations for both positive and negative coordinates, ensuring values consistently round down to 8-voxel boundaries.

* **Tests**
  * Added coverage for tile coordinate calculations across positive and negative inputs and supported basic-mode devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->