### PR TITLE
Add live scalar plots and heatmaps to ViewerRTX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add live scalar plots and array heatmaps to `ViewerRTX` through `log_scalar()` and `log_array()`, with configurable plot history and scalar smoothing. ([#4046](https://github.com/newton-physics/newton/issues/4046))
+
 <!-- towncrier release notes start -->
 
 ## [1.5.1] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Add live scalar plots and array heatmaps to `ViewerRTX` through `log_scalar()` and `log_array()`, with configurable plot history and scalar smoothing. ([#4046](https://github.com/newton-physics/newton/issues/4046))
-
 <!-- towncrier release notes start -->
 
 ## [1.5.1] - 2026-08-27

--- a/changelog/4046.added.md
+++ b/changelog/4046.added.md
@@ -1,0 +1,1 @@
+Add live scalar plots and array heatmaps to `ViewerRTX` through `log_scalar()` and `log_array()`, with configurable plot history and scalar smoothing.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -110,7 +110,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 - :meth:`~newton.viewer.ViewerBase.log_points` — draw a point cloud (e.g. contact locations, particle positions)
 - :meth:`~newton.viewer.ViewerBase.log_contacts` — visualize :class:`~newton.Contacts` as normal lines at contact points
 - :meth:`~newton.viewer.ViewerBase.log_gizmo` — display a transform gizmo (position + orientation axes)
-- :meth:`~newton.viewer.ViewerBase.log_scalar` / :meth:`~newton.viewer.ViewerBase.log_array` — log numeric data for backend-specific visualization (e.g. time-series plots in Rerun)
+- :meth:`~newton.viewer.ViewerBase.log_scalar` / :meth:`~newton.viewer.ViewerBase.log_array` — display numeric diagnostics as scalar plots or array visualizations; see :ref:`viewer-live-plots`
 - :meth:`~newton.viewer.ViewerBase.log_image` — display a single or batched image in :class:`~newton.viewer.ViewerGL` as a dockable window or, with ``fullscreen=True``, as the main viewer surface for the current frame (no-op on other
   backends)
 
@@ -127,6 +127,43 @@ All viewers support ``set_visible_worlds()`` to limit visualization to a subset 
     viewer = newton.viewer.ViewerNull()
     viewer.set_model(model)
     viewer.set_visible_worlds(range(4))
+
+.. _viewer-live-plots:
+
+Live Plots
+~~~~~~~~~~
+
+:meth:`~newton.viewer.ViewerBase.log_scalar` and
+:meth:`~newton.viewer.ViewerBase.log_array` provide numeric diagnostics with
+backend-specific displays:
+
+- :class:`~newton.viewer.ViewerGL` and :class:`~newton.viewer.ViewerRTX`
+  display rolling scalar line plots and heatmaps for scalar, 1-D, and 2-D
+  NumPy or Warp arrays in a Plots window.
+- :class:`~newton.viewer.ViewerViser` displays rolling scalar line plots in
+  the sidebar. Generic array visualization is not supported.
+- :class:`~newton.viewer.ViewerRerun` forwards scalar and array data to
+  Rerun's native scalar visualization.
+
+For ``ViewerGL``, ``ViewerRTX``, and ``ViewerViser``, set
+``plot_history_size`` when constructing the viewer to configure the number
+of plotted scalar samples (default: 250). Use ``smoothing`` to average a
+group of raw samples into each plotted point, and ``clear=True`` with
+``log_scalar`` to reset a signal's history and pending smoothing samples.
+For example, with ``ViewerGL`` or ``ViewerRTX``:
+
+.. code-block:: python
+
+    viewer.log_scalar("Training/reward", reward, smoothing=10)
+    viewer.log_array("Training/observations", observations)
+
+In ``ViewerGL`` and ``ViewerRTX``, pass ``None`` to ``log_array`` to remove
+a heatmap. Logging works before the first rendered frame and in headless
+mode; plots are displayed when the viewer window and its UI are active.
+
+``ViewerRerun`` controls history through ``keep_scalar_history`` for
+scalars and ``keep_historical_data`` for arrays. It ignores ``clear`` and
+``smoothing``, and passing ``None`` to ``log_array`` is a no-op.
 
 Real-time Viewers
 -----------------
@@ -308,25 +345,9 @@ This installs ``ovrtx`` (the NVIDIA OVRTX renderer) and ``usd-core``, in additio
     viewer.log_state(state)
     viewer.end_frame()
 
-**Live plots**: :meth:`~newton.viewer.ViewerRTX.log_scalar` displays scalar
-signals as rolling line plots, and :meth:`~newton.viewer.ViewerRTX.log_array`
-displays scalar, 1-D, and 2-D NumPy or Warp arrays as heatmaps in the same
-Plots window. Set ``plot_history_size`` when constructing the viewer to
-configure the number of plotted samples (default: 250). For example:
-
-.. code-block:: python
-
-    viewer.log_scalar("Training/reward", reward, smoothing=10)
-    viewer.log_array("Training/observations", observations)
-
-Use ``clear=True`` with ``log_scalar`` to reset a signal's history and
-pending smoothing samples. Pass ``None`` to ``log_array`` to remove a
-heatmap. Logging works before the first rendered frame and in headless
-mode; plots are displayed when the viewer window and its UI are active.
-
-The plots use ``imgui_bundle``, included in the ``examples`` dependencies.
-Install both viewer and UI dependencies with
-``uv sync --extra rtx --extra examples``.
+The :ref:`live plots <viewer-live-plots>` use ``imgui_bundle``, included in
+the ``examples`` dependencies. Install both RTX viewer and UI dependencies
+with ``uv sync --extra rtx --extra examples``.
 
 Recording and Offline Viewers
 -----------------------------

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -308,6 +308,26 @@ This installs ``ovrtx`` (the NVIDIA OVRTX renderer) and ``usd-core``, in additio
     viewer.log_state(state)
     viewer.end_frame()
 
+**Live plots**: :meth:`~newton.viewer.ViewerRTX.log_scalar` displays scalar
+signals as rolling line plots, and :meth:`~newton.viewer.ViewerRTX.log_array`
+displays scalar, 1-D, and 2-D NumPy or Warp arrays as heatmaps in the same
+Plots window. Set ``plot_history_size`` when constructing the viewer to
+configure the number of plotted samples (default: 250). For example:
+
+.. code-block:: python
+
+    viewer.log_scalar("Training/reward", reward, smoothing=10)
+    viewer.log_array("Training/observations", observations)
+
+Use ``clear=True`` with ``log_scalar`` to reset a signal's history and
+pending smoothing samples. Pass ``None`` to ``log_array`` to remove a
+heatmap. Logging works before the first rendered frame and in headless
+mode; plots are displayed when the viewer window and its UI are active.
+
+The plots use ``imgui_bundle``, included in the ``examples`` dependencies.
+Install both viewer and UI dependencies with
+``uv sync --extra rtx --extra examples``.
+
 Recording and Offline Viewers
 -----------------------------
 

--- a/newton/_src/viewer/plot_logger.py
+++ b/newton/_src/viewer/plot_logger.py
@@ -39,7 +39,11 @@ class PlotLogger:
         self._get_window = get_window
 
     def _get_gl(self):
-        self._get_window().switch_to()
+        try:
+            self._get_window().switch_to()
+        except AttributeError:
+            # The window or its context may already be destroyed during shutdown.
+            pass
         from pyglet import gl
 
         return gl

--- a/newton/_src/viewer/plot_logger.py
+++ b/newton/_src/viewer/plot_logger.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import collections
+import ctypes
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+
+class PlotLogger:
+    """Store and draw live scalar plots and array heatmaps for GL and RTX viewers.
+
+    Logging is independent of window creation. OpenGL is loaded only when
+    drawing heatmaps; texture operations activate the owning window's context.
+    """
+
+    def __init__(self, plot_history_size: int, *, get_window: Callable[[], Any]):
+        if not isinstance(plot_history_size, int) or isinstance(plot_history_size, bool):
+            raise TypeError("plot_history_size must be an integer")
+        if plot_history_size <= 0:
+            raise ValueError("plot_history_size must be > 0")
+        self._scalar_buffers: dict[str, collections.deque] = {}
+        self._scalar_arrays: dict[str, np.ndarray | None] = {}
+        self._scalar_accumulators: dict[str, list[float]] = {}
+        self._scalar_smoothing: dict[str, int] = {}
+        self._array_buffers: dict[str, np.ndarray] = {}
+        self._array_dirty: set[str] = set()
+        self._array_textures: dict[str, dict[str, Any]] = {}
+        self._heatmap_min_cell_pixels = 3.0
+        self._heatmap_nan_rgba = np.array([51, 51, 51, 255], dtype=np.uint8)
+        self._heatmap_color_lut = self._build_heatmap_color_lut()
+        self._plot_history_size = plot_history_size
+
+        self._get_window = get_window
+
+    def _get_gl(self):
+        self._get_window().switch_to()
+        from pyglet import gl
+
+        return gl
+
+    def log_array(self, name: str, array: wp.array[Any] | np.ndarray | None):
+        """
+        Log a numeric array for visualization.
+
+        Args:
+            name: Unique path/name for the array signal.
+            array: Array data to visualize, or ``None`` to remove a previously
+                logged array.
+        """
+        if array is None:
+            self._array_buffers.pop(name, None)
+            self._array_dirty.discard(name)
+            self._delete_array_texture(name)
+            return
+
+        array_np = array.numpy() if isinstance(array, wp.array) else np.asarray(array)
+        array_np = np.asarray(array_np, dtype=np.float32)
+
+        if array_np.ndim == 0:
+            array_np = array_np.reshape(1, 1)
+        elif array_np.ndim == 1:
+            array_np = array_np.reshape(1, -1)
+        elif array_np.ndim != 2:
+            raise ValueError("log_array only supports scalar, 1-D, or 2-D arrays.")
+
+        self._array_buffers[name] = np.ascontiguousarray(array_np)
+        self._array_dirty.add(name)
+
+    def log_scalar(
+        self,
+        name: str,
+        value: int | float | bool | np.number,
+        *,
+        clear: bool = False,
+        smoothing: int = 1,
+    ):
+        """
+        Log a scalar value as a live time-series plot.
+
+        Each unique *name* creates a separate line plot displayed in an
+        auto-generated "Plots" window.  Values are stored in a rolling
+        buffer of the last ``plot_history_size`` samples.
+
+        Args:
+            name: Unique path/name for the scalar signal.
+            value: Scalar value to record.
+            clear: If ``True``, discard previously recorded samples for
+                *name* before logging the new value.
+            smoothing: Number of raw samples to average before committing
+                a point to the plot history.  Defaults to ``1`` (no smoothing).
+        """
+        if smoothing < 1:
+            raise ValueError("smoothing must be >= 1")
+        val = float(value.item() if hasattr(value, "item") else value)
+        buf = self._scalar_buffers.get(name)
+        if buf is None:
+            buf = collections.deque(maxlen=self._plot_history_size)
+            self._scalar_buffers[name] = buf
+        elif clear:
+            buf.clear()
+            self._scalar_accumulators.pop(name, None)
+
+        self._scalar_smoothing[name] = smoothing
+        if smoothing <= 1:
+            buf.append(val)
+        else:
+            acc = self._scalar_accumulators.get(name)
+            if acc is None:
+                acc = []
+                self._scalar_accumulators[name] = acc
+            acc.append(val)
+            if len(acc) >= smoothing:
+                buf.append(sum(acc) / len(acc))
+                acc.clear()
+
+        self._scalar_arrays[name] = None
+
+    def clear_matching(self, owns: Callable[[str], bool]) -> None:
+        """Release signals and textures whose qualified names match ``owns``."""
+        for buffers in (
+            self._scalar_buffers,
+            self._scalar_arrays,
+            self._scalar_accumulators,
+            self._scalar_smoothing,
+            self._array_buffers,
+        ):
+            for name in list(buffers):
+                if owns(name):
+                    del buffers[name]
+        self._array_dirty.difference_update(name for name in list(self._array_dirty) if owns(name))
+        for name in list(self._array_textures):
+            if owns(name):
+                self._delete_array_texture(name)
+
+    def clear(self) -> None:
+        """Release all logged data and textures before closing the window."""
+        self.clear_matching(lambda _name: True)
+
+    def _delete_array_texture(self, name: str):
+        texture_state = self._array_textures.pop(name, None)
+        if texture_state is None:
+            return
+        texture_id = texture_state.get("texture_id")
+        if texture_id is None:
+            return
+        gl = self._get_gl()
+        texture_ids = (gl.GLuint * 1)(texture_id)
+        gl.glDeleteTextures(1, texture_ids)
+
+    def draw(self, ui) -> None:
+        """Render floating time-series plot window for log_scalar() data and array heatmaps."""
+        scalar_buffers = self._scalar_buffers
+        array_buffers = self._array_buffers
+        if not scalar_buffers and not array_buffers:
+            return
+        imgui = ui.imgui
+        io = ui.io
+        s = ui.dpi_scale
+        scalar_arrays = self._scalar_arrays
+        plot_history_size = self._plot_history_size
+        window_width = 400 * s
+        item_height = len(scalar_buffers) * 140 * s + len(array_buffers) * 260 * s
+        window_height = min(io.display_size[1] - 20 * s, item_height + 60 * s)
+        # ``first_use_ever`` keeps user-dragged positions stable across
+        # collapse/expand cycles and survives ``imgui.ini`` reloads.
+        imgui.set_next_window_pos(
+            imgui.ImVec2(io.display_size[0] - window_width - 10 * s, io.display_size[1] - window_height - 10 * s),
+            imgui.Cond_.first_use_ever,
+        )
+        imgui.set_next_window_size(imgui.ImVec2(window_width, window_height), imgui.Cond_.first_use_ever)
+        n = plot_history_size
+        expanded = imgui.begin("Plots")
+        if expanded:
+            graph_size = imgui.ImVec2(-1, 100 * s)
+            for name, buf in scalar_buffers.items():
+                arr = scalar_arrays.get(name)
+                if arr is None:
+                    arr = np.full(n, np.nan, dtype=np.float32)
+                    arr[n - len(buf) :] = np.array(buf, dtype=np.float32)
+                    scalar_arrays[name] = arr
+                overlay = f"{buf[-1]:.4g}" if buf else ""
+                if imgui.collapsing_header(name, imgui.TreeNodeFlags_.default_open.value):
+                    imgui.plot_lines(f"##{name}", arr, graph_size=graph_size, overlay_text=overlay)
+            for name, array in array_buffers.items():
+                if imgui.collapsing_header(name, imgui.TreeNodeFlags_.default_open.value):
+                    self._render_array_heatmap(imgui, name, array, window_width - 40.0 * s, dpi_scale=s)
+        imgui.end()
+
+    @staticmethod
+    def _build_heatmap_color_lut() -> np.ndarray:
+        inferno_stops = (
+            (0.0, (0.001, 0.000, 0.014)),
+            (0.2, (0.169, 0.042, 0.341)),
+            (0.4, (0.416, 0.090, 0.433)),
+            (0.6, (0.698, 0.165, 0.388)),
+            (0.8, (0.944, 0.403, 0.121)),
+            (1.0, (0.988, 0.998, 0.645)),
+        )
+        lut = np.empty((256, 4), dtype=np.uint8)
+        for index, value in enumerate(np.linspace(0.0, 1.0, 256, dtype=np.float32)):
+            for stop_index in range(len(inferno_stops) - 1):
+                t0, c0 = inferno_stops[stop_index]
+                t1, c1 = inferno_stops[stop_index + 1]
+                if value <= t1:
+                    alpha = 0.0 if t1 <= t0 else (float(value) - t0) / (t1 - t0)
+                    rgb = [round(255.0 * ((1.0 - alpha) * c0[channel] + alpha * c1[channel])) for channel in range(3)]
+                    lut[index, :3] = rgb
+                    lut[index, 3] = 255
+                    break
+            else:
+                lut[index, :3] = [round(255.0 * channel) for channel in inferno_stops[-1][1]]
+                lut[index, 3] = 255
+        return lut
+
+    @staticmethod
+    def _downsample_heatmap(array: np.ndarray, target_rows: int, target_cols: int) -> np.ndarray:
+        rows, cols = array.shape
+        if rows <= target_rows and cols <= target_cols:
+            return array
+
+        row_factor = max(1, (rows + target_rows - 1) // target_rows)
+        col_factor = max(1, (cols + target_cols - 1) // target_cols)
+        new_rows = max(1, rows // row_factor)
+        new_cols = max(1, cols // col_factor)
+        if new_rows == rows and new_cols == cols:
+            return array
+
+        trimmed = array[: new_rows * row_factor, : new_cols * col_factor]
+        finite_mask = np.isfinite(trimmed)
+        safe_values = np.where(finite_mask, trimmed, 0.0)
+        reshaped_shape = (new_rows, row_factor, new_cols, col_factor)
+        value_sum = safe_values.reshape(reshaped_shape).sum(axis=(1, 3), dtype=np.float64)
+        value_count = finite_mask.reshape(reshaped_shape).sum(axis=(1, 3))
+        downsampled = np.full((new_rows, new_cols), np.nan, dtype=np.float32)
+        np.divide(value_sum, value_count, out=downsampled, where=value_count > 0)
+        return downsampled
+
+    def _colorize_heatmap(self, array: np.ndarray) -> tuple[np.ndarray, float, float]:
+        finite_mask = np.isfinite(array)
+        if not np.any(finite_mask):
+            rgba = np.empty((*array.shape, 4), dtype=np.uint8)
+            rgba[...] = self._heatmap_nan_rgba
+            return np.ascontiguousarray(rgba), float("nan"), float("nan")
+
+        finite_values = array[finite_mask]
+        value_min = float(np.min(finite_values))
+        value_max = float(np.max(finite_values))
+        denom = max(value_max - value_min, 1.0e-8)
+
+        normalized = np.zeros(array.shape, dtype=np.float32)
+        np.subtract(array, value_min, out=normalized, where=finite_mask)
+        np.divide(normalized, denom, out=normalized, where=finite_mask)
+        np.clip(normalized, 0.0, 1.0, out=normalized)
+
+        lut_indices = np.rint(normalized * 255.0).astype(np.uint8)
+        rgba = self._heatmap_color_lut[lut_indices].copy()
+        rgba[~finite_mask] = self._heatmap_nan_rgba
+        return np.ascontiguousarray(rgba), value_min, value_max
+
+    def _ensure_array_texture(self, name: str, width: int, height: int) -> dict[str, Any]:
+        texture_state = self._array_textures.get(name)
+        if texture_state is not None and texture_state["size"] == (width, height):
+            return texture_state
+
+        if texture_state is not None:
+            self._delete_array_texture(name)
+
+        gl = self._get_gl()
+        texture_id = (gl.GLuint * 1)()
+        gl.glGenTextures(1, texture_id)
+        gl.glBindTexture(gl.GL_TEXTURE_2D, texture_id[0])
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_NEAREST)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_S, gl.GL_CLAMP_TO_EDGE)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_T, gl.GL_CLAMP_TO_EDGE)
+        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
+        gl.glTexImage2D(
+            gl.GL_TEXTURE_2D,
+            0,
+            gl.GL_RGBA8,
+            width,
+            height,
+            0,
+            gl.GL_RGBA,
+            gl.GL_UNSIGNED_BYTE,
+            None,
+        )
+        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+
+        texture_state = {
+            "texture_id": texture_id[0],
+            "size": (width, height),
+            "source_shape": None,
+            "display_shape": None,
+            "value_min": 0.0,
+            "value_max": 0.0,
+        }
+        self._array_textures[name] = texture_state
+        return texture_state
+
+    def _update_array_texture(self, texture_id: int, rgba: np.ndarray):
+        gl = self._get_gl()
+        gl.glBindTexture(gl.GL_TEXTURE_2D, texture_id)
+        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
+        gl.glTexSubImage2D(
+            gl.GL_TEXTURE_2D,
+            0,
+            0,
+            0,
+            rgba.shape[1],
+            rgba.shape[0],
+            gl.GL_RGBA,
+            gl.GL_UNSIGNED_BYTE,
+            rgba.ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),
+        )
+        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+
+    def _render_array_heatmap(self, imgui, name: str, array: np.ndarray, width: float, dpi_scale: float = 1.0):
+        s = max(1.0, float(dpi_scale))
+
+        rows, cols = array.shape
+        if array.size == 0:
+            imgui.text(f"shape {rows}x{cols} (empty)")
+            return
+        heatmap_width = max(120.0 * s, width)
+        heatmap_height = float(np.clip(heatmap_width * rows / max(cols, 1), 80.0 * s, 220.0 * s))
+        min_cell_px = max(1.0, self._heatmap_min_cell_pixels * s)
+        target_cols = max(1, min(cols, int(heatmap_width / min_cell_px)))
+        target_rows = max(1, min(rows, int(heatmap_height / min_cell_px)))
+        display_array = self._downsample_heatmap(array, target_rows, target_cols)
+        display_rows, display_cols = display_array.shape
+        texture_state = self._ensure_array_texture(name, display_cols, display_rows)
+
+        if (
+            name in self._array_dirty
+            or texture_state["source_shape"] != array.shape
+            or texture_state["display_shape"] != display_array.shape
+        ):
+            rgba, value_min, value_max = self._colorize_heatmap(display_array)
+            self._update_array_texture(texture_state["texture_id"], rgba)
+            texture_state["source_shape"] = array.shape
+            texture_state["display_shape"] = display_array.shape
+            texture_state["value_min"] = value_min
+            texture_state["value_max"] = value_max
+            self._array_dirty.discard(name)
+
+        draw_list = imgui.get_window_draw_list()
+        origin = imgui.get_cursor_screen_pos()
+        imgui.image(imgui.ImTextureRef(texture_state["texture_id"]), imgui.ImVec2(heatmap_width, heatmap_height))
+
+        border_color = imgui.color_convert_float4_to_u32(imgui.ImVec4(1.0, 1.0, 1.0, 0.25))
+        draw_list.add_rect(
+            imgui.ImVec2(origin.x, origin.y),
+            imgui.ImVec2(origin.x + heatmap_width, origin.y + heatmap_height),
+            border_color,
+        )
+        shape_text = f"shape {rows}x{cols}"
+        if (display_rows, display_cols) != (rows, cols):
+            shape_text += f"  shown {display_rows}x{display_cols}"
+        if np.isfinite(texture_state["value_min"]) and np.isfinite(texture_state["value_max"]):
+            range_text = f"min {texture_state['value_min']:.4g}  max {texture_state['value_max']:.4g}"
+        else:
+            range_text = "min --  max --"
+        imgui.text(f"{shape_text}  {range_text}")

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import collections
 import ctypes
 import enum
 import re
@@ -23,6 +22,7 @@ from .camera import Camera
 from .gl.image_logger import ImageLogger
 from .gl.opengl import LinesGL, MeshGL, MeshInstancerGL, RendererGL
 from .picking import Picking
+from .plot_logger import PlotLogger
 from .utils import OPAQUE_OPACITY_THRESHOLD
 from .viewer import _DEFAULT_LAYER_ID, ViewerBase
 from .viewer_gui import ViewerGui
@@ -272,10 +272,7 @@ class ViewerGL(ViewerBase):
                 interoperability. Combine :class:`CudaInterop` flags with ``|``.
                 Defaults to :attr:`CudaInterop.DYNAMIC_MESH`.
         """
-        if not isinstance(plot_history_size, int) or isinstance(plot_history_size, bool):
-            raise TypeError("plot_history_size must be an integer")
-        if plot_history_size <= 0:
-            raise ValueError("plot_history_size must be > 0")
+        self._plot_logger = PlotLogger(plot_history_size, get_window=lambda: self.renderer.window)
         if num_frames is not None:
             if not isinstance(num_frames, int) or isinstance(num_frames, bool):
                 raise TypeError("num_frames must be an integer or None")
@@ -286,19 +283,6 @@ class ViewerGL(ViewerBase):
         if int(enable_cuda_interop) & ~int(ViewerGL.CudaInterop.ALL):
             raise ValueError("enable_cuda_interop contains unsupported flags")
         self._enable_cuda_interop = enable_cuda_interop
-
-        # Rolling buffers for log_scalar() time-series plots.
-        self._scalar_buffers: dict[str, collections.deque] = {}
-        self._scalar_arrays: dict[str, np.ndarray | None] = {}
-        self._scalar_accumulators: dict[str, list[float]] = {}
-        self._scalar_smoothing: dict[str, int] = {}
-        self._array_buffers: dict[str, np.ndarray] = {}
-        self._array_dirty: set[str] = set()
-        self._array_textures: dict[str, dict[str, Any]] = {}
-        self._heatmap_min_cell_pixels = 3.0
-        self._heatmap_nan_rgba = np.array([51, 51, 51, 255], dtype=np.uint8)
-        self._heatmap_color_lut = self._build_heatmap_color_lut()
-        self._plot_history_size = plot_history_size
 
         # Initialized below once self.device is available; declared here so
         # close() can safely run if __init__ raises before that point.
@@ -415,35 +399,6 @@ class ViewerGL(ViewerBase):
             pbo_id = (gl.GLuint * 1)(self._pbo)
             gl.glDeleteBuffers(1, pbo_id)
             self._pbo = None
-
-    def _delete_array_texture(self, name: str):
-        texture_state = self._array_textures.pop(name, None)
-        if texture_state is None:
-            return
-        gl = getattr(RendererGL, "gl", None)
-        texture_id = texture_state.get("texture_id")
-        if gl is None or texture_id is None:
-            return
-        texture_ids = (gl.GLuint * 1)(texture_id)
-        gl.glDeleteTextures(1, texture_ids)
-
-    def _clear_array_textures(self):
-        if not self._array_textures:
-            return
-        gl = getattr(RendererGL, "gl", None)
-        if gl is None:
-            self._array_textures.clear()
-            return
-        texture_ids = [state["texture_id"] for state in self._array_textures.values() if state.get("texture_id")]
-        if texture_ids:
-            gl_ids = (gl.GLuint * len(texture_ids))(*texture_ids)
-            gl.glDeleteTextures(len(texture_ids), gl_ids)
-        self._array_textures.clear()
-
-    def _clear_owned_array_textures(self, owns):
-        for name in list(self._array_textures.keys()):
-            if owns(name):
-                self._delete_array_texture(name)
 
     def register_ui_callback(
         self,
@@ -643,20 +598,7 @@ class ViewerGL(ViewerBase):
 
         # Scalar, array, and image names are layer-qualified just like
         # geometry names; clear only the active layer's entries.
-        for name in list(self._scalar_buffers.keys()):
-            if owns(name):
-                self._scalar_buffers.pop(name, None)
-                self._scalar_arrays.pop(name, None)
-                self._scalar_accumulators.pop(name, None)
-                self._scalar_smoothing.pop(name, None)
-        for name in list(self._scalar_arrays.keys()):
-            if owns(name):
-                self._scalar_arrays.pop(name, None)
-        for name in list(self._array_buffers.keys()):
-            if owns(name):
-                self._array_buffers.pop(name, None)
-                self._array_dirty.discard(name)
-        self._clear_owned_array_textures(owns)
+        self._plot_logger.clear_matching(owns)
 
         if getattr(self, "_image_logger", None) is not None:
             self._image_logger.clear_matching(owns)
@@ -1829,34 +1771,17 @@ class ViewerGL(ViewerBase):
     @override
     def log_array(self, name: str, array: wp.array[Any] | np.ndarray | None):
         """
-        Log a numeric array for visualization.
+        Log a numeric array as a live heatmap.
+
+        Scalars appear as a single cell, 1-D arrays as a single row, and
+        2-D arrays as a grid. Higher-dimensional arrays are not supported.
 
         Args:
             name: Unique path/name for the array signal.
             array: Array data to visualize, or ``None`` to remove a previously
                 logged array.
         """
-        # Route user-supplied names through the active layer (idempotent).
-        name = self._qualify(name)
-
-        if array is None:
-            self._array_buffers.pop(name, None)
-            self._array_dirty.discard(name)
-            self._delete_array_texture(name)
-            return
-
-        array_np = array.numpy() if isinstance(array, wp.array) else np.asarray(array)
-        array_np = np.asarray(array_np, dtype=np.float32)
-
-        if array_np.ndim == 0:
-            array_np = array_np.reshape(1, 1)
-        elif array_np.ndim == 1:
-            array_np = array_np.reshape(1, -1)
-        elif array_np.ndim != 2:
-            raise ValueError("ViewerGL.log_array only supports scalar, 1-D, or 2-D arrays.")
-
-        self._array_buffers[name] = np.ascontiguousarray(array_np)
-        self._array_dirty.add(name)
+        self._plot_logger.log_array(self._qualify(name), array)
 
     @override
     def log_image(self, name: str, image: wp.array[Any] | np.ndarray, *, fullscreen: bool = False) -> None:
@@ -1892,33 +1817,7 @@ class ViewerGL(ViewerBase):
             smoothing: Number of raw samples to average before committing
                 a point to the plot history.  Defaults to ``1`` (no smoothing).
         """
-        if smoothing < 1:
-            raise ValueError("smoothing must be >= 1")
-        # Route user-supplied names through the active layer (idempotent).
-        name = self._qualify(name)
-        val = float(value.item() if hasattr(value, "item") else value)
-        buf = self._scalar_buffers.get(name)
-        if buf is None:
-            buf = collections.deque(maxlen=self._plot_history_size)
-            self._scalar_buffers[name] = buf
-        elif clear:
-            buf.clear()
-            self._scalar_accumulators.pop(name, None)
-
-        self._scalar_smoothing[name] = smoothing
-        if smoothing <= 1:
-            buf.append(val)
-        else:
-            acc = self._scalar_accumulators.get(name)
-            if acc is None:
-                acc = []
-                self._scalar_accumulators[name] = acc
-            acc.append(val)
-            if len(acc) >= smoothing:
-                buf.append(sum(acc) / len(acc))
-                acc.clear()
-
-        self._scalar_arrays[name] = None
+        self._plot_logger.log_scalar(self._qualify(name), value, clear=clear, smoothing=smoothing)
 
     @override
     def log_state(self, state: nt.State):
@@ -2330,7 +2229,7 @@ class ViewerGL(ViewerBase):
         """
         Close the viewer and clean up resources.
         """
-        self._clear_array_textures()
+        self._plot_logger.clear()
         self._invalidate_pbo()
         if self._image_logger is not None:
             self._image_logger.clear()
@@ -2678,178 +2577,3 @@ class ViewerGL(ViewerBase):
                 changed, new_visible = imgui.checkbox(f"Show '{lyr.layer_id}'", lyr.visible)
                 if changed:
                     self.set_layer_visible(lyr.layer_id, new_visible)
-
-    @staticmethod
-    def _build_heatmap_color_lut() -> np.ndarray:
-        inferno_stops = (
-            (0.0, (0.001, 0.000, 0.014)),
-            (0.2, (0.169, 0.042, 0.341)),
-            (0.4, (0.416, 0.090, 0.433)),
-            (0.6, (0.698, 0.165, 0.388)),
-            (0.8, (0.944, 0.403, 0.121)),
-            (1.0, (0.988, 0.998, 0.645)),
-        )
-        lut = np.empty((256, 4), dtype=np.uint8)
-        for index, value in enumerate(np.linspace(0.0, 1.0, 256, dtype=np.float32)):
-            for stop_index in range(len(inferno_stops) - 1):
-                t0, c0 = inferno_stops[stop_index]
-                t1, c1 = inferno_stops[stop_index + 1]
-                if value <= t1:
-                    alpha = 0.0 if t1 <= t0 else (float(value) - t0) / (t1 - t0)
-                    rgb = [round(255.0 * ((1.0 - alpha) * c0[channel] + alpha * c1[channel])) for channel in range(3)]
-                    lut[index, :3] = rgb
-                    lut[index, 3] = 255
-                    break
-            else:
-                lut[index, :3] = [round(255.0 * channel) for channel in inferno_stops[-1][1]]
-                lut[index, 3] = 255
-        return lut
-
-    @staticmethod
-    def _downsample_heatmap(array: np.ndarray, target_rows: int, target_cols: int) -> np.ndarray:
-        rows, cols = array.shape
-        if rows <= target_rows and cols <= target_cols:
-            return array
-
-        row_factor = max(1, (rows + target_rows - 1) // target_rows)
-        col_factor = max(1, (cols + target_cols - 1) // target_cols)
-        new_rows = max(1, rows // row_factor)
-        new_cols = max(1, cols // col_factor)
-        if new_rows == rows and new_cols == cols:
-            return array
-
-        trimmed = array[: new_rows * row_factor, : new_cols * col_factor]
-        finite_mask = np.isfinite(trimmed)
-        safe_values = np.where(finite_mask, trimmed, 0.0)
-        reshaped_shape = (new_rows, row_factor, new_cols, col_factor)
-        value_sum = safe_values.reshape(reshaped_shape).sum(axis=(1, 3), dtype=np.float64)
-        value_count = finite_mask.reshape(reshaped_shape).sum(axis=(1, 3))
-        downsampled = np.full((new_rows, new_cols), np.nan, dtype=np.float32)
-        np.divide(value_sum, value_count, out=downsampled, where=value_count > 0)
-        return downsampled
-
-    def _colorize_heatmap(self, array: np.ndarray) -> tuple[np.ndarray, float, float]:
-        finite_mask = np.isfinite(array)
-        if not np.any(finite_mask):
-            rgba = np.empty((*array.shape, 4), dtype=np.uint8)
-            rgba[...] = self._heatmap_nan_rgba
-            return np.ascontiguousarray(rgba), float("nan"), float("nan")
-
-        finite_values = array[finite_mask]
-        value_min = float(np.min(finite_values))
-        value_max = float(np.max(finite_values))
-        denom = max(value_max - value_min, 1.0e-8)
-
-        normalized = np.zeros(array.shape, dtype=np.float32)
-        np.subtract(array, value_min, out=normalized, where=finite_mask)
-        np.divide(normalized, denom, out=normalized, where=finite_mask)
-        np.clip(normalized, 0.0, 1.0, out=normalized)
-
-        lut_indices = np.rint(normalized * 255.0).astype(np.uint8)
-        rgba = self._heatmap_color_lut[lut_indices].copy()
-        rgba[~finite_mask] = self._heatmap_nan_rgba
-        return np.ascontiguousarray(rgba), value_min, value_max
-
-    def _ensure_array_texture(self, name: str, width: int, height: int) -> dict[str, Any]:
-        texture_state = self._array_textures.get(name)
-        if texture_state is not None and texture_state["size"] == (width, height):
-            return texture_state
-
-        if texture_state is not None:
-            self._delete_array_texture(name)
-
-        gl = RendererGL.gl
-        texture_id = (gl.GLuint * 1)()
-        gl.glGenTextures(1, texture_id)
-        gl.glBindTexture(gl.GL_TEXTURE_2D, texture_id[0])
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_NEAREST)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_S, gl.GL_CLAMP_TO_EDGE)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_T, gl.GL_CLAMP_TO_EDGE)
-        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
-        gl.glTexImage2D(
-            gl.GL_TEXTURE_2D,
-            0,
-            gl.GL_RGBA8,
-            width,
-            height,
-            0,
-            gl.GL_RGBA,
-            gl.GL_UNSIGNED_BYTE,
-            None,
-        )
-        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
-
-        texture_state = {
-            "texture_id": texture_id[0],
-            "size": (width, height),
-            "source_shape": None,
-            "display_shape": None,
-            "value_min": 0.0,
-            "value_max": 0.0,
-        }
-        self._array_textures[name] = texture_state
-        return texture_state
-
-    def _update_array_texture(self, texture_id: int, rgba: np.ndarray):
-        gl = RendererGL.gl
-        gl.glBindTexture(gl.GL_TEXTURE_2D, texture_id)
-        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
-        gl.glTexSubImage2D(
-            gl.GL_TEXTURE_2D,
-            0,
-            0,
-            0,
-            rgba.shape[1],
-            rgba.shape[0],
-            gl.GL_RGBA,
-            gl.GL_UNSIGNED_BYTE,
-            rgba.ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),
-        )
-        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
-
-    def _render_array_heatmap(self, name: str, array: np.ndarray, width: float, dpi_scale: float = 1.0):
-        imgui = self.ui.imgui
-        s = max(1.0, float(dpi_scale))
-
-        rows, cols = array.shape
-        heatmap_width = max(120.0 * s, width)
-        heatmap_height = float(np.clip(heatmap_width * rows / max(cols, 1), 80.0 * s, 220.0 * s))
-        min_cell_px = max(1.0, self._heatmap_min_cell_pixels * s)
-        target_cols = max(1, min(cols, int(heatmap_width / min_cell_px)))
-        target_rows = max(1, min(rows, int(heatmap_height / min_cell_px)))
-        display_array = self._downsample_heatmap(array, target_rows, target_cols)
-        display_rows, display_cols = display_array.shape
-        texture_state = self._ensure_array_texture(name, display_cols, display_rows)
-
-        if (
-            name in self._array_dirty
-            or texture_state["source_shape"] != array.shape
-            or texture_state["display_shape"] != display_array.shape
-        ):
-            rgba, value_min, value_max = self._colorize_heatmap(display_array)
-            self._update_array_texture(texture_state["texture_id"], rgba)
-            texture_state["source_shape"] = array.shape
-            texture_state["display_shape"] = display_array.shape
-            texture_state["value_min"] = value_min
-            texture_state["value_max"] = value_max
-            self._array_dirty.discard(name)
-
-        draw_list = imgui.get_window_draw_list()
-        origin = imgui.get_cursor_screen_pos()
-        imgui.image(imgui.ImTextureRef(texture_state["texture_id"]), imgui.ImVec2(heatmap_width, heatmap_height))
-
-        border_color = imgui.color_convert_float4_to_u32(imgui.ImVec4(1.0, 1.0, 1.0, 0.25))
-        draw_list.add_rect(
-            imgui.ImVec2(origin.x, origin.y),
-            imgui.ImVec2(origin.x + heatmap_width, origin.y + heatmap_height),
-            border_color,
-        )
-        shape_text = f"shape {rows}x{cols}"
-        if (display_rows, display_cols) != (rows, cols):
-            shape_text += f"  shown {display_rows}x{display_cols}"
-        if np.isfinite(texture_state["value_min"]) and np.isfinite(texture_state["value_max"]):
-            range_text = f"min {texture_state['value_min']:.4g}  max {texture_state['value_max']:.4g}"
-        else:
-            range_text = "min --  max --"
-        imgui.text(f"{shape_text}  {range_text}")

--- a/newton/_src/viewer/viewer_gui.py
+++ b/newton/_src/viewer/viewer_gui.py
@@ -1026,46 +1026,10 @@ class ViewerGui:
             imgui.pop_style_color()
 
     def _render_scalar_plots(self):
-        """Render floating time-series plot window for log_scalar() data and array heatmaps."""
-        viewer = self._viewer
-        scalar_buffers = getattr(viewer, "_scalar_buffers", None)
-        array_buffers = getattr(viewer, "_array_buffers", None)
-        if not scalar_buffers and not array_buffers:
-            return
-        imgui = self.ui.imgui
-        io = self.ui.io
-        s = self.ui.dpi_scale
-        scalar_arrays = getattr(viewer, "_scalar_arrays", {})
-        plot_history_size = getattr(viewer, "_plot_history_size", 250)
-        window_width = 400 * s
-        item_height = len(scalar_buffers or {}) * 140 * s + len(array_buffers or {}) * 260 * s
-        window_height = min(io.display_size[1] - 20 * s, item_height + 60 * s)
-        # ``first_use_ever`` keeps user-dragged positions stable across
-        # collapse/expand cycles and survives ``imgui.ini`` reloads.
-        imgui.set_next_window_pos(
-            imgui.ImVec2(io.display_size[0] - window_width - 10 * s, io.display_size[1] - window_height - 10 * s),
-            imgui.Cond_.first_use_ever,
-        )
-        imgui.set_next_window_size(imgui.ImVec2(window_width, window_height), imgui.Cond_.first_use_ever)
-        n = plot_history_size
-        expanded = imgui.begin("Plots")
-        if expanded:
-            graph_size = imgui.ImVec2(-1, 100 * s)
-            for name, buf in (scalar_buffers or {}).items():
-                arr = scalar_arrays.get(name)
-                if arr is None:
-                    arr = np.full(n, np.nan, dtype=np.float32)
-                    arr[n - len(buf) :] = np.array(buf, dtype=np.float32)
-                    scalar_arrays[name] = arr
-                overlay = f"{buf[-1]:.4g}" if buf else ""
-                if imgui.collapsing_header(name, imgui.TreeNodeFlags_.default_open.value):
-                    imgui.plot_lines(f"##{name}", arr, graph_size=graph_size, overlay_text=overlay)
-            render_heatmap = getattr(viewer, "_render_array_heatmap", None)
-            if render_heatmap is not None:
-                for name, array in (array_buffers or {}).items():
-                    if imgui.collapsing_header(name, imgui.TreeNodeFlags_.default_open.value):
-                        render_heatmap(name, array, window_width - 40.0 * s, dpi_scale=s)
-        imgui.end()
+        """Render live scalar plots and array heatmaps."""
+        plot_logger = getattr(self._viewer, "_plot_logger", None)
+        if plot_logger is not None:
+            plot_logger.draw(self.ui)
 
     def _render_selection_panel(self):
         """Render the articulation selection panel."""

--- a/newton/_src/viewer/viewer_rtx.py
+++ b/newton/_src/viewer/viewer_rtx.py
@@ -38,6 +38,7 @@ except ImportError:
 
 from .camera import Camera
 from .picking import Picking
+from .plot_logger import PlotLogger
 from .utils import OPAQUE_OPACITY_THRESHOLD
 from .viewer import _DEFAULT_LAYER_ID
 from .viewer_gui import ViewerGui
@@ -142,6 +143,8 @@ class ViewerRTX(ViewerUSD):
         scaling: float = 1.0,
         environment: Literal["default", "studio", "none"] = "default",
         async_rendering: bool = True,
+        *,
+        plot_history_size: int = 250,
     ):
         """Initialize the OVRTX-backed real-time ray-tracing viewer.
 
@@ -161,7 +164,11 @@ class ViewerRTX(ViewerUSD):
             async_rendering: Submit OVRTX render work asynchronously and
                 present the previous frame while the next one is still in
                 flight.
+            plot_history_size: Maximum number of samples kept per
+                :meth:`log_scalar` signal for the live time-series plots.
         """
+        self._plot_logger = PlotLogger(plot_history_size, get_window=lambda: self._window)
+
         # FIXME: Disable USD checks in OVRTX that refuse to load the library if `usd-core` is present.
         # OVRTX 0.3+ ships with namespaced USD builds that should be safe to use in conjunction with
         # `usd-core`, but the check wasn't removed yet. Upcoming OVRTX releases should remove the check,
@@ -2077,6 +2084,47 @@ void main() {
     # ----------------------------------------------------------- viewer API
 
     @override
+    def log_array(self, name: str, array: wp.array[Any] | np.ndarray | None):
+        """
+        Log a numeric array as a live heatmap.
+
+        Scalars appear as a single cell, 1-D arrays as a single row, and
+        2-D arrays as a grid. Higher-dimensional arrays are not supported.
+
+        Args:
+            name: Unique path/name for the array signal.
+            array: Array data to visualize, or ``None`` to remove a previously
+                logged array.
+        """
+        self._plot_logger.log_array(self._qualify(name), array)
+
+    @override
+    def log_scalar(
+        self,
+        name: str,
+        value: int | float | bool | np.number,
+        *,
+        clear: bool = False,
+        smoothing: int = 1,
+    ):
+        """
+        Log a scalar value as a live time-series plot.
+
+        Each unique *name* creates a separate line plot displayed in an
+        auto-generated "Plots" window.  Values are stored in a rolling
+        buffer of the last ``plot_history_size`` samples.
+
+        Args:
+            name: Unique path/name for the scalar signal.
+            value: Scalar value to record.
+            clear: If ``True``, discard previously recorded samples for
+                *name* before logging the new value.
+            smoothing: Number of raw samples to average before committing
+                a point to the plot history.  Defaults to ``1`` (no smoothing).
+        """
+        self._plot_logger.log_scalar(self._qualify(name), value, clear=clear, smoothing=smoothing)
+
+    @override
     def clear_all_layers(self) -> None:
         """Reset the RTX viewer as one complete layered scene."""
         for layer_id in [lid for lid in self._layers if lid != _DEFAULT_LAYER_ID]:
@@ -2098,6 +2146,9 @@ void main() {
                 "ViewerRTX cannot clear one layer while other user layers are still live; "
                 "create a new ViewerRTX for a different layered scene."
             )
+
+        if getattr(self, "_plot_logger", None) is not None:
+            self._plot_logger.clear_matching(self._is_layer_owned_path)
 
         # Drop example-registered side/free UI callbacks (panel/stats/rendering persist).
         if getattr(self, "gui", None) is not None:
@@ -2289,6 +2340,9 @@ void main() {
 
         # release ovrtx renderer
         self._rtx = None
+
+        if getattr(self, "_plot_logger", None) is not None:
+            self._plot_logger.clear()
 
         if self.ui:
             self.ui.shutdown()

--- a/newton/tests/test_viewer_image_logger_class.py
+++ b/newton/tests/test_viewer_image_logger_class.py
@@ -546,11 +546,11 @@ class TestViewerGLInitialization(unittest.TestCase):
 
         try:
             viewer.log_scalar("metric", 1.0)
-            self.assertIn("metric", viewer._scalar_buffers)
+            self.assertIn("metric", viewer._plot_logger._scalar_buffers)
 
             viewer.clear_model()
 
-            self.assertNotIn("metric", viewer._scalar_buffers)
+            self.assertNotIn("metric", viewer._plot_logger._scalar_buffers)
         finally:
             viewer.close()
 

--- a/newton/tests/test_viewer_plotting.py
+++ b/newton/tests/test_viewer_plotting.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import ctypes
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+import warp as wp
+
+from newton._src.viewer import viewer_gl
+from newton._src.viewer.plot_logger import PlotLogger
+from newton._src.viewer.viewer_gui import ViewerGui
+from newton._src.viewer.viewer_rtx import ViewerRTX
+from newton._src.viewer.viewer_usd import UsdGeom
+
+
+class _ViewerPlottingTests:
+    def setUp(self):
+        with wp.ScopedDevice("cpu"):
+            self.viewer = self._make_viewer()
+        self.gl = mock.MagicMock()
+        self.gl.GLuint = ctypes.c_uint
+        self.gl.glGenTextures.side_effect = lambda count, out: out.__setitem__(0, self.gl.glGenTextures.call_count)
+        patch = mock.patch.object(PlotLogger, "_get_gl", return_value=self.gl)
+        self.get_gl = patch.start()
+        self.addCleanup(patch.stop)
+        self.addCleanup(self.viewer.close)
+        self.logger = self.viewer._plot_logger
+        self.imgui = mock.MagicMock()
+        self.gui = ViewerGui.__new__(ViewerGui)
+        self.gui._viewer = self.viewer
+        self.gui.ui = SimpleNamespace(imgui=self.imgui, io=SimpleNamespace(display_size=(1280, 720)), dpi_scale=1.0)
+
+    def test_scalar_reaches_plot_window(self):
+        """Display scalar values logged before the first rendered frame."""
+        self.viewer.log_scalar("reward", np.float32(2.5))
+        self.gui._render_scalar_plots()
+        self.imgui.plot_lines.assert_called_once()
+        args, kwargs = self.imgui.plot_lines.call_args
+        self.assertEqual(args[0], "##reward")
+        self.assertEqual(args[1][-1], 2.5)
+        self.assertEqual(kwargs["overlay_text"], "2.5")
+
+    def test_array_creates_plot_window(self):
+        """Make logged arrays available to the plot window."""
+        self.viewer.log_array("observations", np.arange(6).reshape(2, 3))
+        self.imgui.begin.return_value = False
+        self.gui._render_scalar_plots()
+        self.imgui.begin.assert_called_once_with("Plots")
+        self.get_gl.assert_not_called()
+
+    def test_history_rolls_and_refreshes(self):
+        """Bound scalar history and refresh cached plots after new samples."""
+        for value in range(5):
+            self.viewer.log_scalar("reward", value)
+        self.gui._render_scalar_plots()
+        np.testing.assert_array_equal(self.imgui.plot_lines.call_args.args[1], [2, 3, 4])
+        self.viewer.log_scalar("reward", True)
+        self.gui._render_scalar_plots()
+        np.testing.assert_array_equal(self.imgui.plot_lines.call_args.args[1], [3, 4, 1])
+
+    def test_smoothing_and_clear(self):
+        """Average complete sample groups and discard pending samples on clear."""
+        self.viewer.log_scalar("reward", 2, smoothing=2)
+        self.gui._render_scalar_plots()
+        self.assertTrue(np.isnan(self.imgui.plot_lines.call_args.args[1]).all())
+        self.viewer.log_scalar("reward", 4, smoothing=2)
+        self.viewer.log_scalar("reward", 100, smoothing=2)
+        self.assertEqual(list(self.logger._scalar_buffers["reward"]), [3])
+        self.viewer.log_scalar("reward", 6, clear=True, smoothing=2)
+        self.viewer.log_scalar("reward", 10, smoothing=2)
+        self.gui._render_scalar_plots()
+        values = self.imgui.plot_lines.call_args.args[1]
+        self.assertTrue(np.isnan(values[:-1]).all())
+        self.assertEqual(values[-1], 8)
+        with self.assertRaisesRegex(ValueError, "smoothing must be >= 1"):
+            self.viewer.log_scalar("reward", 1, smoothing=0)
+
+    def test_array_shapes_and_warp_input(self):
+        """Normalize scalar, vector, strided, and Warp arrays for heatmaps."""
+        inputs = [
+            (np.array(3), [[3]]),
+            (np.array([1, 2]), [[1, 2]]),
+            (np.arange(12).reshape(3, 4)[:, ::2], [[0, 2], [4, 6], [8, 10]]),
+            (wp.array([1.0, 2.0], dtype=wp.float32, device="cpu"), [[1, 2]]),
+        ]
+        for value, expected in inputs:
+            with self.subTest(value=type(value)):
+                self.viewer.log_array("observations", value)
+                actual = self.logger._array_buffers["observations"]
+                np.testing.assert_array_equal(actual, expected)
+                self.assertEqual(actual.dtype, np.float32)
+                self.assertTrue(actual.flags.c_contiguous)
+        with self.assertRaisesRegex(ValueError, "scalar, 1-D, or 2-D"):
+            self.viewer.log_array("observations", np.zeros((2, 2, 2)))
+        self.get_gl.assert_not_called()
+
+    def test_heatmap_updates_resizes_and_removes(self):
+        """Upload changed heatmaps and release textures on resize and removal."""
+        self.viewer.log_array("observations", np.arange(6).reshape(2, 3))
+        self.gui._render_scalar_plots()
+        self.imgui.image.assert_called_once()
+        self.gl.glTexSubImage2D.assert_called_once()
+        texture_id = self.logger._array_textures["observations"]["texture_id"]
+        self.gui._render_scalar_plots()
+        self.gl.glTexSubImage2D.assert_called_once()
+        self.viewer.log_array("observations", np.arange(6).reshape(2, 3) * 2)
+        self.gui._render_scalar_plots()
+        self.assertEqual(self.gl.glTexSubImage2D.call_count, 2)
+        self.assertEqual(self.logger._array_textures["observations"]["texture_id"], texture_id)
+        self.viewer.log_array("observations", np.arange(8).reshape(2, 4))
+        self.gui._render_scalar_plots()
+        self.assertEqual(self.gl.glGenTextures.call_count, 2)
+        self.assertEqual(self.gl.glDeleteTextures.call_args.args[1][0], texture_id)
+        self.viewer.log_array("observations", None)
+        self.assertEqual(self.gl.glDeleteTextures.call_count, 2)
+        self.assertNotIn("observations", self.logger._array_buffers)
+        self.assertNotIn("observations", self.logger._array_dirty)
+        self.assertNotIn("observations", self.logger._array_textures)
+        self.imgui.reset_mock()
+        self.gui._render_scalar_plots()
+        self.imgui.begin.assert_not_called()
+
+    def test_empty_heatmap(self):
+        """Display empty array metadata without allocating invalid GL textures."""
+        self.viewer.log_array("empty", np.zeros((0, 3)))
+        self.gui._render_scalar_plots()
+        self.imgui.text.assert_called_once_with("shape 0x3 (empty)")
+        self.get_gl.assert_not_called()
+
+    def test_layer_names_and_clear_all(self):
+        """Keep same-name layer signals distinct and clear all layer resources."""
+        self.viewer.log_scalar("reward", 1)
+        self.viewer.log_array("observations", np.ones((2, 2)))
+        self.viewer.activate("training")
+        self.viewer.log_scalar("reward", 2)
+        self.viewer.log_array("observations", np.zeros((2, 2)))
+        self.gui._render_scalar_plots()
+        self.assertEqual(set(self.logger._scalar_buffers), {"reward", "/layers/training/reward"})
+        self.viewer.log_scalar("/layers/training/reward", 3)
+        self.assertEqual(list(self.logger._scalar_buffers["/layers/training/reward"]), [2, 3])
+        self.viewer.log_array("observations", None)
+        self.assertIn("observations", self.logger._array_buffers)
+        self.viewer.clear_all_layers()
+        self.assertFalse(self.logger._scalar_buffers)
+        self.assertFalse(self.logger._scalar_arrays)
+        self.assertFalse(self.logger._array_buffers)
+        self.assertFalse(self.logger._array_textures)
+        self.assertEqual(self.gl.glDeleteTextures.call_count, 2)
+
+    def test_clear_model_releases_plots(self):
+        """Clear plot history, pending smoothing, and textures on model reset."""
+        self.viewer.log_scalar("reward", 99, smoothing=2)
+        self.viewer.log_array("observations", np.ones((2, 2)))
+        self.gui._render_scalar_plots()
+        self.viewer.clear_model()
+        self.gl.glDeleteTextures.assert_called_once()
+        self.viewer.log_scalar("reward", 2, smoothing=2)
+        self.viewer.log_scalar("reward", 4, smoothing=2)
+        self.gui._render_scalar_plots()
+        values = self.imgui.plot_lines.call_args.args[1]
+        self.assertTrue(np.isnan(values[:-1]).all())
+        self.assertEqual(values[-1], 3)
+        self.assertFalse(self.logger._array_textures)
+
+    def test_close_releases_textures(self):
+        """Release heatmap textures exactly once when closing the viewer."""
+        self.viewer.log_array("observations", np.ones((2, 2)))
+        self.gui._render_scalar_plots()
+        self.viewer.close()
+        self.gl.glDeleteTextures.assert_called_once()
+        self.logger.clear()
+        self.gl.glDeleteTextures.assert_called_once()
+
+
+@unittest.skipIf(UsdGeom is None, "usd-core is required")
+class TestViewerRTXPlotting(_ViewerPlottingTests, unittest.TestCase):
+    def _make_viewer(self):
+        # OVRTX is not instantiated until the first rendered frame.
+        with mock.patch.dict("sys.modules", {"ovrtx": SimpleNamespace()}):
+            return ViewerRTX(headless=True, plot_history_size=3)
+
+
+class TestViewerGLPlotting(_ViewerPlottingTests, unittest.TestCase):
+    def _make_viewer(self):
+        renderer = mock.MagicMock()
+        renderer.window.get_framebuffer_size.return_value = (1280, 720)
+        renderer.window.get_size.return_value = (1280, 720)
+        with (
+            mock.patch.object(viewer_gl, "RendererGL", return_value=renderer),
+            mock.patch.object(viewer_gl, "ImageLogger"),
+        ):
+            return viewer_gl.ViewerGL(headless=True, plot_history_size=3)
+
+    def test_clear_model_preserves_other_layers(self):
+        """Release only the active GL layer's plots during a model reset."""
+        self.viewer.log_scalar("reward", 1)
+        self.viewer.log_array("observations", np.ones((2, 2)))
+        self.viewer.activate("training")
+        self.viewer.log_scalar("reward", 2)
+        self.viewer.log_array("observations", np.zeros((2, 2)))
+        self.gui._render_scalar_plots()
+        self.viewer.clear_model()
+        self.assertEqual(set(self.logger._scalar_buffers), {"reward"})
+        self.assertEqual(set(self.logger._array_textures), {"observations"})
+        self.gl.glDeleteTextures.assert_called_once()
+
+
+class TestPlotLogger(unittest.TestCase):
+    def test_invalid_history_size(self):
+        """Reject invalid history sizes before either backend initializes."""
+        for viewer_class in (viewer_gl.ViewerGL, ViewerRTX):
+            for value, error in ((0, ValueError), (-1, ValueError), (1.5, TypeError), (True, TypeError)):
+                with self.subTest(viewer=viewer_class.__name__, value=value), self.assertRaises(error):
+                    viewer_class(plot_history_size=value)
+
+    def test_texture_context_is_owned_by_viewer(self):
+        """Activate the owning window before deleting its heatmap texture."""
+        window = mock.Mock()
+        gl = mock.MagicMock(GLuint=ctypes.c_uint)
+        logger = PlotLogger(3, get_window=lambda: window)
+        logger._array_textures["observations"] = {"texture_id": 42}
+        with mock.patch.dict("sys.modules", {"pyglet": SimpleNamespace(gl=gl)}):
+            logger.clear()
+        window.switch_to.assert_called_once()
+        self.assertEqual(gl.glDeleteTextures.call_args.args[1][0], 42)
+
+    def test_heatmap_nonfinite_values(self):
+        """Color nonfinite cells separately and compute finite heatmap bounds."""
+        logger = PlotLogger(3, get_window=lambda: None)
+        rgba, low, high = logger._colorize_heatmap(np.array([[0, 2, np.nan, np.inf]], dtype=np.float32))
+        self.assertEqual((low, high), (0, 2))
+        np.testing.assert_array_equal(rgba[0, 0], logger._heatmap_color_lut[0])
+        np.testing.assert_array_equal(rgba[0, 1], logger._heatmap_color_lut[-1])
+        np.testing.assert_array_equal(rgba[0, 2:], np.tile(logger._heatmap_nan_rgba, (2, 1)))
+        rgba, low, high = logger._colorize_heatmap(np.array([[np.nan]], dtype=np.float32))
+        self.assertTrue(np.isnan(low) and np.isnan(high))
+        np.testing.assert_array_equal(rgba[0, 0], logger._heatmap_nan_rgba)
+        reduced = logger._downsample_heatmap(np.array([[1, np.nan], [3, np.inf]]), 1, 1)
+        np.testing.assert_array_equal(reduced, [[2]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_viewer_plotting.py
+++ b/newton/tests/test_viewer_plotting.py
@@ -227,6 +227,28 @@ class TestPlotLogger(unittest.TestCase):
         window.switch_to.assert_called_once()
         self.assertEqual(gl.glDeleteTextures.call_args.args[1][0], 42)
 
+    def test_clear_after_window_close(self):
+        """Release heatmaps when the window or its context is already gone."""
+        closed_window = mock.Mock()
+        closed_window.switch_to.side_effect = AttributeError("context is already destroyed")
+        for window in (closed_window, None):
+            with self.subTest(window=window):
+                gl = mock.MagicMock(GLuint=ctypes.c_uint)
+                logger = PlotLogger(3, get_window=lambda window=window: window)
+                logger.log_scalar("reward", 1, smoothing=2)
+                for index, name in enumerate(("observations", "actions"), start=42):
+                    logger.log_array(name, np.ones((2, 2)))
+                    logger._array_textures[name] = {"texture_id": index}
+                with mock.patch.dict("sys.modules", {"pyglet": SimpleNamespace(gl=gl)}):
+                    logger.clear()
+                    logger.clear()
+                self.assertFalse(logger._scalar_buffers)
+                self.assertFalse(logger._scalar_accumulators)
+                self.assertFalse(logger._array_buffers)
+                self.assertFalse(logger._array_dirty)
+                self.assertFalse(logger._array_textures)
+                self.assertEqual([call.args[1][0] for call in gl.glDeleteTextures.call_args_list], [42, 43])
+
     def test_heatmap_nonfinite_values(self):
         """Color nonfinite cells separately and compute finite heatmap bounds."""
         logger = PlotLogger(3, get_window=lambda: None)


### PR DESCRIPTION
## Description

`ViewerRTX.log_scalar()` and `log_array()` currently inherit empty USD implementations, so Isaac Lab training metrics never appear. Implement both APIs using shared GL/RTX plotting support, including rolling scalar history, smoothing, array heatmaps, layer-qualified names, and texture cleanup. Add the `plot_history_size` option to `ViewerRTX` and document the APIs.

Closes #4046. Also addresses the plotting capabilities requested in #2564 and #2565.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- Confirmed the original RTX scalar and array regression tests fail before the implementation.
- Ran `python -m unittest discover -s newton/tests -p 'test_viewer*.py' -q` through `uv run --no-project` using the existing environment: **263 tests passed**.
- `uvx pre-commit run -a`: passed.
- Towncrier draft preview: passed; the release note renders with the link to issue #4046.
- Ran `docs/generate_api.py`.
- Verified scalar curves and heatmaps in the real RTX ImGui window, including GL texture deletion when removing an array.

Full scene-plus-GUI validation encountered a pre-existing OVRTX 0.5.0.377615 incompatibility: returned render-variable keys use `/Render/Vars/LdrColor`, while the existing viewer display path expects `LdrColor`. Direct RTX GUI rendering passed; this PR leaves that separate frame lookup unchanged.

## New feature / API change

```python
import numpy as np
import newton.viewer

viewer = newton.viewer.ViewerRTX(plot_history_size=500)

# Log metrics during simulation or training.
viewer.log_scalar("Training/reward", 2.5, smoothing=4)
viewer.log_array("Training/observations", np.arange(16).reshape(4, 4))

# Reset a scalar signal or remove an array visualization.
viewer.log_scalar("Training/reward", 0.0, clear=True)
viewer.log_array("Training/observations", None)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live plotting to the GL and RTX Viewers.
  * Display rolling scalar line charts with optional smoothing.
  * Display scalar, one-dimensional, and two-dimensional arrays as heatmaps.
  * Configure plot history length, clear individual signals, and remove heatmaps.
  * Plotting works before the first rendered frame and in headless mode.

* **Documentation**
  * Added guidance for live plotting across supported viewer backends, including setup requirements and backend-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
