### PR TITLE
Backport conveyor test stability fix to release-1.6

### DIFF
--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -35,7 +35,9 @@ def _make_solver(solver_name, model):
         )
     if solver_name == "mujoco":
         # MuJoCo configuration for Newton-generated contacts.
-        return newton.solvers.SolverMuJoCo(model, cone="elliptic", use_mujoco_contacts=False, njmax=200, nconmax=100)
+        return newton.solvers.SolverMuJoCo(
+            model, cone="elliptic", use_mujoco_contacts=False, njmax=200, nconmax=100, ls_iterations=100
+        )
     return newton.solvers.SolverXPBD(model)
 
 


### PR DESCRIPTION
## Description

Backport #4163 to `release-1.6`.

Increase the MuJoCo line-search iteration limit used by the conveyor tests to
prevent the intermittent solver warning that fails the test output contract.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (test-only change)
- [x] No changelog fragment is needed because this is a test-only change

## Test plan

```console
uv run --extra dev -m newton.tests -k test_conveyor_forces.TestConveyorForces.test_long_running_stability_cuda_0
uvx --python 3.12 pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the long-running conveyor stability test on CUDA.
2. Observe that MuJoCo Warp can emit `linesearch iterations limit reached`,
   which the test harness rejects as unexpected output.

Source PR: #4163
