### PR TITLE
Honor explicit MuJoCo buffer capacities

### DIFF
--- a/changelog/4168.fixed.md
+++ b/changelog/4168.fixed.md
@@ -1,0 +1,1 @@
+Honor explicit `SolverMuJoCo` `nconmax` and `njmax` capacities instead of increasing them to conservative Newton contact estimates.

--- a/docs/concepts/simulation_tuning_mujoco.rst
+++ b/docs/concepts/simulation_tuning_mujoco.rst
@@ -280,10 +280,13 @@ practice:
 ``nconmax`` and ``njmax`` size the **per-world** contact and constraint buffers.
 Set them for the busiest world, not the average: a buffer that fits a quiet
 world can truncate contacts or constraints in a heavier one, while an oversized
-buffer wastes GPU memory multiplied across every world. If left unset, they are
-estimated from the initial state; monitor overflow counters or warnings and raise
-the relevant buffer when needed. A positive gap can increase the number of
-detected contacts even though contacts outside the margin remain inactive.
+buffer wastes GPU memory multiplied across every world. If left unset, Newton
+estimates them automatically. Explicit values set fixed capacities instead of
+lower bounds for those estimates. A value that cannot hold the initial MuJoCo
+contacts or constraints may still be increased with a warning. Monitor overflow
+counters or warnings and raise the relevant buffer when needed. A positive gap
+can increase the number of detected contacts even though contacts outside the
+margin remain inactive.
 After changing gaps or upgrading margin/gap behavior, remeasure peak contacts,
 constraints, and overflow in the busiest world before compensating with
 stiffness or iterations; do not assume the previous run generated the same rows.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3737,9 +3737,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         Args:
             model: The model to be simulated.
             separate_worlds: If True, each Newton world is mapped to a separate MuJoCo world. Defaults to `not use_mujoco_cpu`.
-            njmax: Maximum number of constraints per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
+            njmax: Maximum number of constraints per world. If None, a default
+                value is estimated automatically. An explicit value is preserved
+                unless it cannot hold the initial MuJoCo constraints.
             njmax_nnz: Sparse constraint Jacobian nonzero capacity per world. If provided, must be non-negative and large enough for the initial sparse Jacobian. If None, derived from the model's constraint counts and njmax.
-            nconmax: Number of contact points per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
+            nconmax: Number of contact points per world. If None, a default value
+                is estimated automatically. An explicit value is preserved unless
+                it cannot hold the initial MuJoCo contacts.
             iterations: Number of solver iterations. If None, uses model custom attribute or MuJoCo's default (100).
             ls_iterations: Number of line search iterations for the solver. If None, uses model custom attribute or MuJoCo's default (50).
             ccd_iterations: Maximum CCD iterations. If None, uses model custom attribute or MuJoCo's default (35).
@@ -7781,41 +7785,35 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             if disable_contacts:
                 nconmax = 0
             elif not self._use_mujoco_contacts:
-                # The initialization forward intentionally produces no contacts
-                # in this mode, so size MJWarp from Newton's collision budget.
-                from mujoco_warp._src.io import _default_njmax as estimate_mujoco_warp_njmax
-
-                newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
-                default_nconmax = (newton_contact_max + nworld - 1) // nworld
                 if nconmax is None:
-                    nconmax = default_nconmax
-                elif nconmax >= 0:
-                    nconmax = max(nconmax, default_nconmax)
+                    # The initialization forward intentionally produces no contacts
+                    # in this mode, so size MJWarp from Newton's collision budget.
+                    newton_contact_max = model.rigid_contact_max or _estimate_rigid_contact_max(model)
+                    nconmax = (newton_contact_max + nworld - 1) // nworld
 
-                max_contact_dim = max(
-                    1,
-                    int(np.max(self.mj_model.geom_condim, initial=1)),
-                    int(np.max(self.mj_model.pair_dim, initial=1)),
-                )
-                if self.mj_model.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC:
-                    constraint_rows_per_contact = max_contact_dim
-                else:
-                    constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
-
-                # MJWarp stores contacts in one heterogeneous buffer, so every
-                # contact can belong to any compatible world even though
-                # nconmax is passed as a per-world allocation. Constraint rows
-                # are strictly per-world, so size them from the busiest-world
-                # topology rather than duplicating the global capacity.
-                per_world_contact_max = _estimate_rigid_contact_max_per_world(model, nconmax * nworld)
-                default_njmax = max(
-                    estimate_mujoco_warp_njmax(self.mj_model, self.mj_data),
-                    self.mj_data.nefc + per_world_contact_max * constraint_rows_per_contact,
-                )
                 if njmax is None:
-                    njmax = default_njmax
-                elif njmax >= 0:
-                    njmax = max(njmax, default_njmax)
+                    from mujoco_warp._src.io import _default_njmax as estimate_mujoco_warp_njmax
+
+                    max_contact_dim = max(
+                        1,
+                        int(np.max(self.mj_model.geom_condim, initial=1)),
+                        int(np.max(self.mj_model.pair_dim, initial=1)),
+                    )
+                    if self.mj_model.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC:
+                        constraint_rows_per_contact = max_contact_dim
+                    else:
+                        constraint_rows_per_contact = max(1, 2 * (max_contact_dim - 1))
+
+                    # MJWarp stores contacts in one heterogeneous buffer, so every
+                    # contact can belong to any compatible world even though
+                    # nconmax is passed as a per-world allocation. Constraint rows
+                    # are strictly per-world, so size them from the busiest-world
+                    # topology rather than duplicating the global capacity.
+                    per_world_contact_max = _estimate_rigid_contact_max_per_world(model, nconmax * nworld)
+                    njmax = max(
+                        estimate_mujoco_warp_njmax(self.mj_model, self.mj_data),
+                        self.mj_data.nefc + per_world_contact_max * constraint_rows_per_contact,
+                    )
             elif nconmax is not None and nconmax < self.mj_data.ncon:
                 warnings.warn(
                     f"[WARNING] Value for nconmax is changed from {nconmax} to {self.mj_data.ncon} following an MjWarp requirement.",

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3739,11 +3739,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             separate_worlds: If True, each Newton world is mapped to a separate MuJoCo world. Defaults to `not use_mujoco_cpu`.
             njmax: Maximum number of constraints per world. If None, a default
                 value is estimated automatically. An explicit value is preserved
-                unless it cannot hold the initial MuJoCo constraints.
+                unless it cannot hold the initial MuJoCo constraints; in that case,
+                it is increased with a warning.
             njmax_nnz: Sparse constraint Jacobian nonzero capacity per world. If provided, must be non-negative and large enough for the initial sparse Jacobian. If None, derived from the model's constraint counts and njmax.
             nconmax: Number of contact points per world. If None, a default value
                 is estimated automatically. An explicit value is preserved unless
-                it cannot hold the initial MuJoCo contacts.
+                it cannot hold the initial MuJoCo contacts; in that case, it is
+                increased with a warning.
             iterations: Number of solver iterations. If None, uses model custom attribute or MuJoCo's default (100).
             ls_iterations: Number of line search iterations for the solver. If None, uses model custom attribute or MuJoCo's default (50).
             ccd_iterations: Maximum CCD iterations. If None, uses model custom attribute or MuJoCo's default (35).

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4471,6 +4471,45 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         self.assertEqual(solver.mjw_data.naconmax, nconmax)
         self.assertEqual(solver.mjw_data.njmax, njmax)
 
+    def test_explicit_nconmax_below_initial_contacts_is_increased(self):
+        """Increase an explicit contact capacity below initial MuJoCo contacts."""
+        model = self._build_grounded_spheres(60)
+
+        try:
+            SolverMuJoCo.import_mujoco()
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        with self.assertWarnsRegex(UserWarning, r"Value for nconmax is changed from 16 to 60"):
+            solver = SolverMuJoCo(model, use_mujoco_contacts=True, nconmax=16)
+
+        self.assertEqual(solver.mjw_data.naconmax, 60)
+
+    def test_explicit_njmax_below_initial_constraints_is_increased(self):
+        """Increase an explicit constraint capacity below initial MuJoCo constraints."""
+        builder = newton.ModelBuilder()
+        inertia = wp.mat33(np.eye(3) * 0.1)
+        for _ in range(5):
+            body = builder.add_link(mass=1.0, com=wp.vec3(), inertia=inertia)
+            joint = builder.add_joint_revolute(
+                parent=-1,
+                child=body,
+                limit_lower=1.0,
+                limit_upper=2.0,
+            )
+            builder.add_articulation([joint])
+        model = builder.finalize()
+
+        try:
+            SolverMuJoCo.import_mujoco()
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        with self.assertWarnsRegex(UserWarning, r"Value for njmax is changed from 1 to 5"):
+            solver = SolverMuJoCo(model, use_mujoco_contacts=False, nconmax=1, njmax=1)
+
+        self.assertEqual(solver.mjw_data.njmax, 5)
+
     def test_newton_contact_capacity_preserves_delayed_joint_limits(self):
         """Preserve default capacity for non-contact constraints activated after initialization."""
         joint_count = 10

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4452,29 +4452,24 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
         self.assertEqual(injected_contact_count, generated_contact_count)
 
-    def test_newton_contact_defaults_bound_explicit_capacities(self):
-        """Preserve Newton-derived lower bounds for explicit MuJoCo capacities."""
+    def test_newton_contact_explicit_capacities_are_preserved(self):
+        """Preserve explicit MuJoCo capacities for Newton-generated contacts."""
         model = self._build_grounded_spheres(60)
-        state = model.state()
-        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
-        collision_pipeline = newton.CollisionPipeline(model)
-        contacts = collision_pipeline.contacts()
-        collision_pipeline.collide(state, contacts)
-        generated_contact_count = int(contacts.rigid_contact_count.numpy()[0])
+        nconmax = 200
+        njmax = 300
 
         try:
-            solver = SolverMuJoCo(model, use_mujoco_contacts=False, nconmax=16, njmax=16)
+            solver = SolverMuJoCo(
+                model,
+                use_mujoco_contacts=False,
+                nconmax=nconmax,
+                njmax=njmax,
+            )
         except ImportError as e:
             self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
 
-        self.assertGreater(generated_contact_count, 48)
-        self.assertGreater(model.rigid_contact_max, 16)
-        self.assertGreaterEqual(solver.mjw_data.naconmax, model.rigid_contact_max)
-        self.assertGreaterEqual(solver.mjw_data.njmax, model.rigid_contact_max * 4)
-
-        solver._convert_contacts_to_mjwarp(model, state, contacts)
-        injected_contact_count = int(solver.mjw_data.nacon.numpy()[0])
-        self.assertEqual(injected_contact_count, generated_contact_count)
+        self.assertEqual(solver.mjw_data.naconmax, nconmax)
+        self.assertEqual(solver.mjw_data.njmax, njmax)
 
     def test_newton_contact_capacity_preserves_delayed_joint_limits(self):
         """Preserve default capacity for non-contact constraints activated after initialization."""


### PR DESCRIPTION
## Description

Closes #4168.

Use Newton's conservative contact-topology estimates for `nconmax` and `njmax`
only when the corresponding `SolverMuJoCo` argument is `None`. Explicit values
now remain caller-selected capacities instead of minimum hints, avoiding large
per-world MuJoCo Warp allocations in replicated workloads.

PR #3825 removed an initialization-only MuJoCo contact pass that had acted as
an accidental sizing probe even when Newton generated contacts. Replacing that
probe with explicit automatic sizing was necessary, but applying the automatic
topology estimate as a mandatory lower bound to user-provided values caused the
memory regression reported in #4168.

This PR deliberately preserves the pre-existing warning-and-increase behavior
when an explicit value cannot contain contacts or constraints already present
in the initial MuJoCo state. Turning that compatibility behavior into a hard
error would expand this regression fix and break workflows that currently
continue after the warning. An opt-in hard-cap/strict behavior can instead be
considered with the overflow-reporting work in #4086.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- `uv run --extra dev newton/tests/test_mujoco_solver.py` — 298 passed, 7 skipped
- `uvx --python 3.12 pre-commit run -a` — passed
- Towncrier draft build for 1.7.0 — passed

The focused regression test was also verified to fail before the implementation
change: a requested `nconmax=200` resolved to `naconmax=3300`.

## Bug fix

**Steps to reproduce:**

1. Build a model with enough collision topology for the automatic estimate to
   exceed `nconmax=200` and `njmax=300`.
2. Construct `SolverMuJoCo` with Newton-generated contacts and those explicit
   capacities.
3. Observe that the resolved MuJoCo Warp buffers exceed both requested values.

**Minimal reproduction:**

```python
import newton
import warp as wp

builder = newton.ModelBuilder()
builder.add_ground_plane()
for i in range(60):
    body = builder.add_body(
        xform=wp.transform(
            wp.vec3(float(i % 10) * 2.0, float(i // 10) * 2.0, 10.0),
            wp.quat_identity(),
        )
    )
    builder.add_shape_sphere(body=body, radius=0.5)

model = builder.finalize()
newton.CollisionPipeline(model)
solver = newton.solvers.SolverMuJoCo(
    model,
    use_mujoco_contacts=False,
    nconmax=200,
    njmax=300,
)

assert solver.mjw_data.naconmax == 200
assert solver.mjw_data.njmax == 300
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Explicit `nconmax` and `njmax` settings are now honored instead of being silently increased based on estimated contact or constraint capacity.
  - If a configured capacity is too small for the model’s initial contacts or constraints, it is increased automatically and a warning is issued.

- **Documentation**
  - Clarified automatic capacity estimation when values are unset and when configured values may still be adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->