### PR TITLE
Remove inconsistent internal Kamino state reset

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/dvi/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/dvi/solver.py
@@ -329,11 +329,16 @@ class DVISolver:
             self._sparse_path.contacts = contacts
 
     def reset(self, problem: DualProblem | None = None, world_mask: wp.array[wp.bool] | None = None):
-        """Reset scratch state and cached solution data."""
+        """
+        Resets the persistent solution cache used for internal warm-starting, for all worlds
+        or the subset selected by `world_mask`.
+
+        This does not touch the scratch solver state (`self._data.state`) or the diagnostics
+        (`self._data.info`). `state` is unconditionally reinitialized by `coldstart()`/`warmstart()`
+        before every `solve()` call, and `info.status` is unconditionally overwritten wholesale at
+        the end of every `solve()` call, so resetting either here would be redundant.
+        """
         if world_mask is None:
-            self._data.state.reset()
-            if self._data.info is not None:
-                self._data.info.zero()
             self._data.solution.zero()
         else:
             if problem is None:

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -283,12 +283,14 @@ class PADMMSolver:
 
     def reset(self, problem: DualProblem | None = None, world_mask: wp.array[wp.bool] | None = None):
         """
-        Resets the all internal solver data to sentinel values.
+        Resets the persistent solution cache used for internal warm-starting, for all worlds
+        or the subset selected by `world_mask`.
+
+        This does not modify the scratch solver state (`self._data.state`), since that is
+        unconditionally reinitialized by `coldstart()`/`warmstart()`.
         """
-        # Reset the solution cache, which could be used for internal warm-starting
-        # If no world mask is provided, reset data of all worlds
+        # If no world mask is provided, reset the solution cache of all worlds
         if world_mask is None:
-            self._data.state.reset(use_acceleration=self._use_acceleration)
             self._data.solution.zero()
 
         # Otherwise, only the solution cache of the specified worlds
@@ -342,8 +344,9 @@ class PADMMSolver:
             contacts: The contacts container associated with the model.
                 If `None`, no warm-starting from contacts is performed.
         """
-        # TODO: IS THIS EVEN NECESSARY AT ALL?
-        # First reset the internal solver state to ensure proper initialization
+        # Reset the internal solver state first. Wwarmstarting will only populate
+        # the primal/dual iterate variables, all remaining fields need a clean
+        # initialization.
         self._data.state.reset(use_acceleration=self._use_acceleration)
 
         # Warm-start based on the selected mode


### PR DESCRIPTION
## Description

The PADMM and DVI solvers have internal states (and `info` for DVI) that are currently not consistently handled during a `reset()` call:
* If `reset()` is called without a `world_mask`, the state (and info) is reset.
* If `reset()` is called with a `world_mask`, then state (and info) are left as they are.

Since no array values are reused by the solvers (internal state is reset at every iteration, by `coldstart()` or `warmstart()`, while the info is just overwritten at the end of the iteration), this has not led to any issues. However, this inconcistency is not ideal.

This PR presents one solution, just removing the internal state and info reset from `reset()`, since the solver will always reinitialize them anyway.

Another solution is to enable the state and info resets to take a `world_mask`, in which case a consistent reset could be enabled. The downside of this is that it adds more bloat, custom kernels, and a small loss in reset performance.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved solver reset behavior to preserve transient computation and diagnostic state while clearing persistent solution data.
  * Warm-start operations now reliably reset and repopulate solver state before use.
  * Solver preparation and completion now consistently reinitialize or update temporary state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->