### PR TITLE
Add USD parsing required to implement CollisionPipeline.create_from_usd()

### DIFF
--- a/changelog/+collision-pipeline-usd-api-9d4b7a2c.added.md
+++ b/changelog/+collision-pipeline-usd-api-9d4b7a2c.added.md
@@ -1,0 +1,1 @@
+Add `CollisionPipeline.create_from_usd()` to configure Newton's collision pipeline from `NewtonCollisionPipelineAPI` attributes on a USD physics scene.

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -7,7 +7,7 @@ import dataclasses
 import math
 import operator
 import warnings
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import warp as wp
@@ -42,6 +42,9 @@ from ..geometry.types import GeoType
 from ..sim.contacts import Contacts
 from ..sim.model import Model
 from ..sim.state import State
+
+if TYPE_CHECKING:
+    from pxr import Usd, UsdPhysics
 
 
 def _shape_collide_mask(model: Model, shape_count: int | None = None) -> np.ndarray:
@@ -1871,7 +1874,9 @@ class CollisionPipeline:
         self._soft_self_contact_detector: TriMeshCollisionDetector | None = None
 
     @classmethod
-    def create_from_usd(cls, scene_prim: Any, model: Model, **overrides: Any) -> CollisionPipeline:
+    def create_from_usd(
+        cls, scene_prim: Usd.Prim | UsdPhysics.Scene, model: Model, **overrides: Any
+    ) -> CollisionPipeline:
         """Create a :class:`CollisionPipeline` from ``NewtonCollisionPipelineAPI``.
 
         Reads ``newton:collisionPipeline:*`` attributes off ``scene_prim``.

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1939,7 +1939,8 @@ class CollisionPipeline:
                 suffix = " or -1" if allow_minus_one else ""
                 raise ValueError(f"{path}: {name} must be non-negative{suffix}, got {result}.")
             if result == 0 and disallow_zero:
-                raise ValueError(f"{path}: {name} must be a positive integer or -1, got {result}.")
+                suffix = " or -1" if allow_minus_one else ""
+                raise ValueError(f"{path}: {name} must be a positive integer{suffix}, got {result}.")
             return result
 
         def token(name: str, value: Any, allowed: set[str]) -> str:
@@ -1994,7 +1995,9 @@ class CollisionPipeline:
 
         value = authored("newton:collisionPipeline:maxTrianglePairs")
         if value is not None:
-            kwargs["max_triangle_pairs"] = integer("newton:collisionPipeline:maxTrianglePairs", value)
+            kwargs["max_triangle_pairs"] = integer(
+                "newton:collisionPipeline:maxTrianglePairs", value, disallow_zero=True
+            )
 
         value = authored("newton:collisionPipeline:rigidContactMax")
         if value is not None:
@@ -2063,6 +2066,11 @@ class CollisionPipeline:
         value = authored("newton:collisionPipeline:contactReport")
         if value is not None:
             kwargs["contact_report"] = bool(value)
+            if kwargs["contact_report"] and kwargs.get("contact_matching", "disabled") == "disabled":
+                raise ValueError(
+                    f"{path}: newton:collisionPipeline:contactReport=True requires "
+                    "newton:collisionPipeline:contactMatching != 'disabled'."
+                )
 
         value = authored("newton:collisionPipeline:verifyBuffers")
         if value is not None:

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import dataclasses
+import math
+import operator
 import warnings
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import warp as wp
@@ -1867,6 +1869,199 @@ class CollisionPipeline:
         # the shared detector (re-pointed per Contacts buffer; see
         # _get_soft_self_contact_detector).
         self._soft_self_contact_detector: TriMeshCollisionDetector | None = None
+
+    @classmethod
+    def create_from_usd(cls, scene_prim: Any, model: Model, **overrides: Any) -> CollisionPipeline:
+        """Create a :class:`CollisionPipeline` from ``NewtonCollisionPipelineAPI``.
+
+        Reads ``newton:collisionPipeline:*`` attributes off ``scene_prim``.
+        Only authored USD values override the :meth:`__init__`
+        defaults, so unauthored attributes fall back to the same defaults as
+        constructing :class:`CollisionPipeline` directly. ``overrides`` take
+        precedence over both USD-authored and default values.
+
+        Args:
+            scene_prim: A ``UsdPhysics.Scene`` prim with ``NewtonCollisionPipelineAPI``
+                applied, or its typed schema object.
+            model: The simulation model to build the pipeline for.
+            **overrides: Additional :meth:`__init__` keyword arguments that take
+                precedence over the USD-authored values.
+
+        Returns:
+            A :class:`CollisionPipeline` instance.
+
+        Raises:
+            TypeError: If ``scene_prim`` is not a USD physics scene prim.
+            ValueError: If the API is absent or an authored value is invalid.
+        """
+        try:
+            from pxr import UsdPhysics
+        except ImportError as error:
+            raise ImportError("Creating a CollisionPipeline from USD requires usd-core.") from error
+
+        from ..usd import utils as usd  # noqa: PLC0415
+
+        prim = scene_prim.GetPrim() if hasattr(scene_prim, "GetPrim") else scene_prim
+        if not prim or not prim.IsValid() or not prim.IsA(UsdPhysics.Scene):
+            raise TypeError("scene_prim must be a valid UsdPhysics.Scene prim.")
+        path = str(prim.GetPath())
+        if not usd.has_applied_api_schema(prim, "NewtonCollisionPipelineAPI"):
+            raise ValueError(f"{path}: NewtonCollisionPipelineAPI is not applied.")
+
+        def authored(name: str) -> Any:
+            attr = prim.GetAttribute(name)
+            if not attr or not attr.HasAuthoredValue():
+                return None
+            value = attr.Get()
+            if value is None:
+                raise ValueError(f"{path}: authored attribute {name!r} has no value.")
+            return value
+
+        def integer(name: str, value: Any, *, allow_minus_one: bool = False) -> int:
+            if isinstance(value, (bool, np.bool_)):
+                raise ValueError(f"{path}: {name} must be an integer, got {value!r}.")
+            try:
+                result = operator.index(value)
+            except TypeError as error:
+                raise ValueError(f"{path}: {name} must be an integer, got {value!r}.") from error
+            if result < 0 and not (allow_minus_one and result == -1):
+                suffix = " or -1" if allow_minus_one else ""
+                raise ValueError(f"{path}: {name} must be non-negative{suffix}, got {result}.")
+            return result
+
+        def token(name: str, value: Any, allowed: set[str]) -> str:
+            result = str(value)
+            if result not in allowed:
+                raise ValueError(f"{path}: {name} must be one of {sorted(allowed)}, got {result!r}.")
+            return result
+
+        def finite_float(name: str, value: Any, *, minimum: float | None = None, maximum: float | None = None) -> float:
+            try:
+                result = float(value)
+            except (TypeError, ValueError) as error:
+                raise ValueError(f"{path}: {name} must be a number, got {value!r}.") from error
+            out_of_range = (minimum is not None and result < minimum) or (maximum is not None and result > maximum)
+            if not math.isfinite(result) or out_of_range:
+                bounds = ""
+                if minimum is not None and maximum is not None:
+                    bounds = f" in [{minimum}, {maximum}]"
+                elif minimum is not None:
+                    bounds = f" >= {minimum}"
+                elif maximum is not None:
+                    bounds = f" <= {maximum}"
+                raise ValueError(f"{path}: {name} must be a finite number{bounds}, got {value!r}.")
+            return result
+
+        def optional_finite_float(name: str, value: Any, *, minimum: float | None = None) -> float | None:
+            """Parse a float attribute using the ``-inf`` sentinel convention for "unset"."""
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError) as error:
+                raise ValueError(f"{path}: {name} must be a number, got {value!r}.") from error
+            if numeric == float("-inf"):
+                return None
+            return finite_float(name, numeric, minimum=minimum)
+
+        kwargs: dict[str, Any] = {}
+
+        value = authored("newton:collisionPipeline:broadPhase")
+        if value is not None:
+            kwargs["broad_phase"] = token("newton:collisionPipeline:broadPhase", value, {"nxn", "sap", "explicit"})
+
+        value = authored("newton:collisionPipeline:maxTrianglePairs")
+        if value is not None:
+            kwargs["max_triangle_pairs"] = integer("newton:collisionPipeline:maxTrianglePairs", value)
+
+        value = authored("newton:collisionPipeline:rigidContactMax")
+        if value is not None:
+            result = integer("newton:collisionPipeline:rigidContactMax", value, allow_minus_one=True)
+            if result != -1:
+                kwargs["rigid_contact_max"] = result
+
+        value = authored("newton:collisionPipeline:reduceContacts")
+        if value is not None:
+            kwargs["reduce_contacts"] = bool(value)
+
+        value = authored("newton:collisionPipeline:softContactMax")
+        if value is not None:
+            result = integer("newton:collisionPipeline:softContactMax", value, allow_minus_one=True)
+            if result != -1:
+                kwargs["soft_contact_max"] = result
+
+        value = authored("newton:collisionPipeline:softContactGap")
+        if value is not None:
+            gap = optional_finite_float("newton:collisionPipeline:softContactGap", value, minimum=0.0)
+            if gap is not None:
+                kwargs["soft_contact_gap"] = gap
+
+        value = authored("newton:collisionPipeline:enableRigidSoftFullSurfaceContact")
+        if value is not None:
+            kwargs["enable_rigid_soft_full_surface_contact"] = bool(value)
+
+        value = authored("newton:collisionPipeline:requiresGrad")
+        if value is not None:
+            result = token("newton:collisionPipeline:requiresGrad", value, {"inherit", "true", "false"})
+            if result != "inherit":
+                kwargs["requires_grad"] = result == "true"
+
+        value = authored("newton:collisionPipeline:deterministic")
+        if value is not None:
+            kwargs["deterministic"] = bool(value)
+
+        value = authored("newton:collisionPipeline:includeStaticKinematicPairs")
+        if value is not None:
+            kwargs["include_static_kinematic_pairs"] = bool(value)
+
+        value = authored("newton:collisionPipeline:shapePairsMax")
+        if value is not None:
+            result = integer("newton:collisionPipeline:shapePairsMax", value, allow_minus_one=True)
+            if result != -1:
+                kwargs["shape_pairs_max"] = result
+
+        value = authored("newton:collisionPipeline:contactMatching")
+        if value is not None:
+            kwargs["contact_matching"] = token(
+                "newton:collisionPipeline:contactMatching", value, {"disabled", "latest", "sticky"}
+            )
+
+        value = authored("newton:collisionPipeline:contactMatchingPosThreshold")
+        if value is not None:
+            kwargs["contact_matching_pos_threshold"] = finite_float(
+                "newton:collisionPipeline:contactMatchingPosThreshold", value, minimum=0.0
+            )
+
+        value = authored("newton:collisionPipeline:contactMatchingNormalDotThreshold")
+        if value is not None:
+            kwargs["contact_matching_normal_dot_threshold"] = finite_float(
+                "newton:collisionPipeline:contactMatchingNormalDotThreshold", value, minimum=-1.0, maximum=1.0
+            )
+
+        value = authored("newton:collisionPipeline:contactReport")
+        if value is not None:
+            kwargs["contact_report"] = bool(value)
+
+        value = authored("newton:collisionPipeline:verifyBuffers")
+        if value is not None:
+            kwargs["verify_buffers"] = bool(value)
+
+        value = authored("newton:collisionPipeline:contactReductionHashtableSizeFactor")
+        if value is not None:
+            result = finite_float("newton:collisionPipeline:contactReductionHashtableSizeFactor", value)
+            if not math.isfinite(result) or result <= 0.0:
+                raise ValueError(
+                    f"{path}: newton:collisionPipeline:contactReductionHashtableSizeFactor must be a "
+                    f"finite number > 0, got {result!r}."
+                )
+            kwargs["contact_reduction_hashtable_size_factor"] = result
+
+        value = authored("newton:collisionPipeline:speculativeMaxExtension")
+        if value is not None:
+            extension = optional_finite_float("newton:collisionPipeline:speculativeMaxExtension", value, minimum=0.0)
+            if extension is not None:
+                kwargs["speculative_config"] = cls.SpeculativeContactConfig(max_speculative_extension=extension)
+
+        kwargs.update(overrides)
+        return cls(model, **kwargs)
 
     @property
     def rigid_contact_max(self) -> int:

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1878,7 +1878,11 @@ class CollisionPipeline:
         Only authored USD values override the :meth:`__init__`
         defaults, so unauthored attributes fall back to the same defaults as
         constructing :class:`CollisionPipeline` directly. ``overrides`` take
-        precedence over both USD-authored and default values.
+        precedence over both USD-authored and default values. Length values
+        (``softContactGap``, ``contactMatchingPosThreshold``,
+        ``speculativeMaxExtension``) are authored in stage units and converted
+        to meters. Following :meth:`ModelBuilder.add_usd`, unauthored stage
+        unit metadata is interpreted as one meter per stage unit.
 
         Args:
             scene_prim: A ``UsdPhysics.Scene`` prim with ``NewtonCollisionPipelineAPI``
@@ -1895,7 +1899,7 @@ class CollisionPipeline:
             ValueError: If the API is absent or an authored value is invalid.
         """
         try:
-            from pxr import UsdPhysics
+            from pxr import UsdGeom, UsdPhysics
         except ImportError as error:
             raise ImportError("Creating a CollisionPipeline from USD requires usd-core.") from error
 
@@ -1907,6 +1911,13 @@ class CollisionPipeline:
         path = str(prim.GetPath())
         if not usd.has_applied_api_schema(prim, "NewtonCollisionPipelineAPI"):
             raise ValueError(f"{path}: NewtonCollisionPipelineAPI is not applied.")
+
+        stage = prim.GetStage()
+        linear_unit = (
+            float(UsdGeom.GetStageMetersPerUnit(stage)) if UsdGeom.StageHasAuthoredMetersPerUnit(stage) else 1.0
+        )
+        if not math.isfinite(linear_unit) or linear_unit <= 0.0:
+            raise ValueError(f"{path}: metersPerUnit must be finite and positive, got {linear_unit!r}.")
 
         def authored(name: str) -> Any:
             attr = prim.GetAttribute(name)
@@ -2005,7 +2016,7 @@ class CollisionPipeline:
         if value is not None:
             gap = optional_finite_float("newton:collisionPipeline:softContactGap", value, minimum=0.0)
             if gap is not None:
-                kwargs["soft_contact_gap"] = gap
+                kwargs["soft_contact_gap"] = gap * linear_unit
 
         value = authored("newton:collisionPipeline:enableRigidSoftFullSurfaceContact")
         if value is not None:
@@ -2039,8 +2050,8 @@ class CollisionPipeline:
 
         value = authored("newton:collisionPipeline:contactMatchingPosThreshold")
         if value is not None:
-            kwargs["contact_matching_pos_threshold"] = finite_float(
-                "newton:collisionPipeline:contactMatchingPosThreshold", value, minimum=0.0
+            kwargs["contact_matching_pos_threshold"] = (
+                finite_float("newton:collisionPipeline:contactMatchingPosThreshold", value, minimum=0.0) * linear_unit
             )
 
         value = authored("newton:collisionPipeline:contactMatchingNormalDotThreshold")
@@ -2071,7 +2082,9 @@ class CollisionPipeline:
         if value is not None:
             extension = optional_finite_float("newton:collisionPipeline:speculativeMaxExtension", value, minimum=0.0)
             if extension is not None:
-                kwargs["speculative_config"] = cls.SpeculativeContactConfig(max_speculative_extension=extension)
+                kwargs["speculative_config"] = cls.SpeculativeContactConfig(
+                    max_speculative_extension=extension * linear_unit
+                )
 
         kwargs.update(overrides)
         return cls(model, **kwargs)

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1954,15 +1954,26 @@ class CollisionPipeline:
                 raise ValueError(f"{path}: {name} must be a finite number{bounds}, got {value!r}.")
             return result
 
-        def optional_finite_float(name: str, value: Any, *, minimum: float | None = None) -> float | None:
-            """Parse a float attribute using the ``-inf`` sentinel convention for "unset"."""
+        def optional_finite_float(name: str, value: Any, *, minimum: float) -> float | None:
+            """Parse a float attribute using the ``-inf`` sentinel convention for "unset".
+
+            A value below ``minimum`` warns and falls back to "unset" instead of
+            raising, mirroring the soft-limit convention used for
+            ``newton:hydroelasticStiffness``.
+            """
             try:
                 numeric = float(value)
             except (TypeError, ValueError) as error:
                 raise ValueError(f"{path}: {name} must be a number, got {value!r}.") from error
             if numeric == float("-inf"):
                 return None
-            return finite_float(name, numeric, minimum=minimum)
+            if not math.isfinite(numeric) or numeric < minimum:
+                warnings.warn(
+                    f"{path}: {name}={numeric!r} is invalid (must be >= {minimum}); falling back to default.",
+                    stacklevel=2,
+                )
+                return None
+            return numeric
 
         kwargs: dict[str, Any] = {}
 

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -2070,11 +2070,6 @@ class CollisionPipeline:
         value = authored("newton:collisionPipeline:contactReport")
         if value is not None:
             kwargs["contact_report"] = bool(value)
-            if kwargs["contact_report"] and kwargs.get("contact_matching", "disabled") == "disabled":
-                raise ValueError(
-                    f"{path}: newton:collisionPipeline:contactReport=True requires "
-                    "newton:collisionPipeline:contactMatching != 'disabled'."
-                )
 
         value = authored("newton:collisionPipeline:verifyBuffers")
         if value is not None:
@@ -2099,6 +2094,13 @@ class CollisionPipeline:
                 )
 
         kwargs.update(overrides)
+
+        if kwargs.get("contact_report", False) and kwargs.get("contact_matching", "disabled") == "disabled":
+            raise ValueError(
+                f"{path}: contact_report=True requires contact_matching != 'disabled' "
+                "(from newton:collisionPipeline:contactReport/contactMatching or **overrides)."
+            )
+
         return cls(model, **kwargs)
 
     @property

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1917,7 +1917,7 @@ class CollisionPipeline:
                 raise ValueError(f"{path}: authored attribute {name!r} has no value.")
             return value
 
-        def integer(name: str, value: Any, *, allow_minus_one: bool = False) -> int:
+        def integer(name: str, value: Any, *, allow_minus_one: bool = False, disallow_zero: bool = False) -> int:
             if isinstance(value, (bool, np.bool_)):
                 raise ValueError(f"{path}: {name} must be an integer, got {value!r}.")
             try:
@@ -1927,6 +1927,8 @@ class CollisionPipeline:
             if result < 0 and not (allow_minus_one and result == -1):
                 suffix = " or -1" if allow_minus_one else ""
                 raise ValueError(f"{path}: {name} must be non-negative{suffix}, got {result}.")
+            if result == 0 and disallow_zero:
+                raise ValueError(f"{path}: {name} must be a positive integer or -1, got {result}.")
             return result
 
         def token(name: str, value: Any, allowed: set[str]) -> str:
@@ -2014,7 +2016,7 @@ class CollisionPipeline:
 
         value = authored("newton:collisionPipeline:shapePairsMax")
         if value is not None:
-            result = integer("newton:collisionPipeline:shapePairsMax", value, allow_minus_one=True)
+            result = integer("newton:collisionPipeline:shapePairsMax", value, allow_minus_one=True, disallow_zero=True)
             if result != -1:
                 kwargs["shape_pairs_max"] = result
 

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -1905,7 +1905,11 @@ class CollisionPipeline:
 
         from ..usd import utils as usd  # noqa: PLC0415
 
-        prim = scene_prim.GetPrim() if hasattr(scene_prim, "GetPrim") else scene_prim
+        get_prim = getattr(scene_prim, "GetPrim", None)
+        prim = get_prim() if callable(get_prim) else scene_prim
+        prim_type = type(prim)
+        if not callable(getattr(prim_type, "IsValid", None)) or not callable(getattr(prim_type, "IsA", None)):
+            raise TypeError("scene_prim must be a valid UsdPhysics.Scene prim.")
         if not prim or not prim.IsValid() or not prim.IsA(UsdPhysics.Scene):
             raise TypeError("scene_prim must be a valid UsdPhysics.Scene prim.")
         path = str(prim.GetPath())

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -555,6 +555,14 @@ class TestCollisionPipeline(unittest.TestCase):
             CollisionPipeline.create_from_usd(scene_prim, model)
         scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Clear()
 
+        # 0 is illegal for shapePairsMax: only -1 (sentinel) or positive values are valid.
+        scene_prim.GetAttribute("newton:collisionPipeline:shapePairsMax").Set(0)
+        with self.assertRaisesRegex(
+            ValueError, r"newton:collisionPipeline:shapePairsMax must be a positive integer or -1, got 0"
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:shapePairsMax").Clear()
+
         # Float outside the valid [-1, 1] range.
         scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingNormalDotThreshold").Set(1.5)
         with self.assertRaisesRegex(

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -590,6 +590,10 @@ class TestCollisionPipeline(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "scene_prim must be a valid UsdPhysics.Scene prim"):
             CollisionPipeline.create_from_usd(invalid_prim, model)
 
+        # Arbitrary inputs should fail with the documented TypeError.
+        with self.assertRaisesRegex(TypeError, "scene_prim must be a valid UsdPhysics.Scene prim"):
+            CollisionPipeline.create_from_usd(object(), model)
+
         # NewtonCollisionPipelineAPI is not applied to an otherwise valid scene prim.
         scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
         with self.assertRaisesRegex(ValueError, r"physicsScene: NewtonCollisionPipelineAPI is not applied"):

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -355,7 +355,9 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reads_all_attributes(self):
-        """Read authored collision-pipeline USD attributes."""
+        """Fall back to CollisionPipeline.__init__ defaults when NewtonCollisionPipelineAPI
+        is applied but unauthored, then use the authored newton:collisionPipeline:*
+        values once every attribute is set."""
         from pxr import Usd, UsdPhysics
 
         builder = newton.ModelBuilder()
@@ -464,9 +466,9 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_accepts_typed_schema_and_sentinels_and_honors_overrides(self):
-        """create_from_usd should accept the typed schema object directly, treat the
-        documented -1/-inf sentinels as "unset" (falling back to __init__ defaults),
-        and let **overrides take precedence over authored USD values."""
+        """Accept the typed UsdPhysics.Scene object directly, treat the documented
+        -1/-inf sentinels as "unset" by falling back to __init__ defaults, and let
+        **overrides take precedence over authored USD values."""
         from pxr import Usd, UsdPhysics
 
         builder = newton.ModelBuilder()
@@ -512,9 +514,9 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_soft_limits_warn_and_fall_back_to_default(self):
-        """softContactGap and speculativeMaxExtension below their minimum are a soft
-        limit: create_from_usd warns and falls back to the __init__ default instead
-        of raising, mirroring the newton:hydroelasticStiffness convention."""
+        """Warn and fall back to the __init__ default, instead of raising, when
+        softContactGap or speculativeMaxExtension is authored below its minimum,
+        mirroring the newton:hydroelasticStiffness soft-limit convention."""
         from pxr import Usd, UsdPhysics
 
         builder = newton.ModelBuilder()
@@ -542,9 +544,9 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_converts_length_attributes_to_meters(self):
-        """softContactGap, contactMatchingPosThreshold, and speculativeMaxExtension
-        are authored in stage units and must be converted to meters, matching the
-        geometry ModelBuilder.add_usd() would import from the same stage."""
+        """Convert softContactGap, contactMatchingPosThreshold, and
+        speculativeMaxExtension from stage units to meters, matching the geometry
+        ModelBuilder.add_usd() would import from the same stage."""
         from pxr import Usd, UsdGeom, UsdPhysics
 
         builder = newton.ModelBuilder()
@@ -570,7 +572,7 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reports_errors(self):
-        """create_from_usd should raise with a descriptive message for invalid input."""
+        """Raise a descriptive, path-prefixed error for each invalid create_from_usd input."""
         from pxr import Usd, UsdGeom, UsdPhysics
 
         builder = newton.ModelBuilder()
@@ -663,9 +665,10 @@ class TestCollisionPipeline(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reads_contact_reduction_hashtable_size_factor(self):
-        """Verified separately: only observable when reduce_contacts is on and the
-        model has meshes/heightfields, which conflicts with the other attribute
-        overrides exercised together in test_create_from_usd_reads_all_attributes."""
+        """Verify contactReductionHashtableSizeFactor separately, since it is only
+        observable when reduce_contacts is on and the model has meshes/heightfields,
+        which conflicts with the other attribute overrides exercised together in
+        test_create_from_usd_reads_all_attributes."""
         from pxr import Usd, UsdPhysics
 
         builder = newton.ModelBuilder()

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -512,6 +512,15 @@ class TestCollisionPipeline(unittest.TestCase):
         self.assertEqual(override_pipeline.broad_phase_mode, "nxn")
         self.assertFalse(override_pipeline.reduce_contacts)
 
+        # contactReport=True is authored with contactMatching left at its "disabled"
+        # default, so the contact_report/contact_matching cross-field check must be
+        # evaluated after overrides are merged in, not before -- otherwise a
+        # contact_matching override could never satisfy it.
+        prim.GetAttribute("newton:collisionPipeline:contactReport").Set(True)
+        override_matching_pipeline = CollisionPipeline.create_from_usd(scene, model, contact_matching="latest")
+        self.assertTrue(override_matching_pipeline.contact_report)
+        self.assertEqual(override_matching_pipeline.contact_matching, "latest")
+
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_soft_limits_warn_and_fall_back_to_default(self):
         """Warn and fall back to the __init__ default, instead of raising, when
@@ -631,8 +640,7 @@ class TestCollisionPipeline(unittest.TestCase):
         scene_prim.GetAttribute("newton:collisionPipeline:contactReport").Set(True)
         with self.assertRaisesRegex(
             ValueError,
-            r"physicsScene: newton:collisionPipeline:contactReport=True requires "
-            r"newton:collisionPipeline:contactMatching != 'disabled'",
+            r"physicsScene: contact_report=True requires contact_matching != 'disabled'",
         ):
             CollisionPipeline.create_from_usd(scene_prim, model)
         scene_prim.GetAttribute("newton:collisionPipeline:contactReport").Clear()

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -463,6 +463,117 @@ class TestCollisionPipeline(unittest.TestCase):
         self.assertAlmostEqual(pipeline._contact_matcher._normal_dot_threshold, 0.9)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_accepts_typed_schema_and_sentinels_and_honors_overrides(self):
+        """create_from_usd should accept the typed schema object directly, treat the
+        documented -1/-inf sentinels as "unset" (falling back to __init__ defaults),
+        and let **overrides take precedence over authored USD values."""
+        from pxr import Usd, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+
+        default_pipeline = CollisionPipeline(model)
+
+        stage = Usd.Stage.CreateInMemory()
+        scene = UsdPhysics.Scene.Define(stage, "/World/physicsScene")
+        scene.GetPrim().ApplyAPI("NewtonCollisionPipelineAPI")
+
+        # Passing the typed schema object (not scene.GetPrim()) should work.
+        typed_pipeline = CollisionPipeline.create_from_usd(scene, model)
+        self.assertEqual(typed_pipeline.rigid_contact_max, default_pipeline.rigid_contact_max)
+        self.assertEqual(typed_pipeline.broad_phase_mode, default_pipeline.broad_phase_mode)
+
+        # -1 is a documented sentinel meaning "unset" for these attributes, distinct
+        # from leaving them unauthored, so it should still fall back to the default.
+        prim = scene.GetPrim()
+        prim.GetAttribute("newton:collisionPipeline:rigidContactMax").Set(-1)
+        prim.GetAttribute("newton:collisionPipeline:softContactMax").Set(-1)
+        prim.GetAttribute("newton:collisionPipeline:shapePairsMax").Set(-1)
+        # -inf is the documented sentinel for optional float attributes.
+        prim.GetAttribute("newton:collisionPipeline:softContactGap").Set(float("-inf"))
+        prim.GetAttribute("newton:collisionPipeline:speculativeMaxExtension").Set(float("-inf"))
+
+        sentinel_pipeline = CollisionPipeline.create_from_usd(scene, model)
+        self.assertEqual(sentinel_pipeline.rigid_contact_max, default_pipeline.rigid_contact_max)
+        self.assertEqual(sentinel_pipeline.soft_contact_max, default_pipeline.soft_contact_max)
+        self.assertEqual(sentinel_pipeline.shape_pairs_max, default_pipeline.shape_pairs_max)
+        self.assertAlmostEqual(sentinel_pipeline.soft_contact_gap, default_pipeline.soft_contact_gap)
+        self.assertEqual(sentinel_pipeline.speculative_config, default_pipeline.speculative_config)
+
+        # **overrides take precedence over authored USD values.
+        prim.GetAttribute("newton:collisionPipeline:broadPhase").Set("sap")
+        prim.GetAttribute("newton:collisionPipeline:reduceContacts").Set(True)
+        override_pipeline = CollisionPipeline.create_from_usd(scene, model, broad_phase="nxn", reduce_contacts=False)
+        self.assertEqual(override_pipeline.broad_phase_mode, "nxn")
+        self.assertFalse(override_pipeline.reduce_contacts)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_reports_errors(self):
+        """create_from_usd should raise with a descriptive message for invalid input."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+
+        stage = Usd.Stage.CreateInMemory()
+
+        # scene_prim is not a UsdPhysics.Scene prim.
+        not_a_scene = UsdGeom.Xform.Define(stage, "/World/notAScene").GetPrim()
+        with self.assertRaisesRegex(TypeError, "scene_prim must be a valid UsdPhysics.Scene prim"):
+            CollisionPipeline.create_from_usd(not_a_scene, model)
+
+        # scene_prim is invalid (never defined on the stage).
+        invalid_prim = stage.GetPrimAtPath("/World/doesNotExist")
+        with self.assertRaisesRegex(TypeError, "scene_prim must be a valid UsdPhysics.Scene prim"):
+            CollisionPipeline.create_from_usd(invalid_prim, model)
+
+        # NewtonCollisionPipelineAPI is not applied to an otherwise valid scene prim.
+        scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
+        with self.assertRaisesRegex(ValueError, r"physicsScene: NewtonCollisionPipelineAPI is not applied"):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+
+        scene_prim.ApplyAPI("NewtonCollisionPipelineAPI")
+
+        # Invalid token value.
+        scene_prim.GetAttribute("newton:collisionPipeline:broadPhase").Set("not_a_valid_mode")
+        with self.assertRaisesRegex(
+            ValueError, r"newton:collisionPipeline:broadPhase must be one of .*, got 'not_a_valid_mode'"
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:broadPhase").Clear()
+
+        # Negative integer where only non-negative (or -1) is allowed.
+        scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Set(-5)
+        with self.assertRaisesRegex(
+            ValueError, r"newton:collisionPipeline:maxTrianglePairs must be non-negative, got -5"
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Clear()
+
+        # Float outside the valid [-1, 1] range.
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingNormalDotThreshold").Set(1.5)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"newton:collisionPipeline:contactMatchingNormalDotThreshold must be a finite number in \[-1.0, 1.0\], "
+            r"got 1.5",
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingNormalDotThreshold").Clear()
+
+        # Non-positive hashtable size factor.
+        scene_prim.GetAttribute("newton:collisionPipeline:contactReductionHashtableSizeFactor").Set(0.0)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"newton:collisionPipeline:contactReductionHashtableSizeFactor must be a finite number > 0, got 0.0",
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reads_contact_reduction_hashtable_size_factor(self):
         """Verified separately: only observable when reduce_contacts is on and the
         model has meshes/heightfields, which conflicts with the other attribute

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -511,6 +511,36 @@ class TestCollisionPipeline(unittest.TestCase):
         self.assertFalse(override_pipeline.reduce_contacts)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_soft_limits_warn_and_fall_back_to_default(self):
+        """softContactGap and speculativeMaxExtension below their minimum are a soft
+        limit: create_from_usd warns and falls back to the __init__ default instead
+        of raising, mirroring the newton:hydroelasticStiffness convention."""
+        from pxr import Usd, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+
+        default_pipeline = CollisionPipeline(model)
+
+        stage = Usd.Stage.CreateInMemory()
+        scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
+        scene_prim.ApplyAPI("NewtonCollisionPipelineAPI")
+
+        scene_prim.GetAttribute("newton:collisionPipeline:softContactGap").Set(-0.1)
+        with self.assertWarnsRegex(UserWarning, r"newton:collisionPipeline:softContactGap=-0\.\d+ is invalid"):
+            pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+        self.assertAlmostEqual(pipeline.soft_contact_gap, default_pipeline.soft_contact_gap)
+        scene_prim.GetAttribute("newton:collisionPipeline:softContactGap").Clear()
+
+        scene_prim.GetAttribute("newton:collisionPipeline:speculativeMaxExtension").Set(-0.1)
+        with self.assertWarnsRegex(UserWarning, r"newton:collisionPipeline:speculativeMaxExtension=-0\.\d+ is invalid"):
+            pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+        self.assertEqual(pipeline.speculative_config, default_pipeline.speculative_config)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reports_errors(self):
         """create_from_usd should raise with a descriptive message for invalid input."""
         from pxr import Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -541,6 +541,34 @@ class TestCollisionPipeline(unittest.TestCase):
         self.assertEqual(pipeline.speculative_config, default_pipeline.speculative_config)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_converts_length_attributes_to_meters(self):
+        """softContactGap, contactMatchingPosThreshold, and speculativeMaxExtension
+        are authored in stage units and must be converted to meters, matching the
+        geometry ModelBuilder.add_usd() would import from the same stage."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageMetersPerUnit(stage, 0.01)  # centimeters
+        scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
+        scene_prim.ApplyAPI("NewtonCollisionPipelineAPI")
+        scene_prim.GetAttribute("newton:collisionPipeline:softContactGap").Set(2.0)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingPosThreshold").Set(1.0)
+        scene_prim.GetAttribute("newton:collisionPipeline:speculativeMaxExtension").Set(15.0)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatching").Set("latest")
+
+        pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+
+        self.assertAlmostEqual(pipeline.soft_contact_gap, 0.02)
+        self.assertAlmostEqual(pipeline._contact_matcher._pos_threshold_sq, 0.01**2)
+        self.assertAlmostEqual(pipeline.speculative_config.max_speculative_extension, 0.15)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_create_from_usd_reports_errors(self):
         """create_from_usd should raise with a descriptive message for invalid input."""
         from pxr import Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -613,6 +613,24 @@ class TestCollisionPipeline(unittest.TestCase):
             CollisionPipeline.create_from_usd(scene_prim, model)
         scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Clear()
 
+        # 0 is illegal for maxTrianglePairs.
+        scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Set(0)
+        with self.assertRaisesRegex(
+            ValueError, r"newton:collisionPipeline:maxTrianglePairs must be a positive integer, got 0"
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Clear()
+
+        # contactReport=True requires contactMatching != "disabled" (the default).
+        scene_prim.GetAttribute("newton:collisionPipeline:contactReport").Set(True)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"physicsScene: newton:collisionPipeline:contactReport=True requires "
+            r"newton:collisionPipeline:contactMatching != 'disabled'",
+        ):
+            CollisionPipeline.create_from_usd(scene_prim, model)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactReport").Clear()
+
         # 0 is illegal for shapePairsMax: only -1 (sentinel) or positive values are valid.
         scene_prim.GetAttribute("newton:collisionPipeline:shapePairsMax").Set(0)
         with self.assertRaisesRegex(

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -48,6 +48,7 @@ from newton._src.utils.heightfield import HeightfieldData
 from newton.examples import test_body_state
 from newton.geometry import BroadPhaseAllPairs, NarrowPhase
 from newton.tests.unittest_utils import (
+    USD_AVAILABLE,
     add_function_test,
     configure_sdf_for_collision_shapes,
     get_cuda_test_devices,
@@ -351,6 +352,151 @@ class TestCollisionPipeline(unittest.TestCase):
 
         self.assertEqual(disabled_contacts.soft_contact_max, 0)
         self.assertEqual(int(disabled_contacts.soft_contact_count.numpy()[0]), 0)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_reads_all_attributes(self):
+        """Read authored collision-pipeline USD attributes."""
+        from pxr import Usd, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_sphere(body, radius=1.0)
+        model = builder.finalize(device="cpu")
+
+        # Constructed with no USD involvement, so its attributes are the plain
+        # CollisionPipeline.__init__ defaults -- used below to confirm the USD
+        # attributes actually override something rather than coincidentally match.
+        default_pipeline = CollisionPipeline(model)
+
+        stage = Usd.Stage.CreateInMemory()
+        scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
+        scene_prim.ApplyAPI("NewtonCollisionPipelineAPI")
+
+        # With the API applied but nothing authored, create_from_usd should fall
+        # back to the same defaults as the plain constructor.
+        unauthored_pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+
+        self.assertEqual(unauthored_pipeline.rigid_contact_max, default_pipeline.rigid_contact_max)
+        self.assertEqual(unauthored_pipeline.broad_phase_mode, default_pipeline.broad_phase_mode)
+        self.assertEqual(
+            unauthored_pipeline.narrow_phase.max_triangle_pairs, default_pipeline.narrow_phase.max_triangle_pairs
+        )
+        self.assertEqual(unauthored_pipeline.reduce_contacts, default_pipeline.reduce_contacts)
+        self.assertEqual(unauthored_pipeline.soft_contact_max, default_pipeline.soft_contact_max)
+        self.assertEqual(unauthored_pipeline.soft_contact_gap, default_pipeline.soft_contact_gap)
+        self.assertEqual(
+            unauthored_pipeline.enable_rigid_soft_full_surface_contact,
+            default_pipeline.enable_rigid_soft_full_surface_contact,
+        )
+        self.assertEqual(unauthored_pipeline.requires_grad, default_pipeline.requires_grad)
+        self.assertEqual(unauthored_pipeline.deterministic, default_pipeline.deterministic)
+        self.assertEqual(
+            unauthored_pipeline.include_static_kinematic_pairs, default_pipeline.include_static_kinematic_pairs
+        )
+        self.assertEqual(unauthored_pipeline.contact_matching, default_pipeline.contact_matching)
+        self.assertEqual(unauthored_pipeline.contact_report, default_pipeline.contact_report)
+        self.assertEqual(unauthored_pipeline.narrow_phase.verify_buffers, default_pipeline.narrow_phase.verify_buffers)
+        self.assertEqual(unauthored_pipeline.speculative_config, default_pipeline.speculative_config)
+        self.assertIsNone(unauthored_pipeline._contact_matcher)
+        self.assertIsNone(default_pipeline._contact_matcher)
+
+        # With the API applied and everything authored, create_from_usd should use the
+        # authored values.
+
+        scene_prim.GetAttribute("newton:collisionPipeline:rigidContactMax").Set(19)
+        scene_prim.GetAttribute("newton:collisionPipeline:broadPhase").Set("sap")
+        scene_prim.GetAttribute("newton:collisionPipeline:maxTrianglePairs").Set(500000)
+        scene_prim.GetAttribute("newton:collisionPipeline:reduceContacts").Set(False)
+        scene_prim.GetAttribute("newton:collisionPipeline:softContactMax").Set(128)
+        scene_prim.GetAttribute("newton:collisionPipeline:softContactGap").Set(0.02)
+        scene_prim.GetAttribute("newton:collisionPipeline:enableRigidSoftFullSurfaceContact").Set(True)
+        scene_prim.GetAttribute("newton:collisionPipeline:requiresGrad").Set("true")
+        scene_prim.GetAttribute("newton:collisionPipeline:deterministic").Set(True)
+        scene_prim.GetAttribute("newton:collisionPipeline:includeStaticKinematicPairs").Set(False)
+        scene_prim.GetAttribute("newton:collisionPipeline:shapePairsMax").Set(2048)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatching").Set("sticky")
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingPosThreshold").Set(0.01)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactMatchingNormalDotThreshold").Set(0.9)
+        scene_prim.GetAttribute("newton:collisionPipeline:contactReport").Set(True)
+        scene_prim.GetAttribute("newton:collisionPipeline:verifyBuffers").Set(False)
+        scene_prim.GetAttribute("newton:collisionPipeline:speculativeMaxExtension").Set(0.15)
+
+        pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+
+        self.assertNotEqual(pipeline.rigid_contact_max, default_pipeline.rigid_contact_max)
+        self.assertNotEqual(pipeline.broad_phase_mode, default_pipeline.broad_phase_mode)
+        self.assertNotEqual(pipeline.narrow_phase.max_triangle_pairs, default_pipeline.narrow_phase.max_triangle_pairs)
+        self.assertNotEqual(pipeline.reduce_contacts, default_pipeline.reduce_contacts)
+        self.assertNotEqual(pipeline.soft_contact_max, default_pipeline.soft_contact_max)
+        self.assertNotEqual(pipeline.soft_contact_gap, default_pipeline.soft_contact_gap)
+        self.assertNotEqual(
+            pipeline.enable_rigid_soft_full_surface_contact, default_pipeline.enable_rigid_soft_full_surface_contact
+        )
+        self.assertNotEqual(pipeline.requires_grad, default_pipeline.requires_grad)
+        self.assertNotEqual(pipeline.deterministic, default_pipeline.deterministic)
+        self.assertNotEqual(pipeline.include_static_kinematic_pairs, default_pipeline.include_static_kinematic_pairs)
+        self.assertNotEqual(pipeline.shape_pairs_max, default_pipeline.shape_pairs_max)
+        self.assertNotEqual(pipeline.contact_matching, default_pipeline.contact_matching)
+        self.assertNotEqual(pipeline.contact_report, default_pipeline.contact_report)
+        self.assertNotEqual(pipeline.narrow_phase.verify_buffers, default_pipeline.narrow_phase.verify_buffers)
+        self.assertNotEqual(pipeline.speculative_config, default_pipeline.speculative_config)
+
+        self.assertEqual(pipeline.rigid_contact_max, 19)
+        self.assertEqual(pipeline.broad_phase_mode, "sap")
+        self.assertEqual(pipeline.narrow_phase.max_triangle_pairs, 500000)
+        self.assertFalse(pipeline.reduce_contacts)
+        self.assertEqual(pipeline.soft_contact_max, 128)
+        self.assertAlmostEqual(pipeline.soft_contact_gap, 0.02)
+        self.assertTrue(pipeline.enable_rigid_soft_full_surface_contact)
+        self.assertTrue(pipeline.requires_grad)
+        self.assertTrue(pipeline.deterministic)
+        self.assertFalse(pipeline.include_static_kinematic_pairs)
+        self.assertEqual(pipeline.shape_pairs_max, 2048)
+        self.assertEqual(pipeline.contact_matching, "sticky")
+        self.assertTrue(pipeline.contact_report)
+        self.assertFalse(pipeline.narrow_phase.verify_buffers)
+        self.assertIsNotNone(pipeline.speculative_config)
+        self.assertAlmostEqual(pipeline.speculative_config.max_speculative_extension, 0.15)
+        self.assertIsNotNone(pipeline._contact_matcher)
+        self.assertAlmostEqual(pipeline._contact_matcher._pos_threshold_sq, 0.01**2)
+        self.assertAlmostEqual(pipeline._contact_matcher._normal_dot_threshold, 0.9)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_create_from_usd_reads_contact_reduction_hashtable_size_factor(self):
+        """Verified separately: only observable when reduce_contacts is on and the
+        model has meshes/heightfields, which conflicts with the other attribute
+        overrides exercised together in test_create_from_usd_reads_all_attributes."""
+        from pxr import Usd, UsdPhysics
+
+        builder = newton.ModelBuilder()
+        mesh = newton.Mesh(
+            np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+            np.array([0, 1, 2], dtype=np.int32),
+            compute_inertia=False,
+        )
+        builder.add_shape_mesh(-1, mesh=mesh)
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.5)))
+        builder.add_shape_mesh(body, mesh=mesh)
+        model = builder.finalize(device="cpu")
+
+        default_pipeline = CollisionPipeline(model, broad_phase="nxn")
+        self.assertIsNotNone(default_pipeline.narrow_phase.global_contact_reducer)
+
+        stage = Usd.Stage.CreateInMemory()
+        scene_prim = UsdPhysics.Scene.Define(stage, "/World/physicsScene").GetPrim()
+        scene_prim.ApplyAPI("NewtonCollisionPipelineAPI")
+        scene_prim.GetAttribute("newton:collisionPipeline:broadPhase").Set("nxn")
+        scene_prim.GetAttribute("newton:collisionPipeline:contactReductionHashtableSizeFactor").Set(0.5)
+
+        pipeline = CollisionPipeline.create_from_usd(scene_prim, model)
+
+        self.assertIsNotNone(pipeline.narrow_phase.global_contact_reducer)
+        self.assertNotEqual(
+            pipeline.narrow_phase.global_contact_reducer.hashtable_size_factor,
+            default_pipeline.narrow_phase.global_contact_reducer.hashtable_size_factor,
+        )
+        self.assertAlmostEqual(pipeline.narrow_phase.global_contact_reducer.hashtable_size_factor, 0.5)
 
 
 def test_collision_pipeline_first_call_capture(test, device):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ torch = [
     { index = "pytorch-cu128", extra = "torch-cu12" },
     { index = "pytorch-cu130", extra = "torch-cu13" },
 ]
+# TODO(gyeoman): drop once NewtonCollisionPipelineAPI merges upstream and a
+# release of newton-usd-schemas ships it.
+newton-usd-schemas = { path = "../../newton-usd-schemas", editable = true }
 
 [dependency-groups]
 dev = ["asv>=0.6.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ torch = [
 ]
 # TODO(gyeoman): drop once NewtonCollisionPipelineAPI merges upstream and a
 # release of newton-usd-schemas ships it.
-newton-usd-schemas = { path = "../../newton-usd-schemas", editable = true }
+newton-usd-schemas = { git = "https://github.com/gyeomannvidia/newton-usd-schemas", branch = "dev/gyeoman/collision-pipeline-api" }
 
 [dependency-groups]
 dev = ["asv>=0.6.4"]

--- a/uv.lock
+++ b/uv.lock
@@ -3948,7 +3948,7 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'rtx'" },
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.5.0" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", git = "https://github.com/gyeomannvidia/newton-usd-schemas?branch=dev%2Fgyeoman%2Fcollision-pipeline-api" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
     { name = "ovrtx", marker = "extra == 'rtx'", specifier = ">=0.3" },
@@ -3987,12 +3987,8 @@ dev = [{ name = "asv", specifier = ">=0.6.4" }]
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/3b/602eea8123824daf2215fcdf4a61a0958507ea11e5c38e4313285f6b745f/newton_usd_schemas-0.5.0.tar.gz", hash = "sha256:a404232e9f89cfce130ee5ed5c8b6b23b187514e857803b5d7b08568bb2516e0", size = 76299, upload-time = "2026-08-14T00:02:50.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/bc/ffad9598cc4772cb0b8d8d47c6700493dac3d8d6518dead78c596a0325ed/newton_usd_schemas-0.5.0-py3-none-any.whl", hash = "sha256:edb559522474855fc03e6f395e0702b11074a13fe1c2ed9cce63fbb06516b342", size = 22280, upload-time = "2026-08-14T00:02:49.056Z" },
-]
+version = "0.6.0.dev0"
+source = { git = "https://github.com/gyeomannvidia/newton-usd-schemas?branch=dev%2Fgyeoman%2Fcollision-pipeline-api#2bbcf29599787ff4722dd00aa95586d22fa686a7" }
 
 [[package]]
 name = "notebook-shim"


### PR DESCRIPTION
## Description

<!-- Add USD parsing required to implement CollisionPipeline.create_from_usd(). -->

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

Closes https://github.com/newton-physics/newton/pull/4175

## Test plan

<!-- 
     ```
     uv run --extra dev -m newton.tests -k test_create_from_usd_reads_all_attributes
     ``` -->



```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

CollisionPipeline.create_from_usd(scene_prim, model)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating collision pipelines from settings authored on a USD physics scene.
  * Explicit configuration overrides take precedence over USD-authored settings.
  * Supports typed USD scene objects and documented sentinel values that fall back to standard defaults.
  * Converts authored length settings from stage units to meters.
  * Reads contact reduction settings, collision matching options, and other pipeline configuration from USD.

* **Bug Fixes**
  * Added descriptive validation errors for invalid scene configuration and unsupported collision settings.
  * Out-of-range soft-contact settings now warn and use standard defaults instead of failing.

* **Documentation**
  * Added a changelog entry for USD-based collision pipeline configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->