### PR TITLE
Fix linesearch warnings in conveyor tests

### DIFF
--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -16,7 +16,7 @@ import warp as wp
 
 import newton
 from newton.examples.basic.example_basic_conveyor_forces import ConveyorForceModel
-from newton.tests.unittest_utils import add_function_test, get_test_devices
+from newton.tests.unittest_utils import NewtonTestCase, add_function_test, get_test_devices
 
 BELT_HALF_X = 1.5
 BELT_HALF_Y = 6.0
@@ -25,7 +25,9 @@ BELT_TOP_Z = 0.5
 BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
-SPAWN_GAP = 0.004  # matches the spawn clearance used by the conveyor example [m]
+
+_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
+_MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations \w+ \d+\n?"
 
 
 def _make_solver(solver_name, model):
@@ -36,7 +38,9 @@ def _make_solver(solver_name, model):
         )
     if solver_name == "mujoco":
         # MuJoCo configuration for Newton-generated contacts.
-        return newton.solvers.SolverMuJoCo(model, cone="elliptic", use_mujoco_contacts=False, njmax=200, nconmax=100)
+        return newton.solvers.SolverMuJoCo(
+            model, cone="elliptic", use_mujoco_contacts=False, njmax=200, nconmax=100, ls_iterations=100
+        )
     return newton.solvers.SolverXPBD(model)
 
 
@@ -78,7 +82,7 @@ def run_conveyor(
     )
 
     box_body = builder.add_link(
-        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + BOX_HALF + SPAWN_GAP), q=wp.quat_identity()),
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + BOX_HALF + 0.01), q=wp.quat_identity()),
         label="box",
     )
     builder.add_shape_box(
@@ -200,7 +204,7 @@ def run_multi_belt(device, solver_name, belts, box_xy, *, box_half=(0.45, 0.2, 0
         belt_shapes.append(s)
 
     box_body = builder.add_link(
-        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + box_half[2] + SPAWN_GAP), q=wp.quat_identity()),
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + box_half[2] + 0.01), q=wp.quat_identity()),
         mass=1.0,
         label="box",
     )
@@ -446,8 +450,13 @@ def test_backend_parity(test, device, _solver_name):
     test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
 
 
-class TestConveyorForces(unittest.TestCase):
+class TestConveyorForces(NewtonTestCase):
     """Scenario matrix for the force-based conveyor model."""
+
+    def setUp(self):
+        super().setUp()
+        self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
+        self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")
 
 
 _devices = get_test_devices()

--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -16,7 +16,7 @@ import warp as wp
 
 import newton
 from newton.examples.basic.example_basic_conveyor_forces import ConveyorForceModel
-from newton.tests.unittest_utils import NewtonTestCase, add_function_test, get_test_devices
+from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 BELT_HALF_X = 1.5
 BELT_HALF_Y = 6.0
@@ -25,9 +25,7 @@ BELT_TOP_Z = 0.5
 BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
-
-_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
-_MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations to \d+\n?"
+SPAWN_GAP = 0.004  # matches the spawn clearance used by the conveyor example [m]
 
 
 def _make_solver(solver_name, model):
@@ -80,7 +78,7 @@ def run_conveyor(
     )
 
     box_body = builder.add_link(
-        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + BOX_HALF + 0.01), q=wp.quat_identity()),
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + BOX_HALF + SPAWN_GAP), q=wp.quat_identity()),
         label="box",
     )
     builder.add_shape_box(
@@ -202,7 +200,7 @@ def run_multi_belt(device, solver_name, belts, box_xy, *, box_half=(0.45, 0.2, 0
         belt_shapes.append(s)
 
     box_body = builder.add_link(
-        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + box_half[2] + 0.01), q=wp.quat_identity()),
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + box_half[2] + SPAWN_GAP), q=wp.quat_identity()),
         mass=1.0,
         label="box",
     )
@@ -448,13 +446,8 @@ def test_backend_parity(test, device, _solver_name):
     test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
 
 
-class TestConveyorForces(NewtonTestCase):
+class TestConveyorForces(unittest.TestCase):
     """Scenario matrix for the force-based conveyor model."""
-
-    def setUp(self):
-        super().setUp()
-        self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
-        self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")
 
 
 _devices = get_test_devices()

--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -16,7 +16,7 @@ import warp as wp
 
 import newton
 from newton.examples.basic.example_basic_conveyor_forces import ConveyorForceModel
-from newton.tests.unittest_utils import add_function_test, get_test_devices
+from newton.tests.unittest_utils import NewtonTestCase, add_function_test, get_test_devices
 
 BELT_HALF_X = 1.5
 BELT_HALF_Y = 6.0
@@ -25,6 +25,9 @@ BELT_TOP_Z = 0.5
 BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
+
+_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
+_MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations to \d+\n?"
 
 
 def _make_solver(solver_name, model):
@@ -445,8 +448,13 @@ def test_backend_parity(test, device, _solver_name):
     test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
 
 
-class TestConveyorForces(unittest.TestCase):
+class TestConveyorForces(NewtonTestCase):
     """Scenario matrix for the force-based conveyor model."""
+
+    def setUp(self):
+        super().setUp()
+        self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
+        self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")
 
 
 _devices = get_test_devices()

--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -16,7 +16,7 @@ import warp as wp
 
 import newton
 from newton.examples.basic.example_basic_conveyor_forces import ConveyorForceModel
-from newton.tests.unittest_utils import NewtonTestCase, add_function_test, get_test_devices
+from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 BELT_HALF_X = 1.5
 BELT_HALF_Y = 6.0
@@ -25,9 +25,6 @@ BELT_TOP_Z = 0.5
 BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
-
-_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
-_MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations \w+ \d+\n?"
 
 
 def _make_solver(solver_name, model):
@@ -450,13 +447,8 @@ def test_backend_parity(test, device, _solver_name):
     test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
 
 
-class TestConveyorForces(NewtonTestCase):
+class TestConveyorForces(unittest.TestCase):
     """Scenario matrix for the force-based conveyor model."""
-
-    def setUp(self):
-        super().setUp()
-        self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
-        self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")
 
 
 _devices = get_test_devices()


### PR DESCRIPTION
## Description
The minimum-deps nightly failed on `test_long_running_stability_cuda_0`.  the failure came from unexpected stdout.

MuJoCo Warp 3.12.0, adopted in #4119, added device-side overflow diagnostics
(google-deepmind/mujoco_warp#1579). One of them prints when the Newton solver's
linesearch does not converge within `ls_iterations`. Newton's test harness fails
a test on any unexpected output.
The message text is also misleading: `"please increase ls_iterations to 50"`
prints the *current* value, so it asks you to increase a limit to what it already
is. Already corrected upstream in google-deepmind/mujoco_warp#1611 to say
"beyond".

### The fix

1. **`ls_iterations=100` for the conveyor tests.** The scene converges in 28-30
   iterations on an RTX 6000 Ada but exceeded the default of 50 on the CI runner.
   The linesearch breaks out as soon as it converges, so the higher cap is free.

2. **Tolerate the message via `NewtonTestCase.allowOutputRegex`.** The number of
   iterations actually required is hardware dependent and non deterministic, so the raised cap is a margin rather than a guarantee.
   The regex accepts both the current wording and the corrected upstream one.
<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated conveyor-force validation to use a more robust solver configuration.
  * Restored standard test output handling and warning behavior for more representative test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->