### PR TITLE
Allow CUDA init errors in CPU example tests

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import unittest
 from typing import Any
+from unittest.mock import call, create_autospec
 
 import warp as wp
 
@@ -45,7 +46,7 @@ _WARP_CUDA_UNAVAILABLE_OUTPUT_RE = (
     r"Warp CUDA warning: Could not find or load the NVIDIA CUDA driver\. "
     r"GPU execution will not be available\."
     r"|"
-    r"Warp CUDA error 100: no CUDA-capable device is detected "
+    r"Warp CUDA error \d+(?:: [^\n]*)? "
     r"\(in function init_cuda_driver, [^\n]*cuda_util\.cpp:\d+\)"
     r")\n?"
 )
@@ -97,7 +98,6 @@ _ANYMAL_TEXTURE_WITHOUT_UVS_WARNING_RE = (
 )
 _EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_PXR_WORK_THREAD_LIMIT_OUTPUT_RE, "stderr"),
-    (_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "stderr"),
     (_NEWTON_ASSET_DOWNLOAD_OUTPUT_RE, "stdout"),
 ]
 _OutputRegexSpec = str | tuple[str, str]
@@ -159,7 +159,8 @@ def add_example_test(
         test_options_cuda = {}
 
     def run(test, device):
-        if wp.get_device(device).is_cuda:
+        is_cuda = wp.get_device(device).is_cuda
+        if is_cuda:
             options = _merge_options(test_options, test_options_cuda)
         else:
             options = _merge_options(test_options, test_options_cpu)
@@ -258,7 +259,7 @@ def add_example_test(
 
         if isinstance(test, NewtonTestCase):
             _register_output_regexes(test, expect_output_regexes, required=True)
-            _register_output_regexes(test, _EXAMPLE_ALLOW_OUTPUT_REGEXES, required=False)
+            _register_example_allow_output_regexes(test, is_cuda=is_cuda)
             _register_output_regexes(test, allow_output_regexes, required=False)
             test.assertSubprocessSuccess(result, command=command)
         else:
@@ -297,18 +298,50 @@ def _register_output_regexes(test: NewtonTestCase, regexes: list[_OutputRegexSpe
         add_regex(regex, stream=stream)
 
 
+def _register_example_allow_output_regexes(test: NewtonTestCase, *, is_cuda: bool) -> None:
+    _register_output_regexes(test, _EXAMPLE_ALLOW_OUTPUT_REGEXES, required=False)
+    if not is_cuda:
+        test.allowOutputRegex(_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, stream="stderr")
+
+
 class TestExampleOutputRegexes(unittest.TestCase):
+    def test_warp_cuda_unavailable_output_is_registered_only_for_cpu(self):
+        """Register CUDA driver initialization diagnostics only for CPU examples."""
+        cpu_test = create_autospec(NewtonTestCase, instance=True)
+        cuda_test = create_autospec(NewtonTestCase, instance=True)
+
+        _register_example_allow_output_regexes(cpu_test, is_cuda=False)
+        _register_example_allow_output_regexes(cuda_test, is_cuda=True)
+
+        warp_cuda_call = call(_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, stream="stderr")
+        self.assertIn(warp_cuda_call, cpu_test.allowOutputRegex.call_args_list)
+        self.assertNotIn(warp_cuda_call, cuda_test.allowOutputRegex.call_args_list)
+
     def test_warp_cuda_unavailable_output_is_allowed(self):
+        """Allow CUDA driver initialization diagnostics emitted on CPU-only systems."""
         outputs = (
             "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. GPU execution will not be available.\n",
             "Warp CUDA error 100: no CUDA-capable device is detected "
             "(in function init_cuda_driver, /builds/omniverse/warp/warp/native/cuda_util.cpp:319)\n",
+            "Warp CUDA error 999: unknown error "
+            "(in function init_cuda_driver, /builds/omniverse/warp/warp/native/cuda_util.cpp:333)\n",
         )
 
         for output in outputs:
             with self.subTest(output=output):
                 unmatched_output = re.sub(_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "", output, flags=re.MULTILINE)
                 self.assertEqual(unmatched_output, "")
+
+    def test_warp_cuda_non_initialization_output_is_not_allowed(self):
+        """Keep CUDA diagnostics outside driver initialization visible to tests."""
+        output = (
+            "Warp CUDA error 999: unknown error "
+            "(in function wp_cuda_graphics_register_gl_buffer, /builds/omniverse/warp/warp/native/warp.cu:4419)\n"
+        )
+
+        unmatched_output = re.sub(_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "", output, flags=re.MULTILINE)
+
+        self.assertEqual(unmatched_output, output)
 
     def test_basic_plotting_output_does_not_consume_trailing_output(self):
         unexpected_output = "unexpected output\n"
@@ -871,7 +904,6 @@ def add_diffsim_example_test(**kwargs: Any) -> None:
     extra_allow_output_regexes = kwargs.pop("allow_output_regexes", None) or ()
     allow_output_regexes = [
         (_PXR_WORK_THREAD_LIMIT_OUTPUT_RE, "stderr"),
-        (_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "stderr"),
         *extra_allow_output_regexes,
     ]
     add_example_test(TestDiffSimExamples, allow_output_regexes=allow_output_regexes, **kwargs)
@@ -1058,7 +1090,6 @@ class TestContactsExamples(NewtonTestCase):
 
 _CONTACT_EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_PXR_WORK_THREAD_LIMIT_OUTPUT_RE, "stderr"),
-    (_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "stderr"),
 ]
 
 


### PR DESCRIPTION
## Description

Allow CPU-targeted example subprocesses to tolerate any numeric Warp CUDA
driver-initialization error code. CPU-only hosts can return errors other than
`CUDA_ERROR_NO_DEVICE`, and those diagnostics should not fail otherwise
successful CPU tests.

Keep CUDA-targeted examples strict, and continue rejecting CUDA diagnostics
from functions other than `init_cuda_driver`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] This is test infrastructure only; no changelog fragment is required

## Test plan

```console
uv run --extra dev -m newton.tests -k TestExampleOutputRegexes
CUDA_VISIBLE_DEVICES=-1 uv run --extra dev -m newton.tests \
    -k test_basic.example_basic_pendulum_cpu
uvx --python 3.12 pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the Newton example tests on a CPU-only host where Warp's CUDA driver
   initialization returns an error other than 100.
2. Observe successful CPU examples fail strict stderr validation.

**Minimal reproduction:**

```text
Warp CUDA error 999: unknown error (in function init_cuda_driver,
/builds/omniverse/warp/warp/native/cuda_util.cpp:333)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for CPU and CUDA example execution.
  - Improved validation of expected CUDA driver initialization diagnostics, including varied error messages and codes.
  - Added checks to ensure unrelated CUDA errors are not incorrectly treated as allowed output.
  - Updated example test registrations so CUDA allowances apply only where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->