### PR TITLE
Normalize ADMM parameters and add overrides

### DIFF
--- a/changelog/+admm-default-proximal-9c2e71a4.changed.md
+++ b/changelog/+admm-default-proximal-9c2e71a4.changed.md
@@ -1,0 +1,8 @@
+Change the `SolverCoupledADMM` defaults to `rho=0.5` and `gamma=0.1` to improve convergence for stiff attachments with modest proximal inertia.
+
+Specify `rho` and `gamma` explicitly to override the new tuning. To migrate
+the previous defaults (`rho=1.0`, `gamma=0.0`) while preserving their behavior
+at a fixed coupled substep duration `h`, use `rho=h` and `gamma=0.0`, together
+with the stiffness conversion described in the dimensionless-parameter
+migration note. Copying the old numerical value `rho=1.0` does not preserve
+the previous penalty strength after the timestep normalization.

--- a/changelog/+admm-dimensionless-parameters-4e6b9a21.fixed.md
+++ b/changelog/+admm-dimensionless-parameters-4e6b9a21.fixed.md
@@ -1,0 +1,14 @@
+Make `SolverCoupledADMM` apply timestep conversions for physical attachment stiffness, damping, and dry-friction limits while keeping ADMM penalty and proximal parameters dimensionless.
+
+Migrate configurations tuned with the previous formulation at a fixed coupled
+substep duration `h` (in seconds) using `rho_new = h * rho_old`,
+`gamma_new = gamma_old / h`, and `stiffness_new = stiffness_old / h`.
+Apply the stiffness conversion to translational and angular model-joint
+stiffnesses and body-particle attachment stiffnesses. Keep damping,
+dry-friction force/torque limits, `baumgarte`, and iteration counts unchanged.
+For example, at `h = 1/120`, old values `rho=60`, `gamma=0.001`, and
+`stiffness=1000` become `rho=0.5`, `gamma=0.12`, and `stiffness=120000`.
+These conversions preserve the previous equations at the reference timestep;
+use the resulting dimensionless parameters and physical stiffness/damping
+values when changing timesteps instead of repeating the conversion each step.
+Solver steps now require a strictly positive timestep.

--- a/changelog/+admm-dimensionless-parameters-4e6b9a21.fixed.md
+++ b/changelog/+admm-dimensionless-parameters-4e6b9a21.fixed.md
@@ -11,4 +11,4 @@ For example, at `h = 1/120`, old values `rho=60`, `gamma=0.001`, and
 These conversions preserve the previous equations at the reference timestep;
 use the resulting dimensionless parameters and physical stiffness/damping
 values when changing timesteps instead of repeating the conversion each step.
-Solver steps now require a strictly positive timestep.
+Solver steps now require a finite, strictly positive timestep.

--- a/changelog/+admm-interface-parameters-7f48c2a1.added.md
+++ b/changelog/+admm-interface-parameters-7f48c2a1.added.md
@@ -1,0 +1,14 @@
+Add optional dimensionless `rho`, `gamma`, and `baumgarte` overrides alongside each ADMM constraint definition: on `SolverCoupledADMM.ContactPair` for contacts, in `add_body_particle_attachment()` for body-particle attachments, and through `coupling:joint_rho`, `coupling:joint_gamma`, and `coupling:joint_baumgarte` custom attributes on individual joints.
+
+Existing configurations require no changes. Omitted overrides inherit the
+corresponding global `Config` values. To tune a contact pair, use
+`ContactPair("rigid", "cloth", rho=0.4, gamma=0.2)`; to tune an attachment,
+pass these keywords to `add_body_particle_attachment()`. Register joint
+attributes with `SolverCoupledADMM.register_custom_attributes(builder)` and
+pass them in the joint's existing `custom_attributes` argument. Attachment
+attributes use the `coupling:body_particle_attachment_` prefix. Custom
+attributes use `-1` for inheritance; Python override arguments use `None`.
+Explicit zero `gamma` or `baumgarte` disables that term for the constraint.
+Contact parameters affect only contacts, and the iteration count remains
+global. When migrating values from the previous timestep-dependent
+formulation, apply the dimensionless-parameter migration rules first.

--- a/docs/concepts/coupling.rst
+++ b/docs/concepts/coupling.rst
@@ -255,16 +255,17 @@ sub-solver. This avoids solving the same constraint twice. The current generic
 ADMM path supports ``BALL``, ``FIXED``, and ``REVOLUTE`` joints. Ball joints
 create translational anchor-coincidence rows. Fixed joints add angular rows.
 Revolute joints preserve the hinge axis and can add a dry-friction row from
-model joint friction. Prismatic, distance, and D6 joint rows are not yet part of
-the experimental API.
+model joint friction [N·m]. Prismatic, distance, and D6 joint rows are not yet
+part of the experimental API.
 
 Body-particle attachments cover interfaces that cannot be represented by a
 model joint because one endpoint is a particle. The helper
 ``SolverCoupledADMM.add_body_particle_attachment()`` registers and fills custom
 attributes under ``coupling:body_particle_attachment`` with body id, particle id,
-body-local point, stiffness, damping, and enabled state. Importers can author the
-same custom attributes directly. Rows whose endpoints are unowned or owned by
-the same entry are ignored; only cross-solver attachments are coupled by ADMM.
+body-local point [m], stiffness [N/m], damping [N·s/m], and enabled state.
+Importers can author the same custom attributes directly. Rows whose endpoints
+are unowned or owned by the same entry are ignored; only cross-solver
+attachments are coupled by ADMM.
 
 Contact coupling is enabled by adding one or more ``ContactPair`` values to
 ``SolverCoupledADMM.Config.contact_pairs``. A contact pair names two entries.
@@ -275,10 +276,11 @@ For enabled contact pairs, the coupler owns private detection data and builds
 rows from solver ownership: particle-shape rows between particle entries and
 shapes on bodies owned by other entries, rigid-rigid rows from cross-entry shape
 pairs, and particle-particle rows from cross-entry particle sets through a
-private hash-grid stream. Friction is read from model material properties such
-as ``shape_material_mu`` and ``Model.particle_mu`` at row-fill time; it is not a
-``ContactPair`` field. Contact rows use an isotropic Coulomb
-maximum-dissipation projection. They do not solve cone complementarity directly.
+private hash-grid stream. Dimensionless friction coefficients are read from
+model material properties such as ``shape_material_mu`` and ``Model.particle_mu``
+at row-fill time; they are not ``ContactPair`` fields. Contact rows use an
+isotropic Coulomb maximum-dissipation projection. They do not solve cone
+complementarity directly.
 
 ADMM contact buffers are fixed-capacity device arrays. Persistent contacts
 warm-start local variables and dual variables by stable contact keys across
@@ -289,12 +291,22 @@ stream.
 The main ADMM parameters are:
 
 - ``iterations``: fixed iteration count, chosen to be graph-capture friendly;
-- ``rho``: penalty weight for interface rows;
-- ``gamma``: proximal inertia and velocity weight;
-- ``baumgarte``: positional error stabilization for attachment/contact rows;
-- stiffness and damping values for model-joint and body-particle attachment
-  rows;
-- rigid contact matching mode, thresholds, and warm-start force scale.
+- ``rho``: dimensionless penalty weight for interface rows (default ``0.5``);
+- ``gamma``: dimensionless proximal inertia and velocity weight (default ``0.1``);
+- ``baumgarte``: dimensionless position error correction fraction for
+  attachment/contact rows;
+- ``joint_stiffness`` and ``joint_damping``: translational model-joint
+  attachment stiffness [N/m] and damping [N·s/m];
+- ``joint_angular_stiffness`` and ``joint_angular_damping``: angular model-joint
+  attachment stiffness [N·m/rad] and damping [N·m·s/rad];
+- ``stiffness`` and ``damping`` in ``add_body_particle_attachment()``:
+  body-particle attachment stiffness [N/m] and damping [N·s/m];
+- ``joint_proximal_mass_scale``: dimensionless proxy mass multiplier;
+- ``rigid_contact_matching``: rigid contact matching mode;
+- ``contact_matching_pos_threshold``: contact matching distance threshold [m];
+- ``contact_matching_normal_dot_threshold``: dimensionless minimum dot product
+  between matched contact normals;
+- ``contact_matching_force_scale``: dimensionless warm-start multiplier.
 
 When ``gamma`` is positive, the coupler scales owned body and particle masses in
 each entry ``ModelView``, asks sub-solvers to refresh model-derived caches, and

--- a/docs/concepts/coupling.rst
+++ b/docs/concepts/coupling.rst
@@ -272,6 +272,44 @@ Contact coupling is enabled by adding one or more ``ContactPair`` values to
 ``SolverCoupledADMM.auto_detect_contact_pairs(entries)`` can build the complete
 pair list for every distinct entry combination.
 
+Override the dimensionless ``rho``, ``gamma``, and ``baumgarte`` parameters
+where each constraint is defined: on ``ContactPair`` for contacts, in
+``add_body_particle_attachment()`` for attachments, or in a joint's
+``custom_attributes``. Contact overrides affect only contacts. Joints and
+attachments can each have their own settings, even between the same solver
+entries. Omitted parameters inherit the corresponding global ``Config`` value;
+explicit ``gamma=0.0`` or ``baumgarte=0.0`` disables that term for the constraint.
+All constraints share the global iteration count.
+
+.. code-block:: python
+
+    coupling = SolverCoupledADMM.Config(
+        contact_pairs=[
+            SolverCoupledADMM.ContactPair("rigid", "cloth", rho=0.4, gamma=0.2),
+        ],
+    )
+
+    SolverCoupledADMM.add_body_particle_attachment(
+        builder, body, particle, rho=0.6, gamma=0.1, baumgarte=0.2
+    )
+
+    SolverCoupledADMM.register_custom_attributes(builder)
+    builder.add_joint_ball(
+        parent=body_a,
+        child=body_b,
+        custom_attributes={"coupling:joint_rho": 0.6, "coupling:joint_gamma": 0.1},
+    )
+
+Joint overrides use ``coupling:joint_rho``, ``coupling:joint_gamma``, and
+``coupling:joint_baumgarte``. Attachment overrides use
+``coupling:body_particle_attachment_rho``,
+``coupling:body_particle_attachment_gamma``, and
+``coupling:body_particle_attachment_baumgarte``. These custom attributes use
+``-1`` to inherit the global value; the Python attachment helper and
+``ContactPair`` use ``None``. Overrides are read at solver construction.
+These solver settings are currently authored through Python; no USD schema
+is defined for them.
+
 For enabled contact pairs, the coupler owns private detection data and builds
 rows from solver ownership: particle-shape rows between particle entries and
 shapes on bodies owned by other entries, rigid-rigid rows from cross-entry shape

--- a/newton/_src/solvers/coupled/admm_contact_stream.py
+++ b/newton/_src/solvers/coupled/admm_contact_stream.py
@@ -137,7 +137,7 @@ def admm_contact_stream_update_normal_force_kernel(
         return
 
     W_i = W[i]
-    force = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
-    force_mag = wp.max(0.0, wp.dot(normal[i], force))
-    normal_force[i] = force_mag
-    normal_impulse[i] = force_mag * dt
+    impulse = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    impulse_mag = wp.max(0.0, wp.dot(normal[i], impulse))
+    normal_force[i] = impulse_mag / dt
+    normal_impulse[i] = impulse_mag

--- a/newton/_src/solvers/coupled/admm_utils.py
+++ b/newton/_src/solvers/coupled/admm_utils.py
@@ -723,10 +723,13 @@ def accumulate_joint_qd_factor_from_body_proximal_lump_kernel(
 # Quadratic attachment local solve
 # ----------------------------------------------------------------------
 #
-# The ADMM update rules for a quadratic coupling energy
-# ``E_c(u) = (kappa/2) ||u - u_target||^2 + (damping/2) ||u||^2`` are:
+# The ADMM update rules for a quadratic coupling energy with physical stiffness
+# ``kappa`` and damping ``damping`` are:
 #
-#     u^{k+1}      = (rho W^2 Jv + kappa u_target - W lambda) / (kappa + damping + rho W^2)
+#     kappa_v       = dt^2 kappa
+#     damping_v     = dt damping
+#     u^{k+1}       = (rho W^2 Jv + kappa_v u_target - W lambda)
+#                       / (kappa_v + damping_v + rho W^2)
 #     lambda^{k+1} = lambda^k + rho W (u^{k+1} - Jv)
 #
 # With ``u_target = 0`` the coupling damps the relative velocity to zero;
@@ -737,6 +740,7 @@ def accumulate_joint_qd_factor_from_body_proximal_lump_kernel(
 def u_update_quadratic_kernel(
     kappa: wp.array[float],
     damping: wp.array[float],
+    dt: float,
     W: wp.array[float],
     rho: float,
     lambda_k: wp.array[wp.vec3],
@@ -748,8 +752,10 @@ def u_update_quadratic_kernel(
     i = wp.tid()
     W_i = W[i]
     W2 = W_i * W_i
-    denom = kappa[i] + damping[i] + rho * W2
-    u_out[i] = (rho * W2 * Jv[i] + kappa[i] * u_target[i] - W_i * lambda_k[i]) / denom
+    kappa_v = dt * dt * kappa[i]
+    damping_v = dt * damping[i]
+    denom = kappa_v + damping_v + rho * W2
+    u_out[i] = (rho * W2 * Jv[i] + kappa_v * u_target[i] - W_i * lambda_k[i]) / denom
 
 
 @wp.kernel(enable_backward=False)
@@ -778,6 +784,7 @@ def _soft_threshold_box(value: float, threshold: float) -> float:
 @wp.kernel(enable_backward=False)
 def joint_box_friction_u_update_kernel(
     friction: wp.array[wp.vec3],
+    dt: float,
     W: wp.array[float],
     rho: float,
     lambda_k: wp.array[wp.vec3],
@@ -798,9 +805,9 @@ def joint_box_friction_u_update_kernel(
         p = p - lambda_k[i] / denom
 
     threshold = wp.vec3(0.0, 0.0, 0.0)
-    force_denom = rho * W_i * W_i
-    if force_denom > 0.0:
-        threshold = friction[i] / force_denom
+    impulse_denom = rho * W_i * W_i
+    if impulse_denom > 0.0:
+        threshold = dt * friction[i] / impulse_denom
 
     u_out[i] = wp.vec3(
         _soft_threshold_box(p[0], threshold[0]),
@@ -830,6 +837,17 @@ def solve_coulomb_isotropic(mu: float, normal: wp.vec3, u: wp.vec3):
             u = u * (1.0 + mu * u_n / wp.sqrt(tau))
 
     return u
+
+
+@wp.func
+def _interface_impulse(
+    rho: float,
+    W: float,
+    lambda_k: wp.vec3,
+    u_k: wp.vec3,
+    Jv_k: wp.vec3,
+) -> wp.vec3:
+    return W * (lambda_k + rho * W * (u_k - Jv_k))
 
 
 @wp.kernel(enable_backward=False)
@@ -942,6 +960,7 @@ def attach_rp_accumulate_forces_kernel(
     particle_b: wp.array[int],
     body_q: wp.array[wp.transform],
     body_com: wp.array[wp.vec3],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -955,7 +974,7 @@ def attach_rp_accumulate_forces_kernel(
     ba = body_a[i]
     pb = particle_b[i]
     W_i = W[i]
-    force = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    force = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
 
     xform_a = body_q[ba]
     world_pt_a = wp.transform_point(xform_a, point_a_local[i])
@@ -1098,6 +1117,7 @@ def attach_rr_revolute_angular_local_compute_u_target_kernel(
 def attach_rr_angular_accumulate_forces_kernel(
     body_a: wp.array[int],
     body_b: wp.array[int],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1109,7 +1129,7 @@ def attach_rr_angular_accumulate_forces_kernel(
     """Splat angular attachment torques into both rigid-body force buffers."""
     i = wp.tid()
     W_i = W[i]
-    torque_a = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    torque_a = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
     wp.atomic_add(body_f_a, body_a[i], wp.spatial_vector(wp.vec3(0.0, 0.0, 0.0), torque_a))
     wp.atomic_sub(body_f_b, body_b[i], wp.spatial_vector(wp.vec3(0.0, 0.0, 0.0), torque_a))
 
@@ -1120,6 +1140,7 @@ def attach_rr_angular_local_accumulate_forces_kernel(
     frame_a: wp.array[wp.transform],
     body_b: wp.array[int],
     body_q_a: wp.array[wp.transform],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1132,7 +1153,7 @@ def attach_rr_angular_local_accumulate_forces_kernel(
     i = wp.tid()
     ba = body_a[i]
     W_i = W[i]
-    torque_local = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    torque_local = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
     frame_world = body_q_a[ba] * frame_a[i]
     torque_world = wp.quat_rotate(wp.transform_get_rotation(frame_world), torque_local)
     wp.atomic_add(body_f_a, ba, wp.spatial_vector(wp.vec3(0.0, 0.0, 0.0), torque_world))
@@ -1145,6 +1166,7 @@ def attach_rr_revolute_angular_local_accumulate_forces_kernel(
     frame_a: wp.array[wp.transform],
     body_b: wp.array[int],
     body_q_a: wp.array[wp.transform],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1157,7 +1179,7 @@ def attach_rr_revolute_angular_local_accumulate_forces_kernel(
     i = wp.tid()
     ba = body_a[i]
     W_i = W[i]
-    torque_local = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    torque_local = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
     torque_local = wp.vec3(0.0, torque_local[1], torque_local[2])
     frame_world = body_q_a[ba] * frame_a[i]
     torque_world = wp.quat_rotate(wp.transform_get_rotation(frame_world), torque_local)
@@ -1215,6 +1237,7 @@ def attach_rr_accumulate_forces_kernel(
     body_com_a: wp.array[wp.vec3],
     body_q_b: wp.array[wp.transform],
     body_com_b: wp.array[wp.vec3],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1228,7 +1251,7 @@ def attach_rr_accumulate_forces_kernel(
     ba = body_a[i]
     bb = body_b[i]
     W_i = W[i]
-    force_a = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    force_a = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
 
     xform_a = body_q_a[ba]
     point_a = wp.transform_point(xform_a, point_a_local[i])
@@ -1320,6 +1343,7 @@ def contact_rr_accumulate_forces_kernel(
     body_com_a: wp.array[wp.vec3],
     body_q_b: wp.array[wp.transform],
     body_com_b: wp.array[wp.vec3],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1335,7 +1359,7 @@ def contact_rr_accumulate_forces_kernel(
     ba = body_a[i]
     bb = body_b[i]
     W_i = W[i]
-    force_a = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    force_a = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
 
     xform_a = body_q_a[ba]
     point_a = contact_surface_point(xform_a, point_a_local[i], point_a_offset_local[i])
@@ -1650,6 +1674,7 @@ def contact_rp_accumulate_forces_kernel(
     body_sign: wp.array[int],
     body_q: wp.array[wp.transform],
     body_com: wp.array[wp.vec3],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1665,7 +1690,7 @@ def contact_rp_accumulate_forces_kernel(
     b = body_id[i]
     p = particle_id[i]
     W_i = W[i]
-    force = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    force = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
     force_body = float(body_sign[i]) * force
 
     xform = body_q[b]
@@ -1877,6 +1902,7 @@ def contact_pp_accumulate_forces_kernel(
     active_count: wp.array[int],
     particle_a: wp.array[int],
     particle_b: wp.array[int],
+    inv_dt: float,
     rho: float,
     W: wp.array[float],
     lambda_k: wp.array[wp.vec3],
@@ -1892,7 +1918,7 @@ def contact_pp_accumulate_forces_kernel(
     pa = particle_a[i]
     pb = particle_b[i]
     W_i = W[i]
-    force = W_i * (lambda_k[i] + rho * W_i * (u_k[i] - Jv_k[i]))
+    force = inv_dt * _interface_impulse(rho, W_i, lambda_k[i], u_k[i], Jv_k[i])
     wp.atomic_add(particle_f_a, pa, force)
     wp.atomic_sub(particle_f_b, pb, force)
 

--- a/newton/_src/solvers/coupled/solver_coupled_admm.py
+++ b/newton/_src/solvers/coupled/solver_coupled_admm.py
@@ -533,7 +533,7 @@ class SolverCoupledADMM(SolverCoupled):
             particle: Particle index for the deformable endpoint.
             body_point: Body-local attachment point [m].
             stiffness: Quadratic ADMM attachment stiffness [N/m].
-            damping: Quadratic ADMM attachment damping [N*s/m].
+            damping: Quadratic ADMM attachment damping [N·s/m].
             enabled: Whether the attachment row is active.
 
         Returns:
@@ -563,9 +563,9 @@ class SolverCoupledADMM(SolverCoupled):
         particle-particle} ADMM contact rows. If neither entry owns shapes or
         particles, no contacts are emitted.
 
-        Friction is derived from shape and particle material properties
-        (``shape_material_mu`` and ``Model.particle_mu``), so it is not a
-        ContactPair field — set those on the model to control friction.
+        Dimensionless friction coefficients are derived from shape and particle
+        material properties (``shape_material_mu`` and ``Model.particle_mu``).
+        Set those on the model to control friction.
 
         Args:
             source: Name of one solver entry.
@@ -580,28 +580,33 @@ class SolverCoupledADMM(SolverCoupled):
     class Config:
         """Linearized ADMM coupling configuration.
 
+        Revolute joint dry-friction torque limits come from model joint
+        friction [N·m].
+
         Args:
             iterations: Positive number of ADMM iterations per solver step.
-            rho: Positive ADMM penalty parameter.
-            gamma: Nonnegative proximal mass scaling parameter.
-            baumgarte: Nonnegative position error correction fraction.
+            rho: Positive dimensionless ADMM penalty parameter.
+            gamma: Nonnegative dimensionless proximal mass scaling parameter.
+            baumgarte: Nonnegative dimensionless position error correction
+                fraction.
             joint_stiffness: Quadratic stiffness for translational ADMM
                 attachments derived from cross-solver model joints [N/m].
             joint_damping: Quadratic damping for translational ADMM
-                attachments derived from cross-solver model joints [N*s/m].
+                attachments derived from cross-solver model joints [N·s/m].
             joint_angular_stiffness: Quadratic stiffness for angular ADMM
                 attachments derived from cross-solver fixed and revolute
-                joints [N*m/rad].
+                joints [N·m/rad].
             joint_angular_damping: Quadratic damping for angular ADMM
                 attachments derived from cross-solver fixed and revolute
-                joints [N*m*s/rad].
+                joints [N·m·s/rad].
             joint_proximal_bodies: Keep cross-solver joint neighbor bodies
                 dynamic in each subsolver view as local inertial proxies.
             joint_proximal_destination_entries: Optional entry names that
                 receive cross-solver joint proximal proxy bodies. ``None``
                 keeps the default symmetric visibility.
-            joint_proximal_mass_scale: Multiplier applied to source effective
-                masses before installing cross-solver joint proxy inertias.
+            joint_proximal_mass_scale: Dimensionless multiplier applied to source
+                effective masses before installing cross-solver joint proxy
+                inertias.
             rigid_contact_matching: Frame-to-frame contact matching mode for
                 collision-detected rigid-rigid ADMM contacts. Use
                 ``"disabled"`` to reset dynamic rigid contact state every
@@ -613,14 +618,14 @@ class SolverCoupledADMM(SolverCoupled):
                 between previous and current rigid contact midpoints for
                 non-disabled ``rigid_contact_matching`` modes. ``None`` uses
                 the :class:`CollisionPipeline` default.
-            contact_matching_normal_dot_threshold: Minimum dot product between
-                previous and current rigid contact normals for non-disabled
-                ``rigid_contact_matching`` modes. ``None`` uses the
+            contact_matching_normal_dot_threshold: Dimensionless minimum dot
+                product between previous and current rigid contact normals for
+                non-disabled ``rigid_contact_matching`` modes. ``None`` uses the
                 :class:`CollisionPipeline` default.
-            contact_matching_force_scale: Multiplier applied to the rescaled
-                previous-refresh ADMM contact dual when a rigid-rigid contact
-                matches. ``0`` disables dual warm-start while preserving
-                contact matching.
+            contact_matching_force_scale: Dimensionless multiplier applied to
+                the rescaled previous-refresh ADMM contact dual when a
+                rigid-rigid contact matches. ``0`` disables dual warm-start
+                while preserving contact matching.
             contact_pairs: Per-interface contact pairs to enable. Empty list
                 disables ADMM-managed contacts. Use
                 :meth:`SolverCoupledADMM.auto_detect_contact_pairs` to build the
@@ -628,8 +633,8 @@ class SolverCoupledADMM(SolverCoupled):
         """
 
         iterations: int = 5
-        rho: float = 1.0
-        gamma: float = 0.0
+        rho: float = 0.5
+        gamma: float = 0.1
         baumgarte: float = 0.0
         joint_stiffness: float = 1.0e4
         joint_damping: float = 0.0
@@ -2831,6 +2836,8 @@ class SolverCoupledADMM(SolverCoupled):
     ) -> None:
         """Run ADMM iterations over all sub-solvers."""
         del state_out
+        if dt <= 0.0:
+            raise ValueError("SolverCoupledADMM requires dt > 0")
         coupling = self._coupling
         iters = int(coupling.iterations)
         self._refresh_collision_contact_groups(state_in)
@@ -3767,13 +3774,14 @@ class SolverCoupledADMM(SolverCoupled):
             device=self.model.device,
         )
 
-    def _update_admm_quadratic_dual(self, group: _AdmmQuadraticGroup) -> None:
+    def _update_admm_quadratic_dual(self, group: _AdmmQuadraticGroup, dt: float) -> None:
         wp.launch(
             u_update_quadratic_kernel,
             dim=group.count,
             inputs=[
                 group.kappa,
                 group.damping,
+                float(dt),
                 group.W,
                 float(self._coupling.rho),
                 group.lambda_,
@@ -3811,6 +3819,7 @@ class SolverCoupledADMM(SolverCoupled):
     ) -> None:
         del iteration_k
         coupling = self._coupling
+        inv_dt = 1.0 / float(dt)
         for group in self._admm_rr_groups:
             if group.count == 0:
                 continue
@@ -3849,6 +3858,7 @@ class SolverCoupledADMM(SolverCoupled):
                     entry_a.view.body_com,
                     entry_b.state_0.body_q,
                     entry_b.view.body_com,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -3882,6 +3892,7 @@ class SolverCoupledADMM(SolverCoupled):
                 inputs=[
                     group.body_ids_a,
                     group.body_ids_b,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -3920,6 +3931,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.frame_a,
                     group.body_ids_b,
                     entry_a.state_0.body_q,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -3958,6 +3970,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.frame_a,
                     group.body_ids_b,
                     entry_a.state_0.body_q,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -3998,6 +4011,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.particle_ids,
                     body_entry.state_0.body_q,
                     body_entry.view.body_com,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -4053,6 +4067,7 @@ class SolverCoupledADMM(SolverCoupled):
                     entry_a.view.body_com,
                     entry_b.state_0.body_q,
                     entry_b.view.body_com,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -4099,6 +4114,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.body_sign,
                     body_entry.state_0.body_q,
                     body_entry.view.body_com,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -4136,6 +4152,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.active_count,
                     group.particle_ids_a,
                     group.particle_ids_b,
+                    inv_dt,
                     float(coupling.rho),
                     group.W,
                     group.lambda_,
@@ -4164,7 +4181,7 @@ class SolverCoupledADMM(SolverCoupled):
                 )
 
     def _update_admm_dual(self, iteration_k: int, dt: float) -> None:
-        del iteration_k, dt
+        del iteration_k
         coupling = self._coupling
         for group in self._admm_rr_groups:
             if group.count == 0:
@@ -4189,7 +4206,7 @@ class SolverCoupledADMM(SolverCoupled):
                 outputs=[group.Jv],
                 device=self.model.device,
             )
-            self._update_admm_quadratic_dual(group)
+            self._update_admm_quadratic_dual(group, dt)
         for group in self._admm_rr_angular_groups:
             if group.count == 0:
                 continue
@@ -4207,7 +4224,7 @@ class SolverCoupledADMM(SolverCoupled):
                 outputs=[group.Jv],
                 device=self.model.device,
             )
-            self._update_admm_quadratic_dual(group)
+            self._update_admm_quadratic_dual(group, dt)
         for group in self._admm_rr_revolute_angular_groups:
             if group.count == 0:
                 continue
@@ -4227,7 +4244,7 @@ class SolverCoupledADMM(SolverCoupled):
                 outputs=[group.Jv],
                 device=self.model.device,
             )
-            self._update_admm_quadratic_dual(group)
+            self._update_admm_quadratic_dual(group, dt)
         for group in self._admm_rr_angular_friction_groups:
             if group.count == 0:
                 continue
@@ -4250,7 +4267,7 @@ class SolverCoupledADMM(SolverCoupled):
             wp.launch(
                 joint_box_friction_u_update_kernel,
                 dim=group.count,
-                inputs=[group.friction, group.W, float(coupling.rho), group.lambda_, group.Jv],
+                inputs=[group.friction, float(dt), group.W, float(coupling.rho), group.lambda_, group.Jv],
                 outputs=[group.u],
                 device=self.model.device,
             )
@@ -4281,7 +4298,7 @@ class SolverCoupledADMM(SolverCoupled):
                 outputs=[group.Jv],
                 device=self.model.device,
             )
-            self._update_admm_quadratic_dual(group)
+            self._update_admm_quadratic_dual(group, dt)
         for group in self._admm_dynamic_rr_contact_groups:
             if group.count == 0:
                 continue

--- a/newton/_src/solvers/coupled/solver_coupled_admm.py
+++ b/newton/_src/solvers/coupled/solver_coupled_admm.py
@@ -165,6 +165,15 @@ class _AdmmBuffers:
     particle_effective_mass_local: wp.array = field(default=None)
 
 
+@dataclass(frozen=True)
+class _AdmmInterfaceParameters:
+    """Resolved ADMM parameters for a group of constraints."""
+
+    rho: float
+    gamma: float
+    baumgarte: float
+
+
 @dataclass
 class _AdmmRigidRigidAttachmentGroup:
     """Rigid-body to rigid-body ADMM point attachment group for one owner pair."""
@@ -182,6 +191,7 @@ class _AdmmRigidRigidAttachmentGroup:
     lambda_: wp.array
     Jv: wp.array
     u_target: wp.array
+    parameters: _AdmmInterfaceParameters
 
     @property
     def count(self) -> int:
@@ -205,6 +215,7 @@ class _AdmmRigidRigidAngularAttachmentGroup:
     lambda_: wp.array
     Jv: wp.array
     u_target: wp.array
+    parameters: _AdmmInterfaceParameters
 
     @property
     def count(self) -> int:
@@ -225,6 +236,7 @@ class _AdmmRigidRigidAngularFrictionGroup:
     u: wp.array
     lambda_: wp.array
     Jv: wp.array
+    parameters: _AdmmInterfaceParameters
 
     @property
     def count(self) -> int:
@@ -247,6 +259,7 @@ class _AdmmRigidParticleAttachmentGroup:
     lambda_: wp.array
     Jv: wp.array
     u_target: wp.array
+    parameters: _AdmmInterfaceParameters
 
     @property
     def count(self) -> int:
@@ -273,6 +286,7 @@ class _AdmmRigidRigidContactGroup:
     lambda_: wp.array
     Jv: wp.array
     u_min: wp.array
+    parameters: _AdmmInterfaceParameters
     capacity: int | None = None
     active_count: wp.array | None = None
     active_count_max: wp.array | None = None
@@ -313,6 +327,7 @@ class _AdmmRigidParticleContactGroup:
     lambda_: wp.array
     Jv: wp.array
     u_min: wp.array
+    parameters: _AdmmInterfaceParameters
     capacity: int | None = None
     active_count: wp.array | None = None
     active_count_max: wp.array | None = None
@@ -351,6 +366,7 @@ class _AdmmParticleParticleContactGroup:
     lambda_: wp.array
     Jv: wp.array
     u_min: wp.array
+    parameters: _AdmmInterfaceParameters
     capacity: int | None = None
     active_count: wp.array | None = None
     active_count_max: wp.array | None = None
@@ -442,6 +458,15 @@ class SolverCoupledADMM(SolverCoupled):
         particle endpoints are owned by different solver entries into ADMM
         attachment constraints.
 
+        Dimensionless overrides ``coupling:joint_rho``, ``coupling:joint_gamma``,
+        and ``coupling:joint_baumgarte`` are authored on individual model joints.
+        Attachment rows use ``coupling:body_particle_attachment_rho``,
+        ``coupling:body_particle_attachment_gamma``, and
+        ``coupling:body_particle_attachment_baumgarte``. For these attributes,
+        ``-1`` (the default) inherits the global Config value.
+        Otherwise rho must be positive, and gamma and baumgarte nonnegative.
+        Overrides are read when the coupled solver is constructed.
+
         Args:
             builder: Model builder receiving the custom frequency and attributes.
         """
@@ -450,6 +475,21 @@ class SolverCoupledADMM(SolverCoupled):
         builder.add_custom_frequency(
             ModelBuilder.CustomFrequency(name="body_particle_attachment", namespace="coupling")
         )
+        for prefix, frequency in (
+            ("joint", Model.AttributeFrequency.JOINT),
+            ("body_particle_attachment", cls.BODY_PARTICLE_ATTACHMENT_FREQUENCY),
+        ):
+            for name in ("rho", "gamma", "baumgarte"):
+                builder.add_custom_attribute(
+                    ModelBuilder.CustomAttribute(
+                        name=f"{prefix}_{name}",
+                        frequency=frequency,
+                        assignment=Model.AttributeAssignment.MODEL,
+                        dtype=wp.float32,
+                        default=-1.0,
+                        namespace="coupling",
+                    )
+                )
         builder.add_custom_attribute(
             ModelBuilder.CustomAttribute(
                 name="body_particle_attachment_body",
@@ -524,6 +564,9 @@ class SolverCoupledADMM(SolverCoupled):
         stiffness: float = 1.0e4,
         damping: float = 0.0,
         enabled: bool = True,
+        rho: float | None = None,
+        gamma: float | None = None,
+        baumgarte: float | None = None,
     ) -> int:
         """Add a model-level rigid-body-to-particle ADMM attachment.
 
@@ -535,11 +578,26 @@ class SolverCoupledADMM(SolverCoupled):
             stiffness: Quadratic ADMM attachment stiffness [N/m].
             damping: Quadratic ADMM attachment damping [N·s/m].
             enabled: Whether the attachment row is active.
+            rho: Positive dimensionless ADMM penalty override. ``None`` inherits
+                the global :class:`SolverCoupledADMM.Config` value.
+            gamma: Nonnegative dimensionless proximal scaling override.
+                ``None`` inherits the global Config value.
+            baumgarte: Nonnegative dimensionless position error correction
+                fraction. ``None`` inherits the global Config value.
 
         Returns:
             The custom-frequency row index for the attachment.
         """
         cls.register_custom_attributes(builder)
+        overrides = {}
+        for name, value in (("rho", rho), ("gamma", gamma), ("baumgarte", baumgarte)):
+            overrides[f"coupling:body_particle_attachment_{name}"] = (
+                -1.0
+                if value is None
+                else cls._finite_scalar(
+                    value, f"ADMM attachment {name}", lower_bound=0.0, lower_inclusive=name != "rho"
+                )
+            )
         point = wp.vec3(float(body_point[0]), float(body_point[1]), float(body_point[2]))
         indices = builder.add_custom_values(
             **{
@@ -549,6 +607,7 @@ class SolverCoupledADMM(SolverCoupled):
                 cls.BODY_PARTICLE_ATTACHMENT_STIFFNESS_ATTR: float(stiffness),
                 cls.BODY_PARTICLE_ATTACHMENT_DAMPING_ATTR: float(damping),
                 cls.BODY_PARTICLE_ATTACHMENT_ENABLED_ATTR: bool(enabled),
+                **overrides,
             }
         )
         return indices[cls.BODY_PARTICLE_ATTACHMENT_BODY_ATTR]
@@ -558,6 +617,9 @@ class SolverCoupledADMM(SolverCoupled):
         """One cross-solver contact interface for ADMM coupling.
 
         A ``ContactPair`` activates ADMM contacts between two solver entries.
+        Optional parameter overrides apply only to contacts between those entries,
+        regardless of their order. Omitted overrides inherit the corresponding
+        global :class:`SolverCoupledADMM.Config` values.
         The coupler inspects ownership for ``source`` and ``destination`` and
         emits the applicable subset of {rigid-rigid, rigid-particle,
         particle-particle} ADMM contact rows. If neither entry owns shapes or
@@ -571,10 +633,22 @@ class SolverCoupledADMM(SolverCoupled):
             source: Name of one solver entry.
             destination: Name of the other solver entry. Must differ from
                 ``source``.
+            rho: Positive dimensionless penalty override. ``None`` inherits
+                the global :class:`SolverCoupledADMM.Config` value.
+            gamma: Nonnegative dimensionless proximal scaling override.
+                ``None`` inherits the global Config value.
+            baumgarte: Nonnegative dimensionless position error correction
+                fraction. ``None`` inherits the global Config value.
         """
 
         source: str
         destination: str
+        rho: float | None = field(default=None, kw_only=True)
+        """Positive dimensionless penalty; ``None`` inherits the global value."""
+        gamma: float | None = field(default=None, kw_only=True)
+        """Nonnegative dimensionless proximal scaling; ``None`` inherits the global value."""
+        baumgarte: float | None = field(default=None, kw_only=True)
+        """Nonnegative dimensionless correction fraction; ``None`` inherits the global value."""
 
     @dataclass(frozen=True)
     class Config:
@@ -626,8 +700,9 @@ class SolverCoupledADMM(SolverCoupled):
                 the rescaled previous-refresh ADMM contact dual when a
                 rigid-rigid contact matches. ``0`` disables dual warm-start
                 while preserving contact matching.
-            contact_pairs: Per-interface contact pairs to enable. Empty list
-                disables ADMM-managed contacts. Use
+            contact_pairs: Contact pairs to enable, with optional ADMM parameter
+                overrides for contacts only. Empty list disables ADMM-managed
+                contacts. Use
                 :meth:`SolverCoupledADMM.auto_detect_contact_pairs` to build the
                 old auto-discovery list.
         """
@@ -679,6 +754,23 @@ class SolverCoupledADMM(SolverCoupled):
         self._admm_joint_proxy_mappings: list[_AdmmJointProxyMapping] = []
 
         self._validate_config(coupling)
+        self._admm_joint_parameters = self._read_model_parameters(model, "joint", model.joint_count, coupling)
+        self._admm_attachment_parameters = self._read_model_parameters(
+            model,
+            "body_particle_attachment",
+            int(model.custom_frequency_counts.get(self.BODY_PARTICLE_ATTACHMENT_FREQUENCY, 0)),
+            coupling,
+        )
+        self._admm_proximal_enabled = (
+            coupling.gamma > 0.0
+            or any(params.gamma is not None and params.gamma > 0.0 for params in coupling.contact_pairs)
+            or any(params.gamma > 0.0 for params in self._admm_joint_parameters)
+            or any(params.gamma > 0.0 for params in self._admm_attachment_parameters)
+        )
+        self._admm_default_parameters = _AdmmInterfaceParameters(
+            rho=float(coupling.rho), gamma=float(coupling.gamma), baumgarte=float(coupling.baumgarte)
+        )
+        self._admm_contact_parameters: dict[frozenset[str], _AdmmInterfaceParameters] = {}
         if coupling.joint_proximal_bodies:
             self._init_admm_joint_proxy_visibility(model, entries, coupling.joint_proximal_destination_entries)
 
@@ -693,6 +785,15 @@ class SolverCoupledADMM(SolverCoupled):
 
     @classmethod
     def _validate_config(cls, coupling: SolverCoupledADMM.Config) -> None:
+        for params in coupling.contact_pairs:
+            if not isinstance(params, cls.ContactPair):
+                raise ValueError("ADMM contact_pairs must contain ContactPair instances")
+            for name in ("rho", "gamma", "baumgarte"):
+                value = getattr(params, name)
+                if value is not None:
+                    cls._finite_scalar(
+                        value, f"ADMM ContactPair {name}", lower_bound=0.0, lower_inclusive=name != "rho"
+                    )
         cls._positive_integer(coupling.iterations, "ADMM iterations")
         cls._finite_scalar(coupling.rho, "ADMM rho", lower_bound=0.0, lower_inclusive=False)
         cls._finite_scalar(coupling.gamma, "ADMM gamma", lower_bound=0.0)
@@ -1013,8 +1114,7 @@ class SolverCoupledADMM(SolverCoupled):
         )
 
     def _refresh_body_inertial_view_overrides(self, entry: SolverEntry) -> None:
-        gamma = float(self._coupling.gamma)
-        if gamma <= 0.0:
+        if not self._admm_proximal_enabled:
             super()._refresh_body_inertial_view_overrides(entry)
             return
 
@@ -1026,6 +1126,7 @@ class SolverCoupledADMM(SolverCoupled):
             entry.view.disable_body_dynamics(entry.body_dynamics_disabled_local_indices)
 
     def _setup_admm(self, coupling: SolverCoupledADMM.Config) -> None:
+        self._setup_admm_contact_parameters(coupling)
         for entry in self._entries.values():
             buf = _AdmmBuffers()
             buf.supports_dynamic_inertial_refresh = bool(entry.solver.coupling_supports_inertial_property_refresh())
@@ -1129,7 +1230,7 @@ class SolverCoupledADMM(SolverCoupled):
         ) and self._admm_internal_contacts is None:
             self._admm_internal_contacts = self._admm_collision_pipeline.contacts()
 
-        if coupling.gamma > 0.0:
+        if self._admm_proximal_enabled:
             self._refresh_admm_proximal_masks()
             self._refresh_admm_proximal_view_overrides(
                 refresh_supported_solvers=True,
@@ -1211,9 +1312,6 @@ class SolverCoupledADMM(SolverCoupled):
         self._mark_static_admm_proximal_masks()
         self._mark_dynamic_contact_admm_proximal_masks()
         self._mark_joint_qd_proximal_masks_from_bodies()
-
-    def _proximal_gamma_rho(self) -> float:
-        return float(self._coupling.gamma) * float(self._coupling.rho)
 
     def _mark_indices_for_proximal_mask(self, mask: wp.array | None, indices: wp.array | None) -> None:
         if mask is None or indices is None or indices.shape[0] == 0:
@@ -1317,6 +1415,8 @@ class SolverCoupledADMM(SolverCoupled):
         body_ids: wp.array | None,
         point_local: wp.array | None,
         W: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             body_ids is None
@@ -1337,7 +1437,7 @@ class SolverCoupledADMM(SolverCoupled):
                 entry.state_0.body_q,
                 entry.view.body_com,
                 W,
-                self._proximal_gamma_rho(),
+                gamma_rho,
                 buf.body_proximal_mass,
                 buf.body_proximal_inertia,
                 buf.body_proximal_mask,
@@ -1353,6 +1453,8 @@ class SolverCoupledADMM(SolverCoupled):
         body_ids: wp.array | None,
         point_local: wp.array | None,
         W: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             active_count is None
@@ -1375,7 +1477,7 @@ class SolverCoupledADMM(SolverCoupled):
                 entry.state_0.body_q,
                 entry.view.body_com,
                 W,
-                self._proximal_gamma_rho(),
+                gamma_rho,
                 buf.body_proximal_mass,
                 buf.body_proximal_inertia,
                 buf.body_proximal_mask,
@@ -1392,6 +1494,8 @@ class SolverCoupledADMM(SolverCoupled):
         point_local: wp.array | None,
         point_offset_local: wp.array | None,
         W: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             active_count is None
@@ -1416,7 +1520,7 @@ class SolverCoupledADMM(SolverCoupled):
                 entry.state_0.body_q,
                 entry.view.body_com,
                 W,
-                self._proximal_gamma_rho(),
+                gamma_rho,
                 buf.body_proximal_mass,
                 buf.body_proximal_inertia,
                 buf.body_proximal_mask,
@@ -1430,6 +1534,8 @@ class SolverCoupledADMM(SolverCoupled):
         body_ids: wp.array | None,
         W: wp.array | None,
         component_lump: float,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             body_ids is None
@@ -1445,7 +1551,7 @@ class SolverCoupledADMM(SolverCoupled):
             inputs=[
                 body_ids,
                 W,
-                self._proximal_gamma_rho(),
+                gamma_rho,
                 float(component_lump),
                 buf.body_proximal_inertia,
                 buf.body_proximal_mask,
@@ -1459,13 +1565,15 @@ class SolverCoupledADMM(SolverCoupled):
         W: wp.array | None,
         lump: wp.array | None,
         mask: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if indices is None or W is None or lump is None or mask is None or indices.shape[0] == 0:
             return
         wp.launch(
             accumulate_indices_proximal_lump_kernel,
             dim=indices.shape[0],
-            inputs=[indices, W, self._proximal_gamma_rho(), lump, mask],
+            inputs=[indices, W, gamma_rho, lump, mask],
             device=self.model.device,
         )
 
@@ -1476,6 +1584,8 @@ class SolverCoupledADMM(SolverCoupled):
         W: wp.array | None,
         lump: wp.array | None,
         mask: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             active_count is None
@@ -1489,7 +1599,7 @@ class SolverCoupledADMM(SolverCoupled):
         wp.launch(
             accumulate_active_indices_proximal_lump_kernel,
             dim=indices.shape[0],
-            inputs=[active_count, indices, W, self._proximal_gamma_rho(), lump, mask],
+            inputs=[active_count, indices, W, gamma_rho, lump, mask],
             device=self.model.device,
         )
 
@@ -1500,6 +1610,8 @@ class SolverCoupledADMM(SolverCoupled):
         W: wp.array | None,
         lump: wp.array | None,
         mask: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             indices is None
@@ -1513,7 +1625,7 @@ class SolverCoupledADMM(SolverCoupled):
         wp.launch(
             accumulate_global_indices_proximal_lump_kernel,
             dim=indices.shape[0],
-            inputs=[indices, global_to_local, W, self._proximal_gamma_rho(), lump, mask],
+            inputs=[indices, global_to_local, W, gamma_rho, lump, mask],
             device=self.model.device,
         )
 
@@ -1525,6 +1637,8 @@ class SolverCoupledADMM(SolverCoupled):
         W: wp.array | None,
         lump: wp.array | None,
         mask: wp.array | None,
+        *,
+        gamma_rho: float,
     ) -> None:
         if (
             active_count is None
@@ -1539,7 +1653,7 @@ class SolverCoupledADMM(SolverCoupled):
         wp.launch(
             accumulate_active_global_indices_proximal_lump_kernel,
             dim=indices.shape[0],
-            inputs=[active_count, indices, global_to_local, W, self._proximal_gamma_rho(), lump, mask],
+            inputs=[active_count, indices, global_to_local, W, gamma_rho, lump, mask],
             device=self.model.device,
         )
 
@@ -1549,26 +1663,52 @@ class SolverCoupledADMM(SolverCoupled):
             entry_b = self._entries[group.body_entry_name_b]
             buf_a = self._admm_buffers[group.body_entry_name_a]
             buf_b = self._admm_buffers[group.body_entry_name_b]
-            self._accumulate_body_point_proximal_lump(entry_a, buf_a, group.body_ids_a, group.point_a, group.W)
-            self._accumulate_body_point_proximal_lump(entry_b, buf_b, group.body_ids_b, group.point_b, group.W)
+            self._accumulate_body_point_proximal_lump(
+                entry_a,
+                buf_a,
+                group.body_ids_a,
+                group.point_a,
+                group.W,
+                gamma_rho=group.parameters.gamma * group.parameters.rho,
+            )
+            self._accumulate_body_point_proximal_lump(
+                entry_b,
+                buf_b,
+                group.body_ids_b,
+                group.point_b,
+                group.W,
+                gamma_rho=group.parameters.gamma * group.parameters.rho,
+            )
 
         for group in self._admm_rr_angular_groups:
             buf_a = self._admm_buffers[group.body_entry_name_a]
             buf_b = self._admm_buffers[group.body_entry_name_b]
-            self._accumulate_body_angular_proximal_lump(buf_a, group.body_ids_a, group.W, 1.0)
-            self._accumulate_body_angular_proximal_lump(buf_b, group.body_ids_b, group.W, 1.0)
+            self._accumulate_body_angular_proximal_lump(
+                buf_a, group.body_ids_a, group.W, 1.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
+            self._accumulate_body_angular_proximal_lump(
+                buf_b, group.body_ids_b, group.W, 1.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
 
         for group in self._admm_rr_revolute_angular_groups:
             buf_a = self._admm_buffers[group.body_entry_name_a]
             buf_b = self._admm_buffers[group.body_entry_name_b]
-            self._accumulate_body_angular_proximal_lump(buf_a, group.body_ids_a, group.W, 2.0 / 3.0)
-            self._accumulate_body_angular_proximal_lump(buf_b, group.body_ids_b, group.W, 2.0 / 3.0)
+            self._accumulate_body_angular_proximal_lump(
+                buf_a, group.body_ids_a, group.W, 2.0 / 3.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
+            self._accumulate_body_angular_proximal_lump(
+                buf_b, group.body_ids_b, group.W, 2.0 / 3.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
 
         for group in self._admm_rr_angular_friction_groups:
             buf_a = self._admm_buffers[group.body_entry_name_a]
             buf_b = self._admm_buffers[group.body_entry_name_b]
-            self._accumulate_body_angular_proximal_lump(buf_a, group.body_ids_a, group.W, 1.0)
-            self._accumulate_body_angular_proximal_lump(buf_b, group.body_ids_b, group.W, 1.0)
+            self._accumulate_body_angular_proximal_lump(
+                buf_a, group.body_ids_a, group.W, 1.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
+            self._accumulate_body_angular_proximal_lump(
+                buf_b, group.body_ids_b, group.W, 1.0, gamma_rho=group.parameters.gamma * group.parameters.rho
+            )
 
         for group in self._admm_rp_groups:
             body_entry = self._entries[group.body_entry_name]
@@ -1581,6 +1721,7 @@ class SolverCoupledADMM(SolverCoupled):
                 group.body_ids,
                 group.point_body,
                 group.W,
+                gamma_rho=group.parameters.gamma * group.parameters.rho,
             )
             self._accumulate_global_indices_proximal_lump(
                 group.particle_ids,
@@ -1588,6 +1729,7 @@ class SolverCoupledADMM(SolverCoupled):
                 group.W,
                 particle_buf.particle_proximal_mass,
                 particle_buf.particle_proximal_mask,
+                gamma_rho=group.parameters.gamma * group.parameters.rho,
             )
 
     def _mark_dynamic_contact_admm_proximal_masks(self) -> None:
@@ -1605,6 +1747,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.point_a,
                     group.offset_a,
                     group.W,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_indices_proximal_lump(
@@ -1612,6 +1755,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     buf_a.body_proximal_mass,
                     buf_a.body_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             if buf_b.supports_dynamic_inertial_refresh:
                 self._accumulate_active_body_contact_proximal_lump(
@@ -1622,6 +1766,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.point_b,
                     group.offset_b,
                     group.W,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_indices_proximal_lump(
@@ -1629,6 +1774,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     buf_b.body_proximal_mass,
                     buf_b.body_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
 
         for group in self._admm_dynamic_rp_contact_groups:
@@ -1644,6 +1790,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.body_ids,
                     group.point_body,
                     group.W,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_indices_proximal_lump(
@@ -1651,6 +1798,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     body_buf.body_proximal_mass,
                     body_buf.body_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             if particle_buf.supports_dynamic_inertial_refresh:
                 self._accumulate_active_global_indices_proximal_lump(
@@ -1660,6 +1808,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.W,
                     particle_buf.particle_proximal_mass,
                     particle_buf.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_global_indices_proximal_lump(
@@ -1668,6 +1817,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     particle_buf.particle_proximal_mass,
                     particle_buf.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
 
         for group in self._admm_dynamic_pp_contact_groups:
@@ -1683,6 +1833,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.W,
                     buf_a.particle_proximal_mass,
                     buf_a.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_global_indices_proximal_lump(
@@ -1691,6 +1842,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     buf_a.particle_proximal_mass,
                     buf_a.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             if buf_b.supports_dynamic_inertial_refresh:
                 self._accumulate_active_global_indices_proximal_lump(
@@ -1700,6 +1852,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.W,
                     buf_b.particle_proximal_mass,
                     buf_b.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
             else:
                 self._accumulate_global_indices_proximal_lump(
@@ -1708,6 +1861,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.candidate_W,
                     buf_b.particle_proximal_mass,
                     buf_b.particle_proximal_mask,
+                    gamma_rho=group.parameters.gamma * group.parameters.rho,
                 )
 
     def _mark_joint_qd_proximal_masks_from_bodies(self) -> None:
@@ -1751,8 +1905,7 @@ class SolverCoupledADMM(SolverCoupled):
         refresh_supported_solvers: bool,
         notify_unsupported_solvers: bool = False,
     ) -> None:
-        gamma = float(self._coupling.gamma)
-        if gamma <= 0.0:
+        if not self._admm_proximal_enabled:
             return
 
         for entry in self._entries.values():
@@ -1818,7 +1971,7 @@ class SolverCoupledADMM(SolverCoupled):
 
         if self._admm_internal_contacts is not None:
             self._admm_internal_contacts.clear(bump_generation=True)
-        if float(self._coupling.gamma) > 0.0:
+        if self._admm_proximal_enabled:
             self._refresh_admm_proximal_masks()
             self._refresh_admm_proximal_view_overrides(refresh_supported_solvers=True)
 
@@ -2121,6 +2274,51 @@ class SolverCoupledADMM(SolverCoupled):
             device=self.model.device,
         )
 
+    @classmethod
+    def _read_model_parameters(
+        cls, model: Model, prefix: str, count: int, coupling: SolverCoupledADMM.Config
+    ) -> list[_AdmmInterfaceParameters]:
+        """Resolve per-row custom attributes, with -1 or absent attributes inheriting defaults."""
+        namespace = getattr(model, "coupling", None)
+        arrays = {name: getattr(namespace, f"{prefix}_{name}", None) for name in ("rho", "gamma", "baumgarte")}
+        arrays = {name: array.numpy() for name, array in arrays.items() if array is not None}
+        result = []
+        for row in range(count):
+            values = {}
+            for name in ("rho", "gamma", "baumgarte"):
+                value = float(arrays[name][row]) if name in arrays else -1.0
+                values[name] = (
+                    float(getattr(coupling, name))
+                    if value == -1.0
+                    else cls._finite_scalar(
+                        value, f"ADMM {prefix} row {row} {name}", lower_bound=0.0, lower_inclusive=name != "rho"
+                    )
+                )
+            result.append(_AdmmInterfaceParameters(**values))
+        return result
+
+    def _setup_admm_contact_parameters(self, coupling: SolverCoupledADMM.Config) -> None:
+        """Resolve parameter overrides for unordered pairs of solver entries."""
+        for params in coupling.contact_pairs:
+            if params.source == params.destination:
+                raise ValueError("ADMM ContactPair requires distinct source and destination")
+            if params.source not in self._entries:
+                raise ValueError(f"Unknown ADMM ContactPair source {params.source!r}")
+            if params.destination not in self._entries:
+                raise ValueError(f"Unknown ADMM ContactPair destination {params.destination!r}")
+            key = frozenset((params.source, params.destination))
+            if key in self._admm_contact_parameters:
+                raise ValueError(f"Duplicate ADMM ContactPair for entries {params.source!r} and {params.destination!r}")
+            self._admm_contact_parameters[key] = _AdmmInterfaceParameters(
+                rho=float(coupling.rho if params.rho is None else params.rho),
+                gamma=float(coupling.gamma if params.gamma is None else params.gamma),
+                baumgarte=float(coupling.baumgarte if params.baumgarte is None else params.baumgarte),
+            )
+
+    def _contact_parameters(self, owner_a: str, owner_b: str) -> _AdmmInterfaceParameters:
+        """Get resolved parameters for an interface, falling back to global values."""
+        return self._admm_contact_parameters.get(frozenset((owner_a, owner_b)), self._admm_default_parameters)
+
     def _setup_admm_contact_specs(self, coupling: SolverCoupledADMM.Config) -> None:
         """Populate dynamic ADMM contact specs from configured contact pairs."""
         if not coupling.contact_pairs:
@@ -2129,34 +2327,19 @@ class SolverCoupledADMM(SolverCoupled):
         # Discover all candidate specs from model state (one rigid-rigid/rigid-particle
         # /particle-particle entry per cross-owner combination), then keep only those
         # whose owner pair appears in the user's ContactPair list.
-        pair_by_owners: dict[frozenset[str], SolverCoupledADMM.ContactPair] = {}
-        for pair in coupling.contact_pairs:
-            if pair.source == pair.destination:
-                raise ValueError(f"ADMM ContactPair requires distinct source and destination, got {pair.source!r}")
-            if pair.source not in self._entries:
-                raise ValueError(f"Unknown ADMM ContactPair source {pair.source!r}")
-            if pair.destination not in self._entries:
-                raise ValueError(f"Unknown ADMM ContactPair destination {pair.destination!r}")
-            key = frozenset({pair.source, pair.destination})
-            if key in pair_by_owners:
-                raise ValueError(f"Duplicate ADMM ContactPair for entries {pair.source!r} and {pair.destination!r}")
-            pair_by_owners[key] = pair
-
         rp_specs = self._discover_rigid_particle_contact_specs()
         rr_specs = self._discover_rigid_rigid_contact_specs()
         pp_specs = self._discover_particle_particle_contact_specs()
 
-        def matching_pair(owner_a: str, owner_b: str):
-            return pair_by_owners.get(frozenset({owner_a, owner_b}))
+        def matches_pair(owner_a: str, owner_b: str) -> bool:
+            return frozenset((owner_a, owner_b)) in self._admm_contact_parameters
 
         self._admm_rigid_particle_contact_specs = [
-            spec for spec in rp_specs if matching_pair(spec.body_owner, spec.particle_owner) is not None
+            spec for spec in rp_specs if matches_pair(spec.body_owner, spec.particle_owner)
         ]
-        self._admm_rigid_rigid_contact_specs = [
-            spec for spec in rr_specs if matching_pair(spec.owner_a, spec.owner_b) is not None
-        ]
+        self._admm_rigid_rigid_contact_specs = [spec for spec in rr_specs if matches_pair(spec.owner_a, spec.owner_b)]
         self._admm_particle_particle_contact_specs = [
-            spec for spec in pp_specs if matching_pair(spec.owner_a, spec.owner_b) is not None
+            spec for spec in pp_specs if matches_pair(spec.owner_a, spec.owner_b)
         ]
 
     @classmethod
@@ -2483,15 +2666,17 @@ class SolverCoupledADMM(SolverCoupled):
         joint_axis = self.model.joint_axis.numpy()
 
         point_items: dict[
-            tuple[str, str],
+            tuple[str, str, _AdmmInterfaceParameters],
             list[tuple[int, tuple[float, float, float], int, tuple[float, float, float], float, float]],
         ] = {}
-        angular_items: dict[tuple[str, str], list[tuple[int, wp.transform, int, wp.transform, float, float]]] = {}
+        angular_items: dict[
+            tuple[str, str, _AdmmInterfaceParameters], list[tuple[int, wp.transform, int, wp.transform, float, float]]
+        ] = {}
         revolute_angular_items: dict[
-            tuple[str, str], list[tuple[int, wp.transform, int, wp.transform, float, float]]
+            tuple[str, str, _AdmmInterfaceParameters], list[tuple[int, wp.transform, int, wp.transform, float, float]]
         ] = {}
         angular_friction_items: dict[
-            tuple[str, str], list[tuple[int, wp.transform, int, tuple[float, float, float]]]
+            tuple[str, str, _AdmmInterfaceParameters], list[tuple[int, wp.transform, int, tuple[float, float, float]]]
         ] = {}
 
         for joint in range(self.model.joint_count):
@@ -2504,9 +2689,10 @@ class SolverCoupledADMM(SolverCoupled):
                 continue
 
             child_entry, parent_entry = owner_pair
+            key = (child_entry, parent_entry, self._admm_joint_parameters[joint])
             jtype = int(joint_type[joint])
             if jtype == int(JointType.BALL):
-                point_items.setdefault((child_entry, parent_entry), []).append(
+                point_items.setdefault(key, []).append(
                     (
                         child,
                         self._transform_translation_from_row(joint_X_c[joint]),
@@ -2525,7 +2711,7 @@ class SolverCoupledADMM(SolverCoupled):
                 if friction[0] < 0.0 or friction[1] < 0.0 or friction[2] < 0.0:
                     raise ValueError(f"ADMM cross-solver ball joint {joint} has negative friction")
                 if friction[0] > 0.0 or friction[1] > 0.0 or friction[2] > 0.0:
-                    angular_friction_items.setdefault((child_entry, parent_entry), []).append(
+                    angular_friction_items.setdefault(key, []).append(
                         (
                             child,
                             self._transform_from_row(joint_X_c[joint]),
@@ -2534,7 +2720,7 @@ class SolverCoupledADMM(SolverCoupled):
                         )
                     )
             elif jtype == int(JointType.REVOLUTE):
-                point_items.setdefault((child_entry, parent_entry), []).append(
+                point_items.setdefault(key, []).append(
                     (
                         child,
                         self._transform_translation_from_row(joint_X_c[joint]),
@@ -2551,7 +2737,7 @@ class SolverCoupledADMM(SolverCoupled):
                     joint_X_c[joint],
                     axis_parent,
                 )
-                revolute_angular_items.setdefault((child_entry, parent_entry), []).append(
+                revolute_angular_items.setdefault(key, []).append(
                     (
                         child,
                         frame_child,
@@ -2565,7 +2751,7 @@ class SolverCoupledADMM(SolverCoupled):
                 if friction_value < 0.0:
                     raise ValueError(f"ADMM cross-solver revolute joint {joint} has negative friction")
                 if friction_value > 0.0:
-                    angular_friction_items.setdefault((child_entry, parent_entry), []).append(
+                    angular_friction_items.setdefault(key, []).append(
                         (
                             child,
                             frame_child,
@@ -2574,7 +2760,7 @@ class SolverCoupledADMM(SolverCoupled):
                         )
                     )
             elif jtype == int(JointType.FIXED):
-                point_items.setdefault((child_entry, parent_entry), []).append(
+                point_items.setdefault(key, []).append(
                     (
                         child,
                         self._transform_translation_from_row(joint_X_c[joint]),
@@ -2584,7 +2770,7 @@ class SolverCoupledADMM(SolverCoupled):
                         float(coupling.joint_damping),
                     )
                 )
-                angular_items.setdefault((child_entry, parent_entry), []).append(
+                angular_items.setdefault(key, []).append(
                     (
                         child,
                         self._transform_from_row(joint_X_c[joint]),
@@ -2604,7 +2790,7 @@ class SolverCoupledADMM(SolverCoupled):
                 )
 
         device = self.model.device
-        for (entry_name_a, entry_name_b), items in point_items.items():
+        for (entry_name_a, entry_name_b, parameters), items in point_items.items():
             self._require_effective_mass(entry_name_a, CouplingEndpointKind.BODY)
             self._require_effective_mass(entry_name_b, CouplingEndpointKind.BODY)
             body_global_ids_a = [item[0] for item in items]
@@ -2625,6 +2811,7 @@ class SolverCoupledADMM(SolverCoupled):
             n = len(items)
             self._admm_rr_groups.append(
                 _AdmmRigidRigidAttachmentGroup(
+                    parameters=parameters,
                     body_entry_name_a=entry_name_a,
                     body_entry_name_b=entry_name_b,
                     body_ids_a=wp.array(body_ids_a, dtype=int, device=device),
@@ -2641,7 +2828,7 @@ class SolverCoupledADMM(SolverCoupled):
                 )
             )
 
-        for (entry_name_a, entry_name_b), items in angular_items.items():
+        for (entry_name_a, entry_name_b, parameters), items in angular_items.items():
             body_global_ids_a = [item[0] for item in items]
             body_global_ids_b = [item[2] for item in items]
             body_ids_a = [self._body_local_id(entry_name_a, body) for body in body_global_ids_a]
@@ -2659,6 +2846,7 @@ class SolverCoupledADMM(SolverCoupled):
             n = len(items)
             self._admm_rr_angular_groups.append(
                 _AdmmRigidRigidAngularAttachmentGroup(
+                    parameters=parameters,
                     body_entry_name_a=entry_name_a,
                     body_entry_name_b=entry_name_b,
                     body_ids_a=wp.array(body_ids_a, dtype=int, device=device),
@@ -2675,7 +2863,7 @@ class SolverCoupledADMM(SolverCoupled):
                 )
             )
 
-        for (entry_name_a, entry_name_b), items in revolute_angular_items.items():
+        for (entry_name_a, entry_name_b, parameters), items in revolute_angular_items.items():
             body_global_ids_a = [item[0] for item in items]
             body_global_ids_b = [item[2] for item in items]
             body_ids_a = [self._body_local_id(entry_name_a, body) for body in body_global_ids_a]
@@ -2693,6 +2881,7 @@ class SolverCoupledADMM(SolverCoupled):
             n = len(items)
             self._admm_rr_revolute_angular_groups.append(
                 _AdmmRigidRigidAngularAttachmentGroup(
+                    parameters=parameters,
                     body_entry_name_a=entry_name_a,
                     body_entry_name_b=entry_name_b,
                     body_ids_a=wp.array(body_ids_a, dtype=int, device=device),
@@ -2709,7 +2898,7 @@ class SolverCoupledADMM(SolverCoupled):
                 )
             )
 
-        for (entry_name_a, entry_name_b), items in angular_friction_items.items():
+        for (entry_name_a, entry_name_b, parameters), items in angular_friction_items.items():
             body_global_ids_a = [item[0] for item in items]
             body_global_ids_b = [item[2] for item in items]
             body_ids_a = [self._body_local_id(entry_name_a, body) for body in body_global_ids_a]
@@ -2725,6 +2914,7 @@ class SolverCoupledADMM(SolverCoupled):
             n = len(items)
             self._admm_rr_angular_friction_groups.append(
                 _AdmmRigidRigidAngularFrictionGroup(
+                    parameters=parameters,
                     body_entry_name_a=entry_name_a,
                     body_entry_name_b=entry_name_b,
                     body_ids_a=wp.array(body_ids_a, dtype=int, device=device),
@@ -2766,7 +2956,9 @@ class SolverCoupledADMM(SolverCoupled):
         damping_np = coupling_ns.body_particle_attachment_damping.numpy()
         enabled_np = coupling_ns.body_particle_attachment_enabled.numpy()
 
-        grouped: dict[tuple[str, str], list[tuple[int, tuple[float, float, float], int, float, float]]] = {}
+        grouped: dict[
+            tuple[str, str, _AdmmInterfaceParameters], list[tuple[int, tuple[float, float, float], int, float, float]]
+        ] = {}
         for row in range(count):
             if not bool(enabled_np[row]):
                 continue
@@ -2789,10 +2981,12 @@ class SolverCoupledADMM(SolverCoupled):
                 continue
 
             point = (float(point_np[row][0]), float(point_np[row][1]), float(point_np[row][2]))
-            grouped.setdefault((body_entry, particle_entry), []).append((body, point, particle, stiffness, damping))
+            grouped.setdefault((body_entry, particle_entry, self._admm_attachment_parameters[row]), []).append(
+                (body, point, particle, stiffness, damping)
+            )
 
         device = self.model.device
-        for (body_entry, particle_entry), items in grouped.items():
+        for (body_entry, particle_entry, parameters), items in grouped.items():
             self._require_effective_mass(body_entry, CouplingEndpointKind.BODY)
             self._require_effective_mass(particle_entry, CouplingEndpointKind.PARTICLE)
             body_global_ids = [item[0] for item in items]
@@ -2811,6 +3005,7 @@ class SolverCoupledADMM(SolverCoupled):
             n = len(items)
             self._admm_rp_groups.append(
                 _AdmmRigidParticleAttachmentGroup(
+                    parameters=parameters,
                     body_entry_name=body_entry,
                     particle_entry_name=particle_entry,
                     body_ids=wp.array(body_ids, dtype=int, device=device),
@@ -2840,7 +3035,7 @@ class SolverCoupledADMM(SolverCoupled):
         coupling = self._coupling
         iters = int(coupling.iterations)
         self._refresh_collision_contact_groups(state_in)
-        if float(coupling.gamma) > 0.0:
+        if self._admm_proximal_enabled:
             self._refresh_admm_proximal_masks()
             self._refresh_admm_proximal_view_overrides(refresh_supported_solvers=True)
 
@@ -3268,6 +3463,7 @@ class SolverCoupledADMM(SolverCoupled):
 
             groups.append(
                 _AdmmRigidRigidContactGroup(
+                    parameters=self._contact_parameters(spec.owner_a, spec.owner_b),
                     body_entry_name_a=spec.owner_a,
                     body_entry_name_b=spec.owner_b,
                     body_ids_a=wp.zeros(capacity, dtype=int, device=device),
@@ -3346,6 +3542,7 @@ class SolverCoupledADMM(SolverCoupled):
 
             groups.append(
                 _AdmmRigidParticleContactGroup(
+                    parameters=self._contact_parameters(spec.body_owner, spec.particle_owner),
                     body_entry_name=spec.body_owner,
                     particle_entry_name=spec.particle_owner,
                     body_ids=wp.zeros(capacity, dtype=int, device=device),
@@ -3415,6 +3612,7 @@ class SolverCoupledADMM(SolverCoupled):
 
             groups.append(
                 _AdmmParticleParticleContactGroup(
+                    parameters=self._contact_parameters(spec.owner_a, spec.owner_b),
                     particle_entry_name_a=spec.owner_a,
                     particle_entry_name_b=spec.owner_b,
                     particle_ids_a=wp.zeros(capacity, dtype=int, device=device),
@@ -3448,11 +3646,10 @@ class SolverCoupledADMM(SolverCoupled):
         return groups
 
     def _admm_begin_step(self, dt: float) -> None:
-        coupling = self._coupling
         for group in self._admm_rr_groups:
             if group.count == 0:
                 continue
-            if coupling.baumgarte <= 0.0:
+            if group.parameters.baumgarte <= 0.0:
                 group.u_target.zero_()
                 continue
             entry_a = self._entries[group.body_entry_name_a]
@@ -3467,7 +3664,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.point_b,
                     entry_a.state_0.body_q,
                     entry_b.state_0.body_q,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_target],
@@ -3476,7 +3673,7 @@ class SolverCoupledADMM(SolverCoupled):
         for group in self._admm_rr_angular_groups:
             if group.count == 0:
                 continue
-            if coupling.baumgarte <= 0.0:
+            if group.parameters.baumgarte <= 0.0:
                 group.u_target.zero_()
                 continue
             entry_a = self._entries[group.body_entry_name_a]
@@ -3491,7 +3688,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.frame_b,
                     entry_a.state_0.body_q,
                     entry_b.state_0.body_q,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_target],
@@ -3500,7 +3697,7 @@ class SolverCoupledADMM(SolverCoupled):
         for group in self._admm_rr_revolute_angular_groups:
             if group.count == 0:
                 continue
-            if coupling.baumgarte <= 0.0:
+            if group.parameters.baumgarte <= 0.0:
                 group.u_target.zero_()
                 continue
             entry_a = self._entries[group.body_entry_name_a]
@@ -3515,7 +3712,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.frame_b,
                     entry_a.state_0.body_q,
                     entry_b.state_0.body_q,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_target],
@@ -3524,7 +3721,7 @@ class SolverCoupledADMM(SolverCoupled):
         for group in self._admm_rp_groups:
             if group.count == 0:
                 continue
-            if coupling.baumgarte <= 0.0:
+            if group.parameters.baumgarte <= 0.0:
                 group.u_target.zero_()
                 continue
             body_entry = self._entries[group.body_entry_name]
@@ -3538,7 +3735,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.particle_ids,
                     body_entry.state_0.body_q,
                     particle_entry.state_0.particle_q,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_target],
@@ -3563,7 +3760,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.normal,
                     entry_a.state_0.body_q,
                     entry_b.state_0.body_q,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_min],
@@ -3587,7 +3784,7 @@ class SolverCoupledADMM(SolverCoupled):
                     body_entry.state_0.body_q,
                     particle_entry.state_0.particle_q,
                     self.model.particle_radius,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_min],
@@ -3609,7 +3806,7 @@ class SolverCoupledADMM(SolverCoupled):
                     entry_a.state_0.particle_q,
                     entry_b.state_0.particle_q,
                     self.model.particle_radius,
-                    float(coupling.baumgarte),
+                    group.parameters.baumgarte,
                     float(dt),
                 ],
                 outputs=[group.u_min],
@@ -3679,8 +3876,7 @@ class SolverCoupledADMM(SolverCoupled):
         *,
         iteration_restart: bool = False,
     ) -> None:
-        gamma = float(self._coupling.gamma)
-        apply_proximal = gamma > 0.0
+        apply_proximal = self._admm_proximal_enabled
         flags = int(StateFlags.NONE)
 
         if buf.body_q_n is not None:
@@ -3763,7 +3959,7 @@ class SolverCoupledADMM(SolverCoupled):
                 group.active_count,
                 group.u_min,
                 group.W,
-                float(self._coupling.rho),
+                group.parameters.rho,
                 group.friction,
                 group.normal,
                 group.lambda_,
@@ -3782,7 +3978,7 @@ class SolverCoupledADMM(SolverCoupled):
                 group.damping,
                 float(dt),
                 group.W,
-                float(self._coupling.rho),
+                group.parameters.rho,
                 group.lambda_,
                 group.Jv,
                 group.u_target,
@@ -3793,7 +3989,7 @@ class SolverCoupledADMM(SolverCoupled):
         wp.launch(
             lambda_update_kernel,
             dim=group.count,
-            inputs=[float(self._coupling.rho), group.W, group.u, group.Jv],
+            inputs=[group.parameters.rho, group.W, group.u, group.Jv],
             outputs=[group.lambda_],
             device=self.model.device,
         )
@@ -3803,7 +3999,7 @@ class SolverCoupledADMM(SolverCoupled):
         wp.launch(
             contact_lambda_update_kernel,
             dim=group.count,
-            inputs=[group.active_count, float(self._coupling.rho), group.W, group.u, group.Jv],
+            inputs=[group.active_count, group.parameters.rho, group.W, group.u, group.Jv],
             outputs=[group.lambda_],
             device=self.model.device,
         )
@@ -3817,7 +4013,6 @@ class SolverCoupledADMM(SolverCoupled):
         initialize_contact_u: bool,
     ) -> None:
         del iteration_k
-        coupling = self._coupling
         inv_dt = 1.0 / float(dt)
         for group in self._admm_rr_groups:
             if group.count == 0:
@@ -3858,7 +4053,7 @@ class SolverCoupledADMM(SolverCoupled):
                     entry_b.state_0.body_q,
                     entry_b.view.body_com,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -3892,7 +4087,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.body_ids_a,
                     group.body_ids_b,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -3931,7 +4126,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.body_ids_b,
                     entry_a.state_0.body_q,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -3970,7 +4165,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.body_ids_b,
                     entry_a.state_0.body_q,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -4011,7 +4206,7 @@ class SolverCoupledADMM(SolverCoupled):
                     body_entry.state_0.body_q,
                     body_entry.view.body_com,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -4067,7 +4262,7 @@ class SolverCoupledADMM(SolverCoupled):
                     entry_b.state_0.body_q,
                     entry_b.view.body_com,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -4114,7 +4309,7 @@ class SolverCoupledADMM(SolverCoupled):
                     body_entry.state_0.body_q,
                     body_entry.view.body_com,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -4152,7 +4347,7 @@ class SolverCoupledADMM(SolverCoupled):
                     group.particle_ids_a,
                     group.particle_ids_b,
                     inv_dt,
-                    float(coupling.rho),
+                    group.parameters.rho,
                     group.W,
                     group.lambda_,
                     group.u,
@@ -4168,7 +4363,7 @@ class SolverCoupledADMM(SolverCoupled):
                     inputs=[
                         group.active_count,
                         float(dt),
-                        float(coupling.rho),
+                        group.parameters.rho,
                         group.W,
                         group.normal,
                         group.lambda_,
@@ -4181,7 +4376,6 @@ class SolverCoupledADMM(SolverCoupled):
 
     def _update_admm_dual(self, iteration_k: int, dt: float) -> None:
         del iteration_k
-        coupling = self._coupling
         for group in self._admm_rr_groups:
             if group.count == 0:
                 continue
@@ -4266,14 +4460,14 @@ class SolverCoupledADMM(SolverCoupled):
             wp.launch(
                 joint_box_friction_u_update_kernel,
                 dim=group.count,
-                inputs=[group.friction, float(dt), group.W, float(coupling.rho), group.lambda_, group.Jv],
+                inputs=[group.friction, float(dt), group.W, group.parameters.rho, group.lambda_, group.Jv],
                 outputs=[group.u],
                 device=self.model.device,
             )
             wp.launch(
                 lambda_update_kernel,
                 dim=group.count,
-                inputs=[float(coupling.rho), group.W, group.u, group.Jv],
+                inputs=[group.parameters.rho, group.W, group.u, group.Jv],
                 outputs=[group.lambda_],
                 device=self.model.device,
             )

--- a/newton/_src/solvers/coupled/solver_coupled_admm.py
+++ b/newton/_src/solvers/coupled/solver_coupled_admm.py
@@ -2836,8 +2836,7 @@ class SolverCoupledADMM(SolverCoupled):
     ) -> None:
         """Run ADMM iterations over all sub-solvers."""
         del state_out
-        if dt <= 0.0:
-            raise ValueError("SolverCoupledADMM requires dt > 0")
+        dt = self._finite_scalar(dt, "ADMM dt", lower_bound=0.0, lower_inclusive=False)
         coupling = self._coupling
         iters = int(coupling.iterations)
         self._refresh_collision_contact_groups(state_in)

--- a/newton/examples/multiphysics/example_admm_contact_solver.py
+++ b/newton/examples/multiphysics/example_admm_contact_solver.py
@@ -370,15 +370,15 @@ class Example:
         )
         parser.add_argument(
             "--rho",
-            help="ADMM penalty parameter",
+            help="Dimensionless ADMM penalty parameter",
             type=float,
-            default=45.0,
+            default=0.4,
         )
         parser.add_argument(
             "--gamma",
-            help="ADMM proximal metric scale",
+            help="Dimensionless ADMM proximal metric scale",
             type=float,
-            default=0.001,
+            default=0.1,
         )
         parser.add_argument(
             "--baumgarte",

--- a/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
+++ b/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
@@ -371,10 +371,10 @@ class Example:
         parser.set_defaults(world_count=4)
         parser.add_argument("--substeps", type=int, default=3, help="Coupled substeps per rendered frame.")
         parser.add_argument("--admm-iterations", type=int, default=2, help="ADMM iterations per coupled substep.")
-        parser.add_argument("--rho", type=float, default=50.0, help="ADMM penalty parameter.")
-        parser.add_argument("--gamma", type=float, default=0.1, help="ADMM proximal mass scaling.")
+        parser.add_argument("--rho", type=float, default=0.3, help="Dimensionless ADMM penalty parameter.")
+        parser.add_argument("--gamma", type=float, default=20.0, help="Dimensionless ADMM proximal mass scaling.")
         parser.add_argument("--baumgarte", type=float, default=0.02, help="Position error correction fraction.")
-        parser.add_argument("--joint-stiffness", type=float, default=2.0e4, help="Cross-solver joint stiffness [N/m].")
+        parser.add_argument("--joint-stiffness", type=float, default=3.6e6, help="Cross-solver joint stiffness [N/m].")
         parser.add_argument("--joint-damping", type=float, default=1.0, help="Cross-solver joint damping [N*s/m].")
         parser.add_argument("--kamino-iterations", type=int, default=40, help="Kamino PADMM iterations per substep.")
         parser.add_argument(

--- a/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
@@ -603,8 +603,8 @@ class Example:
         parser.set_defaults(world_count=8)
         parser.add_argument("--substeps", type=int, default=16, help="Coupled substeps per rendered frame.")
         parser.add_argument("--admm-iterations", type=int, default=5, help="ADMM iterations per coupled substep.")
-        parser.add_argument("--rho", type=float, default=200.0, help="ADMM penalty parameter.")
-        parser.add_argument("--gamma", type=float, default=0.001, help="ADMM proximal metric scale.")
+        parser.add_argument("--rho", type=float, default=0.2, help="Dimensionless ADMM penalty parameter.")
+        parser.add_argument("--gamma", type=float, default=1.0, help="Dimensionless ADMM proximal metric scale.")
         parser.add_argument("--baumgarte", type=float, default=0.5, help="Position error correction fraction.")
         parser.add_argument(
             "--rigid-contact-matching",

--- a/newton/examples/multiphysics/example_mujoco_vbd_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_vbd_admm_solver.py
@@ -152,7 +152,7 @@ class Example:
             self.ball_body,
             self.center_particle,
             body_point=wp.vec3(0.0, 0.0, ball_radius),
-            stiffness=1.0e3,
+            stiffness=4.8e5,
         )
 
         link_hx = 0.28
@@ -221,9 +221,10 @@ class Example:
             ],
             coupling=SolverCoupledADMM.Config(
                 iterations=2,
-                rho=50,
-                gamma=0.1,
+                rho=0.1,
+                gamma=50.0,
                 baumgarte=0.01,
+                joint_stiffness=4.8e6,
                 joint_proximal_bodies=args.joint_proximal_bodies,
                 joint_proximal_destination_entries=(rigid_name,),
             ),

--- a/newton/tests/test_admm_coupled_solver.py
+++ b/newton/tests/test_admm_coupled_solver.py
@@ -515,7 +515,9 @@ def _make_admm_inclined_plane_particle_box_solver(
         ],
         coupling=SolverCoupledADMM.Config(
             iterations=18,
-            rho=50.0,
+            # Migrate the legacy tuning at the reference substep of 1/360 s.
+            rho=50.0 / 360.0,
+            gamma=0.0,
             baumgarte=0.1,
             contact_pairs=[
                 SolverCoupledADMM.ContactPair(
@@ -679,8 +681,9 @@ def _make_collision_admm_inclined_plane_rigid_box_solver(
         ],
         coupling=SolverCoupledADMM.Config(
             iterations=30,
-            rho=5.0,
-            gamma=0.2,
+            # Migrate the legacy tuning at the reference substep of 1/360 s.
+            rho=5.0 / 360.0,
+            gamma=72.0,
             baumgarte=0.03,
             rigid_contact_matching=rigid_contact_matching,
             contact_matching_pos_threshold=contact_matching_pos_threshold,
@@ -731,6 +734,21 @@ def _run_collision_inclined_plane_rigid_box(
 
 class TestAdmmSmoke(unittest.TestCase):
     """End-to-end: construct, run, verify state advances without NaNs."""
+
+    def test_rejects_invalid_timesteps(self):
+        """Reject nonpositive and non-finite timesteps before advancing state."""
+        model = _build_two_particle_scene()
+        solver = SolverCoupledADMM(
+            model,
+            [
+                SolverCoupled.Entry(name="a", solver=SolverSemiImplicit, particles=[0]),
+                SolverCoupled.Entry(name="b", solver=SolverSemiImplicit, particles=[1]),
+            ],
+            SolverCoupledADMM.Config(),
+        )
+        for dt in (0.0, -1.0, float("nan"), float("inf"), -float("inf")):
+            with self.subTest(dt=dt), self.assertRaisesRegex(ValueError, "dt"):
+                solver.step(model.state(), model.state(), model.control(), contacts=None, dt=dt)
 
     def test_rejects_invalid_numerical_config(self):
         model = _build_two_particle_scene()
@@ -1393,8 +1411,9 @@ class TestAdmmCollisionDetection(unittest.TestCase):
             ],
             coupling=SolverCoupledADMM.Config(
                 iterations=12,
-                rho=45.0,
-                gamma=0.05,
+                # Migrate the legacy tuning at the reference substep of 1/120 s.
+                rho=0.375,
+                gamma=6.0,
                 baumgarte=0.1,
                 contact_pairs=[
                     SolverCoupledADMM.ContactPair(

--- a/newton/tests/test_admm_coupled_solver.py
+++ b/newton/tests/test_admm_coupled_solver.py
@@ -779,6 +779,38 @@ class TestAdmmSmoke(unittest.TestCase):
 class TestAdmmProximal(unittest.TestCase):
     """Proximal terms affect constrained DOFs only."""
 
+    def test_default_proximal_stabilizes_stiff_attachment(self):
+        """Converge to a shared velocity for a nearly rigid attachment."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        particle = builder.add_particle(pos=(0.0, 0.0, 0.0), vel=(1.0, 0.0, 0.0), mass=1.0, radius=0.0)
+        SolverCoupledADMM.add_body_particle_attachment(builder, body, particle, stiffness=1.0e12)
+        builder.color()
+        model = builder.finalize(device="cpu")
+        model.particle_grid = None
+        solver = SolverCoupledADMM(
+            model,
+            [
+                SolverCoupled.Entry(
+                    "body",
+                    lambda view: SolverSemiImplicit(view, enable_tri_contact=False),
+                    bodies=[body],
+                ),
+                SolverCoupled.Entry(
+                    "particle",
+                    lambda view: SolverSemiImplicit(view, enable_tri_contact=False),
+                    particles=[particle],
+                ),
+            ],
+            SolverCoupledADMM.Config(iterations=40),
+        )
+        state_in, state_out = model.state(), model.state()
+        solver.step(state_in, state_out, model.control(), contacts=None, dt=1.0 / 120.0)
+
+        # Equal masses share the initial momentum in the hard-constraint limit.
+        np.testing.assert_allclose(state_out.body_qd.numpy()[body, :3], (0.5, 0.0, 0.0), atol=1.0e-4)
+        np.testing.assert_allclose(state_out.particle_qd.numpy()[particle], (0.5, 0.0, 0.0), atol=1.0e-4)
+
     def test_gamma_does_not_change_unconstrained_freefall(self):
         # Place the rigid body high so it stays in free-fall across the
         # window; with no ADMM constraints, gamma should not alter the result.

--- a/newton/tests/test_admm_interface_parameters.py
+++ b/newton/tests/test_admm_interface_parameters.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify per-interface ADMM parameters through solver motion."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.solvers import SolverSemiImplicit, SolverVBD, SolverXPBD
+from newton.solvers.experimental.coupled import SolverCoupled, SolverCoupledADMM
+from newton.tests.unittest_utils import get_cuda_test_devices
+
+
+class TestAdmmInterfaceParameters(unittest.TestCase):
+    """Exercise attachment and contact groups with independent interface settings."""
+
+    device = "cpu"
+    kinds = ("rr", "rp", "pp", "ball", "fixed", "revolute", "attachment", "mixed")
+
+    def _scene(self, kind, params=None):
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        endpoints = []
+        joint = kind in ("ball", "fixed", "revolute")
+        endpoint_kinds = "rr" if joint else "rp" if kind in ("attachment", "mixed") else kind
+        for index, endpoint in enumerate(endpoint_kinds):
+            pos = (0.08 * index, 0.0, 0.0)
+            if endpoint == "r":
+                rotation = wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.2 * index) if joint else wp.quat_identity()
+                body = builder.add_body(xform=wp.transform(pos, rotation))
+                builder.add_shape_sphere(body, radius=0.05, cfg=newton.ModelBuilder.ShapeConfig(density=1000.0, mu=0.0))
+                endpoints.append({"bodies": [body]})
+            else:
+                particle = builder.add_particle(pos=pos, vel=wp.vec3(), mass=1.0, radius=0.05)
+                endpoints.append({"particles": [particle]})
+        if joint:
+            if params is not None:
+                SolverCoupledADMM.register_custom_attributes(builder)
+            kwargs = {"friction": 0.1} if kind in ("ball", "revolute") else {}
+            if params is not None:
+                kwargs["custom_attributes"] = {
+                    "coupling:joint_" + name: value for name, value in params.items() if value is not None
+                }
+            getattr(builder, "add_joint_" + kind)(parent=0, child=1, collision_filter_parent=False, **kwargs)
+            # Exercise both hinge friction and constrained angular directions.
+            builder.body_qd[1] = wp.spatial_vector(0.0, 0.0, 0.0, 1.0, 0.5, 0.0)
+        elif kind in ("attachment", "mixed"):
+            SolverCoupledADMM.add_body_particle_attachment(
+                builder, 0, 0, stiffness=5000.0, damping=2.0, **(params or {})
+            )
+        model = builder.finalize(device=self.device)
+        return model, endpoints
+
+    def _solver(self, kind, global_params, pair_params, reverse=False):
+        model, endpoints = self._scene(kind, pair_params)
+        names = ("a", "b")
+        entries = [
+            SolverCoupled.Entry(name, lambda view: SolverSemiImplicit(view, enable_tri_contact=False), **owned)
+            for name, owned in zip(names, endpoints, strict=True)
+        ]
+        pair = SolverCoupledADMM.ContactPair(*(reversed(names) if reverse else names), **(pair_params or {}))
+        solver = SolverCoupledADMM(
+            model,
+            entries,
+            SolverCoupledADMM.Config(
+                iterations=3,
+                contact_pairs=[pair] if kind in ("rr", "rp", "pp", "mixed") else [],
+                joint_proximal_bodies=False,
+                **global_params,
+            ),
+        )
+        return model, solver
+
+    def _run(self, model, solver, *, capture=False):
+        state, other = model.state(), model.state()
+        if capture:
+            solver.step(state, other, model.control(), None, 1.0 / 240.0)
+            state, other = model.state(), model.state()
+            solver.reset(state, flags=0)
+            with wp.ScopedDevice(model.device), wp.ScopedCapture() as captured:
+                solver.step(state, other, model.control(), None, 1.0 / 240.0)
+            wp.capture_launch(captured.graph)
+            state = other
+        else:
+            for _ in range(3):
+                state.clear_forces()
+                solver.step(state, other, model.control(), None, 1.0 / 240.0)
+                state, other = other, state
+        arrays = [
+            getattr(state, name).numpy()
+            for name in ("body_q", "body_qd", "particle_q", "particle_qd")
+            if getattr(state, name) is not None
+        ]
+        return np.concatenate([array.flatten() for array in arrays])
+
+    def test_explicit_inheritance_preserves_motion(self):
+        """Match omitted, inherited, partial, and explicit interface parameters."""
+        effective = {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1}
+        for kind in self.kinds:
+            with self.subTest(kind=kind):
+                model, solver = self._solver(kind, effective, None)
+                reference = self._run(model, solver)
+                for params in (
+                    {},
+                    {"rho": None, "gamma": None, "baumgarte": None},
+                    {"rho": effective["rho"]},
+                    {"gamma": effective["gamma"]},
+                    {"baumgarte": effective["baumgarte"]},
+                    effective,
+                ):
+                    other_model, other_solver = self._solver(kind, effective, params)
+                    np.testing.assert_allclose(self._run(other_model, other_solver), reference, atol=1e-7, rtol=1e-6)
+
+    def test_overrides_replace_globals_for_all_interface_kinds(self):
+        """Use pair values in correction, projection, force, dual, and proximal paths."""
+        effective = {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1}
+        for kind in self.kinds:
+            with self.subTest(kind=kind):
+                model, solver = self._solver(kind, effective, {})
+                reference = self._run(model, solver)
+                override_model, override_solver = self._solver(
+                    kind,
+                    {"rho": 0.1, "gamma": 0.0, "baumgarte": 0.0},
+                    effective,
+                    reverse=True,
+                )
+                np.testing.assert_allclose(self._run(override_model, override_solver), reference, atol=1e-7, rtol=1e-6)
+                override_solver.reset(override_model.state(), flags=0)
+                np.testing.assert_allclose(self._run(override_model, override_solver), reference, atol=1e-7, rtol=1e-6)
+
+    def test_zero_gamma_disables_interface_proximal_terms(self):
+        """Honor explicit zero gamma despite positive global gamma."""
+        for kind in self.kinds:
+            with self.subTest(kind=kind):
+                model, solver = self._solver(kind, {"rho": 0.4, "gamma": 0.0, "baumgarte": 0.1}, {})
+                reference = self._run(model, solver)
+                model, solver = self._solver(
+                    kind,
+                    {"rho": 0.4, "gamma": 0.5, "baumgarte": 0.1},
+                    {"gamma": 0.0},
+                )
+                np.testing.assert_allclose(self._run(model, solver), reference, atol=1e-7, rtol=1e-6)
+
+    def test_two_interfaces_add_independent_proximal_terms(self):
+        """Sum distinct interface gamma-rho contributions on their shared endpoint."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        for x in (-0.08, 0.0, 0.08):
+            builder.add_particle(pos=(x, 0.0, 0.0), vel=wp.vec3(), mass=1.0, radius=0.05)
+        model = builder.finalize(device=self.device)
+        entries = [
+            SolverCoupled.Entry(name, lambda view: SolverSemiImplicit(view, enable_tri_contact=False), particles=[i])
+            for i, name in enumerate(("a", "b", "c"))
+        ]
+        solver = SolverCoupledADMM(
+            model,
+            entries,
+            SolverCoupledADMM.Config(
+                gamma=0.0,
+                contact_pairs=[
+                    SolverCoupledADMM.ContactPair("a", "b", rho=0.2, gamma=0.2, baumgarte=0.1),
+                    SolverCoupledADMM.ContactPair("c", "b", rho=0.8, gamma=0.3, baumgarte=0.2),
+                ],
+            ),
+        )
+        solver._refresh_collision_contact_groups(model.state())
+        solver._refresh_admm_proximal_masks()
+        masses = {
+            name: buf.particle_proximal_mass.numpy()[index]
+            for index, (name, buf) in enumerate(solver._admm_buffers.items())
+        }
+        self.assertGreater(masses["a"], 0.0)
+        self.assertAlmostEqual(masses["c"] / masses["a"], 6.0, places=5)
+        self.assertAlmostEqual(masses["b"], masses["a"] + masses["c"], places=5)
+        solver.sync_entry_states(model.state())
+        solver._admm_begin_step(1.0 / 240.0)
+        targets = [group.u_min.numpy()[0] for group in solver._admm_dynamic_pp_contact_groups]
+        self.assertAlmostEqual(targets[1] / targets[0], 2.0, places=5)
+
+    def test_invalid_overrides_fail_validation(self):
+        """Reject nonfinite, negative, and zero-penalty overrides before solver setup."""
+        for field, values in (
+            ("rho", (0.0, -1.0, float("nan"), float("inf"))),
+            ("gamma", (-1.0, float("nan"), float("inf"))),
+            ("baumgarte", (-1.0, float("nan"), float("inf"))),
+        ):
+            for value in values:
+                with (
+                    self.subTest(field=field, value=value),
+                    self.assertRaisesRegex(ValueError, "ContactPair " + field),
+                ):
+                    SolverCoupledADMM._validate_config(
+                        SolverCoupledADMM.Config(
+                            contact_pairs=[SolverCoupledADMM.ContactPair("a", "b", **{field: value})]
+                        )
+                    )
+
+    def test_invalid_interface_entries_fail_validation(self):
+        """Reject unknown, identical, duplicate, and invalid interface definitions."""
+        params = SolverCoupledADMM.ContactPair
+        cases = (
+            ([params("a", "a")], "distinct"),
+            ([params("missing", "b")], "Unknown"),
+            ([params("a", "missing")], "Unknown"),
+            ([params("a", "b"), params("b", "a")], "Duplicate"),
+            ([{"source": "a", "destination": "b"}], "ContactPair instances"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides), self.assertRaisesRegex(ValueError, message):
+                model, endpoints = self._scene("pp")
+                entries = [
+                    SolverCoupled.Entry(name, SolverSemiImplicit, **owned)
+                    for name, owned in zip(("a", "b"), endpoints, strict=True)
+                ]
+                SolverCoupledADMM(model, entries, SolverCoupledADMM.Config(contact_pairs=overrides))
+
+    def test_attachment_overrides_do_not_enable_contacts(self):
+        """Keep overlapping endpoints contact-free when only parameters are configured."""
+        for kind in ("ball", "fixed", "revolute", "attachment"):
+            with self.subTest(kind=kind):
+                model, solver = self._solver(kind, {"gamma": 0.0}, {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1})
+                self.assertTrue(np.all(np.isfinite(self._run(model, solver))))
+                self.assertEqual(solver.collision_contact_count_max, 0)
+
+    def test_override_preserves_other_interface_motion(self):
+        """Keep a second interface on the global parameters when overriding the first."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        for x in (0.0, 0.08, 1.0, 1.08):
+            builder.add_particle(pos=(x, 0.0, 0.0), vel=wp.vec3(), mass=1.0, radius=0.05)
+        model = builder.finalize(device=self.device)
+        entries = [
+            SolverCoupled.Entry(name, SolverSemiImplicit, particles=[i]) for i, name in enumerate(("a", "b", "c", "d"))
+        ]
+        global_params = {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1}
+        solver = SolverCoupledADMM(
+            model,
+            entries,
+            SolverCoupledADMM.Config(
+                iterations=3,
+                **global_params,
+                contact_pairs=[
+                    SolverCoupledADMM.ContactPair("a", "b", gamma=0.0, baumgarte=0.0),
+                    SolverCoupledADMM.ContactPair("c", "d"),
+                ],
+            ),
+        )
+        actual = self._run(model, solver).reshape(2, 4, 3)
+        np.testing.assert_allclose(actual[0, :2], ((0.0, 0.0, 0.0), (0.08, 0.0, 0.0)), atol=1e-7)
+        np.testing.assert_allclose(actual[1, :2], 0.0, atol=1e-7)
+        reference_model, reference_solver = self._solver("pp", global_params, None)
+        reference = self._run(reference_model, reference_solver).reshape(2, 2, 3)
+        actual[0, 2:, 0] -= 1.0
+        np.testing.assert_allclose(actual[:, 2:], reference, atol=1e-6, rtol=1e-5)
+
+    def test_contact_overrides_do_not_change_joint_or_attachment_motion(self):
+        """Keep contact tuning separate from constraints sharing the same entries."""
+        effective = {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1}
+        for kind in ("ball", "fixed", "revolute", "attachment"):
+            results = []
+            for contact_params in ({}, {"rho": 0.8, "gamma": 0.0, "baumgarte": 0.0}):
+                model, endpoints = self._scene(kind)
+                # Disable collision geometry so only the joint or attachment drives motion.
+                model.shape_flags.zero_()
+                model.shape_contact_pairs = wp.zeros(0, dtype=wp.vec2i, device=model.device)
+                entries = [
+                    SolverCoupled.Entry(name, SolverSemiImplicit, **owned)
+                    for name, owned in zip(("a", "b"), endpoints, strict=True)
+                ]
+                solver = SolverCoupledADMM(
+                    model,
+                    entries,
+                    SolverCoupledADMM.Config(
+                        iterations=3,
+                        joint_proximal_bodies=False,
+                        **effective,
+                        contact_pairs=[SolverCoupledADMM.ContactPair("a", "b", **contact_params)],
+                    ),
+                )
+                results.append(self._run(model, solver))
+            with self.subTest(kind=kind):
+                np.testing.assert_allclose(*results, atol=1e-7, rtol=1e-6)
+
+    def test_same_owner_pair_preserves_individual_constraint_parameters(self):
+        """Match separately tuned constraints to independent simulations with their global settings."""
+        settings = [{"rho": 0.2, "gamma": 0.0, "baumgarte": 0.1}, {"rho": 0.8, "gamma": 0.3, "baumgarte": 0.2}]
+
+        def simulate(kind, parameters, defaults):
+            builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+            SolverCoupledADMM.register_custom_attributes(builder)
+            bodies_a, bodies_b, particles = [], [], []
+            for index, params in enumerate(parameters):
+                body = builder.add_body(xform=wp.transform((0.0, float(index), 0.0), wp.quat_identity()))
+                builder.add_shape_sphere(body, radius=0.05)
+                bodies_a.append(body)
+                if kind == "attachment":
+                    particle = builder.add_particle(pos=(0.08, float(index), 0.0), vel=wp.vec3(), mass=1.0)
+                    particles.append(particle)
+                    SolverCoupledADMM.add_body_particle_attachment(builder, body, particle, **params)
+                else:
+                    child = builder.add_body(xform=wp.transform((0.08, float(index), 0.0), wp.quat_identity()))
+                    builder.add_shape_sphere(child, radius=0.05)
+                    bodies_b.append(child)
+                    kwargs = {"friction": 0.1} if kind in ("ball", "revolute") else {}
+                    getattr(builder, "add_joint_" + kind)(
+                        body,
+                        child,
+                        custom_attributes={"coupling:joint_" + name: value for name, value in params.items()},
+                        **kwargs,
+                    )
+                    builder.body_qd[child] = wp.spatial_vector(0.0, 0.0, 0.0, 1.0, 0.5, 0.0)
+            model = builder.finalize(device=self.device)
+            solver = SolverCoupledADMM(
+                model,
+                [
+                    SolverCoupled.Entry("a", SolverSemiImplicit, bodies=bodies_a),
+                    SolverCoupled.Entry("b", SolverSemiImplicit, bodies=bodies_b, particles=particles),
+                ],
+                SolverCoupledADMM.Config(iterations=3, joint_proximal_bodies=False, **defaults),
+            )
+            result = self._run(model, solver)
+            n = model.body_count
+            result[: n * 7].reshape(n, 7)[:, 1] -= np.repeat(
+                np.arange(len(parameters)), 1 if kind == "attachment" else 2
+            )
+            if model.particle_count:
+                result[n * 13 : n * 13 + model.particle_count * 3].reshape(-1, 3)[:, 1] -= np.arange(len(parameters))
+            return np.split(result, [n * 7, n * 13, n * 13 + model.particle_count * 3])
+
+        for kind in ("ball", "fixed", "revolute", "attachment"):
+            with self.subTest(kind=kind):
+                actual = simulate(kind, settings, {"rho": 0.1, "gamma": 0.0, "baumgarte": 0.0})
+                references = [simulate(kind, [{}], params) for params in settings]
+                for field, values in enumerate(actual):
+                    np.testing.assert_allclose(
+                        values, np.concatenate([ref[field] for ref in references]), atol=1e-7, rtol=1e-6
+                    )
+
+    def test_invalid_authored_parameters_fail_validation(self):
+        """Validate custom-attribute overrides as well as attachment helper arguments."""
+        for kind in ("ball", "attachment"):
+            for name, value in (
+                ("rho", 0.0),
+                ("rho", -2.0),
+                ("gamma", -2.0),
+                ("baumgarte", -2.0),
+                ("rho", float("inf")),
+                ("gamma", float("nan")),
+                ("baumgarte", float("inf")),
+            ):
+                with self.subTest(kind=kind, name=name, value=value), self.assertRaisesRegex(ValueError, name):
+                    model, endpoints = self._scene(kind, {})
+                    getattr(model.coupling, ("joint_" if kind == "ball" else "body_particle_attachment_") + name).fill_(
+                        value
+                    )
+                    entries = [
+                        SolverCoupled.Entry(entry, SolverSemiImplicit, **owned)
+                        for entry, owned in zip(("a", "b"), endpoints, strict=True)
+                    ]
+                    SolverCoupledADMM(model, entries, SolverCoupledADMM.Config())
+        for name in ("rho", "gamma", "baumgarte"):
+            with self.subTest(helper=name), self.assertRaisesRegex(ValueError, name):
+                self._scene("attachment", {name: -1.0})
+
+    def test_cuda_inertial_refresh_with_authored_gamma(self):
+        """Refresh XPBD and VBD inertias when only a contact or joint enables gamma."""
+        devices = get_cuda_test_devices()
+        if not devices:
+            self.skipTest("CUDA device required")
+        for device in devices:
+            for kind in ("contact", "joint"):
+                with self.subTest(device=device, kind=kind):
+                    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+                    for x in (0.0, 0.08):
+                        body = builder.add_body(xform=wp.transform((x, 0.0, 0.0), wp.quat_identity()))
+                        builder.add_shape_box(body, hx=0.05, hy=0.05, hz=0.05)
+                    if kind == "joint":
+                        SolverCoupledADMM.register_custom_attributes(builder)
+                        builder.add_joint_fixed(0, 1, custom_attributes={"coupling:joint_gamma": 0.3})
+                    builder.color()
+                    model = builder.finalize(device=device)
+                    solver = SolverCoupledADMM(
+                        model,
+                        [
+                            SolverCoupled.Entry("a", lambda view: SolverXPBD(view, iterations=1), bodies=[0]),
+                            SolverCoupled.Entry(
+                                "b", lambda view: SolverVBD(view, iterations=1, rigid_compliant_alm=True), bodies=[1]
+                            ),
+                        ],
+                        SolverCoupledADMM.Config(
+                            gamma=0.0,
+                            joint_proximal_bodies=False,
+                            contact_pairs=[SolverCoupledADMM.ContactPair("a", "b", gamma=0.3)]
+                            if kind == "contact"
+                            else [],
+                        ),
+                    )
+                    self.assertTrue(np.all(np.isfinite(self._run(model, solver, capture=True))))
+                    self.assertTrue(
+                        any(np.any(buf.body_proximal_mass.numpy() > 0.0) for buf in solver._admm_buffers.values())
+                    )
+
+    def test_cuda_capture_with_interface_only_gamma(self):
+        """Capture overrides when only the interface enables proximal terms."""
+        devices = get_cuda_test_devices()
+        if not devices:
+            self.skipTest("CUDA device required")
+        for device in devices:
+            self.device = device
+            for kind in self.kinds:
+                with self.subTest(device=device, kind=kind):
+                    model, solver = self._solver(
+                        kind,
+                        {"rho": 0.1, "gamma": 0.0, "baumgarte": 0.0},
+                        {"rho": 0.4, "gamma": 0.3, "baumgarte": 0.1},
+                    )
+                    self.assertTrue(np.all(np.isfinite(self._run(model, solver, capture=True))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

 - Fix ADMM momentum consistency by make rho and gamma dimensionless (see #4058). Convert physical stiffness, damping, and dry-friction limits at the solver boundary, and set rho=0.5 and gamma=0.1 for light stabilization.
Document units and migration rules, retune examples, and add a stiff attachment regression that fails with the previous defaults.

- Allow overriding ADMM parameters per-interface type, for instance using different proximal regularization for joints vs contacts. By default, the global parameters remain applied

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ADMM coupling now applies timestep-aware scaling to stiffness, damping, friction, impulses, and force calculations.
  - Default ADMM parameters are now `rho=0.5` and `gamma=0.1`.
  - Solver steps require a finite, strictly positive timestep.

- **Bug Fixes**
  - Corrected contact impulse and force conversion behavior.

- **Documentation**
  - Clarified parameter units, friction behavior, dimensionless settings, and migration guidance.

- **Tests**
  - Added coverage for invalid timesteps and improved proximal stabilization of stiff attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->