### PR TITLE
Rigid-only LOX backend for SolverKamino

### DIFF
--- a/changelog/+lox-rigid-3e7c9a21.added.md
+++ b/changelog/+lox-rigid-3e7c9a21.added.md
@@ -1,0 +1,4 @@
+Add the experimental LOX rigid-body dynamics backend to `SolverKamino`, with
+Euler and Moreau integration, augmented-Lagrangian structural joints,
+fixed-topology RCM/Cholesky reuse, implicit drive compliance, and relaxed
+candidate-pose updates for nonlinear joint constraints.

--- a/docs/solvers/kamino.rst
+++ b/docs/solvers/kamino.rst
@@ -28,7 +28,7 @@ and configuration details. Runnable workflows are available in the
 Choosing a dynamics solver
 --------------------------
 
-Kamino provides two forward-dynamics backends:
+Kamino provides three forward-dynamics backends:
 
 * ``"padmm"`` (default): proximal ADMM, dense Jacobians/dynamics, and the Euler
   integrator. It is the slower, more robust option because it solves equality
@@ -40,6 +40,10 @@ Kamino provides two forward-dynamics backends:
   inequality constraints. As a rule of thumb, DVI solves inequality constraints
   less accurately than PADMM, particularly as the number of active inequalities
   grows. Dual preconditioning is not supported.
+* ``"lox"`` (opt-in): a primal splitting method with sparse Jacobians and
+  dense per-island dynamics. It performs one frozen-linearization solve at the
+  configuration supplied by the selected Kamino integrator. Unlike PADMM and
+  DVI, it supports singular-inertia frames. Rod joints are not supported.
 
 Select the backend when constructing the configuration so dependent defaults
 initialize consistently:
@@ -95,8 +99,14 @@ residual definitions are backend-specific:
   from the dual cone and the bilateral velocity violation [m/s or rad/s].
   ``r_c = max |lambda_k dot v_k|`` is the maximum inequality complementarity
   violation [J].
+* **LOX:** ``converged`` and ``iterations`` report LOX's native splitting
+  termination state. With ``compute_solution_metrics=True``, ``r_p``, ``r_d``,
+  and ``r_c`` are the NCP primal, dual, and complementarity residuals evaluated
+  from the final constraint reactions and velocity. Without solution metrics,
+  these three fields are NaN. LOX additionally reports ``accepted``, ``failed``,
+  and ``iteration_limit``.
 
-These are absolute maxima: neither backend divides them by a reference norm,
+These are absolute maxima: no backend divides them by a reference norm,
 constraint count, or tolerance. Additional fields are not portable between
 backends.
 

--- a/newton/_src/solvers/kamino/_src/core/math.py
+++ b/newton/_src/solvers/kamino/_src/core/math.py
@@ -523,10 +523,13 @@ def compute_body_twist_update_with_eom(
     inv_I_i: wp.mat33f,
     u_i: wp.spatial_vectorf,
     w_i: wp.spatial_vectorf,
+    integrate_singular_bodies: bool,
 ) -> tuple[wp.vec3f, wp.vec3f]:
     # Extract linear and angular parts
     v_i = wp.spatial_top(u_i)
     omega_i = wp.spatial_bottom(u_i)
+    if integrate_singular_bodies and (inv_m_i == 0.0 or wp.determinant(inv_I_i) == 0.0):
+        return v_i, omega_i
     S_i = wp.skew(omega_i)
     f_i = wp.spatial_top(w_i)
     tau_i = wp.spatial_bottom(w_i)

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -724,6 +724,7 @@ class ModelKamino:
                 q_j=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
                 q_j_p=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
                 dq_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=wp.float32, requires_grad=requires_grad),
+                lambda_w_i=wp.zeros_like(self.bodies.u_i_0, requires_grad=requires_grad),
                 lambda_kin_j=wp.zeros(
                     shape=self.size.sum_of_num_kinematic_joint_cts, dtype=wp.float32, requires_grad=requires_grad
                 ),

--- a/newton/_src/solvers/kamino/_src/core/state.py
+++ b/newton/_src/solvers/kamino/_src/core/state.py
@@ -111,6 +111,9 @@ class StateKamino:
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
+    lambda_w_i: wp.array[wp.spatial_vectorf] | None = None
+    """Body consensus impulses [N·s, N·m·s], shape ``(num_bodies,)``."""
+
     lambda_kin_j: wp.array[wp.float32] | None = None
     """
     Array of generalized joint kinematic constraint forces [N or N·m].
@@ -174,6 +177,7 @@ class StateKamino:
         wp.copy(self.q_j, other.q_j)
         wp.copy(self.q_j_p, other.q_j_p)
         wp.copy(self.dq_j, other.dq_j)
+        wp.copy(self.lambda_w_i, other.lambda_w_i)
         wp.copy(self.lambda_kin_j, other.lambda_kin_j)
         wp.copy(self.lambda_dyn_j, other.lambda_dyn_j)
         wp.copy(self.lambda_f_j, other.lambda_f_j)
@@ -296,6 +300,18 @@ class StateKamino:
             joint_q_prev = wp.clone(state.joint_q)
             state.joint_q_prev = joint_q_prev
 
+        lambda_w_i = getattr(state, "body_lox_dual_impulse", None)
+        if lambda_w_i is None:
+            lambda_w_i = wp.zeros(size.sum_of_num_bodies, dtype=wp.spatial_vectorf, device=device)
+            state.body_lox_dual_impulse = lambda_w_i
+        if (
+            not isinstance(lambda_w_i, wp.array)
+            or lambda_w_i.shape != (size.sum_of_num_bodies,)
+            or lambda_w_i.dtype != wp.spatial_vectorf
+            or lambda_w_i.device != wp.get_device(device)
+        ):
+            raise ValueError("State.body_lox_dual_impulse must have one spatial vector per body on the state device.")
+
         # If the state contains the Kamino-specific `joint_lambdas` custom attribute,
         # capture a reference to it; otherwise, create a new array for it.
         # The attribute has JOINT_CONSTRAINT frequency and should therefore correspond to joint kinematic constraints.
@@ -355,6 +371,7 @@ class StateKamino:
             q_j=state.joint_q,
             q_j_p=joint_q_prev,
             dq_j=state.joint_qd,
+            lambda_w_i=lambda_w_i,
             lambda_kin_j=lambda_kin_j,
             lambda_dyn_j=lambda_dyn_j,
             lambda_f_j=lambda_f_j,
@@ -413,6 +430,7 @@ class StateKamino:
         # Add Kamino-specific custom attributes to the newton.State object
         state_newton.body_f_total = state.w_i.view(dtype=wp.spatial_vectorf)
         state_newton.joint_q_prev = state.q_j_p
+        state_newton.body_lox_dual_impulse = state.lambda_w_i
         state_newton.joint_lambdas = state.lambda_kin_j
         state_newton.joint_lambdas_dyn = state.lambda_dyn_j
         state_newton.joint_lambdas_f = state.lambda_f_j

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -944,6 +944,7 @@ def make_convert_contacts_newton_to_kamino(
     friction_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
     restitution_mix_mode: MaterialMixMode = MaterialMixMode.MIN,
     cull_speculative: bool = DEFAULT_CULL_SPECULATIVE_CONTACTS,
+    skip_fully_prescribed: bool = False,
 ):
     """
     Generates a kernel to convert Newton contacts to the Kamino format.
@@ -953,6 +954,8 @@ def make_convert_contacts_newton_to_kamino(
         restitution_mix_mode: The mixing mode to use for restitution.
         cull_speculative: If ``True``, skip speculative contacts, i.e., contacts
             with positive margin-shifted distance.
+        skip_fully_prescribed: If ``True``, skip contacts between bodies that
+            cannot respond to contact impulses.
 
     Returns:
         A kernel function that converts Newton contacts to the Kamino format.
@@ -1038,6 +1041,12 @@ def make_convert_contacts_newton_to_kamino(
         bid_1 = shape_body[sid_1]
         wid_0 = shape_world[sid_0]
         wid_1 = shape_world[sid_1]
+
+        if wp.static(skip_fully_prescribed):
+            dynamic_0 = bid_0 >= 0 and body_inv_mass[bid_0] > 0.0
+            dynamic_1 = bid_1 >= 0 and body_inv_mass[bid_1] > 0.0
+            if not dynamic_0 and not dynamic_1:
+                return
 
         # Determine the world index.  Global shapes (shape_world == -1) can
         # collide with shapes from any world, so fall back to the other shape.
@@ -1403,6 +1412,7 @@ def convert_contacts_newton_to_kamino(
     friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average",
     restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "min",
     cull_speculative_contacts: bool = DEFAULT_CULL_SPECULATIVE_CONTACTS,
+    skip_fully_prescribed_contacts: bool = False,
 ):
     """
     Converts Newton's :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
@@ -1447,6 +1457,9 @@ def convert_contacts_newton_to_kamino(
         cull_speculative_contacts:
             If ``True`` (the default), drop speculative contacts (contacts with
             positive margin-shifted distance).
+        skip_fully_prescribed_contacts:
+            If ``True``, omit contacts between two world-static or zero-mass
+            bodies. Defaults to ``False``.
     """
     # Skip conversion if there are no contacts to convert or no capacity to store them.
     if contacts_out.model_max_contacts_host == 0 or contacts_in.rigid_contact_max == 0:
@@ -1493,6 +1506,7 @@ def convert_contacts_newton_to_kamino(
         friction_mix_mode=MaterialMixMode.from_string(friction_mix_mode),
         restitution_mix_mode=MaterialMixMode.from_string(restitution_mix_mode),
         cull_speculative=cull_speculative_contacts,
+        skip_fully_prescribed=skip_fully_prescribed_contacts,
     )
 
     # Launch the conversion kernel to convert Newton contacts to Kamino's format.

--- a/newton/_src/solvers/kamino/_src/integrators/euler.py
+++ b/newton/_src/solvers/kamino/_src/integrators/euler.py
@@ -46,6 +46,7 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 @wp.func
 def euler_semi_implicit_with_logmap(
     alpha: wp.float32,
+    integrate_singular_bodies: bool,
     dt: wp.float32,
     g: wp.vec3f,
     inv_m_i: wp.float32,
@@ -64,6 +65,7 @@ def euler_semi_implicit_with_logmap(
         inv_I_i=inv_I_i,
         u_i=u_i,
         w_i=w_i,
+        integrate_singular_bodies=integrate_singular_bodies,
     )
 
     # Apply damping to angular velocity
@@ -90,6 +92,7 @@ def euler_semi_implicit_with_logmap(
 def _integrate_semi_implicit_euler_inplace(
     # Inputs:
     alpha: float,
+    integrate_singular_bodies: bool,
     model_dt: wp.array[wp.float32],
     model_gravity: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
@@ -113,7 +116,7 @@ def _integrate_semi_implicit_euler_inplace(
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]
-    if inv_m_i <= 0.0:
+    if inv_m_i <= 0.0 and not integrate_singular_bodies:
         return
     I_i = model_bodies_I[tid]
     inv_I_i = model_bodies_inv_I[tid]
@@ -126,6 +129,7 @@ def _integrate_semi_implicit_euler_inplace(
     # Compute the next pose and twist
     q_i_n, u_i_n = euler_semi_implicit_with_logmap(
         alpha,
+        integrate_singular_bodies,
         dt,
         g,
         inv_m_i,
@@ -146,13 +150,20 @@ def _integrate_semi_implicit_euler_inplace(
 ###
 
 
-def integrate_euler_semi_implicit(model: ModelKamino, data: DataKamino, alpha: float = 0.0):
+def integrate_euler_semi_implicit(
+    model: ModelKamino,
+    data: DataKamino,
+    alpha: float = 0.0,
+    *,
+    integrate_singular_bodies: bool = False,
+):
     wp.launch(
         _integrate_semi_implicit_euler_inplace,
         dim=model.size.sum_of_num_bodies,
         inputs=[
             # Inputs:
             alpha,  # alpha: angular damping
+            integrate_singular_bodies,
             model.time.dt,
             model.gravity.vector,
             model.bodies.wid,
@@ -195,13 +206,20 @@ class IntegratorEuler(IntegratorBase):
     constraint reactions.
     """
 
-    def __init__(self, model: ModelKamino, alpha: float | None = None):
+    def __init__(
+        self,
+        model: ModelKamino,
+        alpha: float | None = None,
+        *,
+        integrate_singular_bodies: bool = False,
+    ):
         """
         Initializes the Semi-Implicit Euler integrator with the given :class:`ModelKamino` instance.
 
         Args:
             model: The model container holding the time-invariant parameters of the system being simulated.
             alpha: The angular damping coefficient. Defaults to 0.0 if `None` is provided.
+            integrate_singular_bodies: Whether singular bodies carry a velocity supplied by the dynamics solver.
         """
         super().__init__(model)
 
@@ -210,6 +228,7 @@ class IntegratorEuler(IntegratorBase):
         Damping coefficient for angular velocity used to improve numerical stability of the integrator.
         Defaults to `0.0`, corresponding to no damping being applied.
         """
+        self._integrate_singular_bodies = integrate_singular_bodies
 
     ###
     # Operations
@@ -259,4 +278,9 @@ class IntegratorEuler(IntegratorBase):
         )
 
         # Perform forward integration to compute the next state of the system
-        integrate_euler_semi_implicit(model=model, data=data, alpha=self._alpha)
+        integrate_euler_semi_implicit(
+            model=model,
+            data=data,
+            alpha=self._alpha,
+            integrate_singular_bodies=self._integrate_singular_bodies,
+        )

--- a/newton/_src/solvers/kamino/_src/integrators/moreau.py
+++ b/newton/_src/solvers/kamino/_src/integrators/moreau.py
@@ -47,6 +47,7 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 @wp.func
 def moreau_jean_semi_implicit_with_logmap(
     alpha: wp.float32,
+    integrate_singular_bodies: bool,
     dt: wp.float32,
     g: wp.vec3f,
     inv_m_i: wp.float32,
@@ -65,6 +66,7 @@ def moreau_jean_semi_implicit_with_logmap(
         inv_I_i=inv_I_i,
         u_i=u_i,
         w_i=w_i,
+        integrate_singular_bodies=integrate_singular_bodies,
     )
 
     # Apply damping to angular velocity
@@ -90,6 +92,7 @@ def moreau_jean_semi_implicit_with_logmap(
 @wp.kernel
 def _integrate_moreau_jean_first_inplace(
     # Inputs:
+    integrate_singular_bodies: bool,
     model_dt: wp.array[wp.float32],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_inv_m: wp.array[wp.float32],
@@ -100,7 +103,7 @@ def _integrate_moreau_jean_first_inplace(
     # Retrieve the thread index
     tid = wp.tid()
 
-    if model_bodies_inv_m[tid] <= 0.0:
+    if model_bodies_inv_m[tid] <= 0.0 and not integrate_singular_bodies:
         return
 
     # Retrieve the world index
@@ -129,6 +132,7 @@ def _integrate_moreau_jean_first_inplace(
 def _integrate_moreau_jean_second_inplace(
     # Inputs:
     alpha: float,
+    integrate_singular_bodies: bool,
     model_dt: wp.array[wp.float32],
     model_gravity: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
@@ -153,7 +157,7 @@ def _integrate_moreau_jean_second_inplace(
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]
-    if inv_m_i <= 0.0:
+    if inv_m_i <= 0.0 and not integrate_singular_bodies:
         return
     I_i = model_bodies_I[tid]
     inv_I_i = model_bodies_inv_I[tid]
@@ -166,6 +170,7 @@ def _integrate_moreau_jean_second_inplace(
     # Compute the next pose and twist
     q_i_n, u_i_n = moreau_jean_semi_implicit_with_logmap(
         alpha,
+        integrate_singular_bodies,
         dt,
         g,
         inv_m_i,
@@ -226,13 +231,20 @@ class IntegratorMoreauJean(IntegratorBase):
     at the mid-point from the forward dynamics sub-problem.
     """
 
-    def __init__(self, model: ModelKamino, alpha: float | None = None):
+    def __init__(
+        self,
+        model: ModelKamino,
+        alpha: float | None = None,
+        *,
+        integrate_singular_bodies: bool = False,
+    ):
         """
         Initializes the semi-implicit Moreau-Jean integrator with the given :class:`ModelKamino` instance.
 
         Args:
             model: The model container holding the time-invariant parameters of the system being simulated.
             alpha: The angular damping coefficient. Defaults to 0.0 if `None` is provided.
+            integrate_singular_bodies: Whether singular bodies carry a velocity supplied by the dynamics solver.
         """
         super().__init__(model)
 
@@ -241,6 +253,7 @@ class IntegratorMoreauJean(IntegratorBase):
         Damping coefficient for angular velocity used to improve numerical stability of the integrator.
         Defaults to `0.0`, corresponding to no damping being applied.
         """
+        self._integrate_singular_bodies = integrate_singular_bodies
 
     ###
     # Operations
@@ -320,6 +333,7 @@ class IntegratorMoreauJean(IntegratorBase):
             dim=model.size.sum_of_num_bodies,
             inputs=[
                 # Inputs:
+                self._integrate_singular_bodies,
                 model.time.dt,
                 model.bodies.wid,
                 model.bodies.inv_m_i,
@@ -347,6 +361,7 @@ class IntegratorMoreauJean(IntegratorBase):
             inputs=[
                 # Inputs:
                 self._alpha,
+                self._integrate_singular_bodies,
                 model.time.dt,
                 model.gravity.vector,
                 model.bodies.wid,

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -447,6 +447,7 @@ def _reset_body_wrenches(
     # Outputs
     body_w: wp.array[wp.spatial_vectorf],
     body_w_e: wp.array[wp.spatial_vectorf],
+    lambda_w_i: wp.array[wp.spatial_vectorf],
 ):
     # Get thread id as body id
     body_id = wp.tid()
@@ -459,6 +460,7 @@ def _reset_body_wrenches(
     # Reset wrenches to zero
     body_w[body_id] = wp.spatial_vectorf(0.0)
     body_w_e[body_id] = wp.spatial_vectorf(0.0)
+    lambda_w_i[body_id] = wp.spatial_vectorf(0.0)
 
 
 @wp.kernel
@@ -891,6 +893,6 @@ def reset_body_wrenches(
     wp.launch(
         _reset_body_wrenches,
         dim=model.size.sum_of_num_bodies,
-        inputs=[model.bodies.wid, world_mask, state.w_i, state.w_i_e],
+        inputs=[model.bodies.wid, world_mask, state.w_i, state.w_i_e, state.lambda_w_i],
         device=model.device,
     )

--- a/newton/_src/solvers/kamino/_src/linalg/__init__.py
+++ b/newton/_src/solvers/kamino/_src/linalg/__init__.py
@@ -9,11 +9,10 @@ from .core import (
     DenseRectangularMultiLinearInfo,
     DenseSquareMultiLinearInfo,
 )
+from .factorize.hybrid_llt_solver import HybridLLTBlockedSolver
 
-# Import the RCM-reordered semi-sparse blocked LLT solver here (rather than
-# from .linear) to avoid a circular import: .factorize.llt_blocked_rcm_solver
-# imports DirectSolver from .linear, so .linear cannot import it back.
-# At this point .linear has been fully resolved, so the downstream import is safe.
+# Import the RCM and hybrid implementations from factorize rather than from
+# linear because both build on the dense solver classes defined there.
 from .factorize.llt_blocked_rcm_solver import LLTBlockedRCMSolver
 from .linear import (
     ConjugateGradientSolver,
@@ -58,6 +57,7 @@ __all__ = [
     "DenseRectangularMultiLinearInfo",
     "DenseSquareMultiLinearInfo",
     "DirectSolver",
+    "HybridLLTBlockedSolver",
     "IterativeSolver",
     "LLTBlockedRCMSolver",
     "LLTBlockedSolver",

--- a/newton/_src/solvers/kamino/_src/linalg/__init__.py
+++ b/newton/_src/solvers/kamino/_src/linalg/__init__.py
@@ -11,8 +11,9 @@ from .core import (
 )
 from .factorize.hybrid_llt_solver import HybridLLTBlockedSolver
 
-# Import the RCM and hybrid implementations from factorize rather than from
-# linear because both build on the dense solver classes defined there.
+# Import the RCM-reordered and hybrid blocked LLT solvers here (rather than
+# from .linear) to avoid a circular import: both implementations import the
+# dense solver classes from .linear.
 from .factorize.llt_blocked_rcm_solver import LLTBlockedRCMSolver
 from .linear import (
     ConjugateGradientSolver,

--- a/newton/_src/solvers/kamino/_src/linalg/core.py
+++ b/newton/_src/solvers/kamino/_src/linalg/core.py
@@ -420,12 +420,16 @@ class DenseSquareMultiLinearInfo(Generic[ScalarType, IndexType]):
             self.device = device
 
         # Compute the allocation sizes and offsets for the flat data arrays
-        mat_sizes = [n * n for n in self.dimensions]
-        mat_offsets = [0] + [sum(mat_sizes[:i]) for i in range(1, len(mat_sizes) + 1)]
-        mat_flat_size = sum(mat_sizes)
-        vec_sizes = self.dimensions
-        vec_offsets = [0] + [sum(vec_sizes[:i]) for i in range(1, len(vec_sizes) + 1)]
-        vec_flat_size = sum(vec_sizes)
+        dimensions_np = np.asarray(self.dimensions, dtype=np.int64)
+        mat_sizes = dimensions_np * dimensions_np
+        mat_offsets = np.empty(len(self.dimensions) + 1, dtype=np.int64)
+        mat_offsets[0] = 0
+        np.cumsum(mat_sizes, out=mat_offsets[1:])
+        mat_flat_size = int(mat_offsets[-1])
+        vec_offsets = np.empty(len(self.dimensions) + 1, dtype=np.int64)
+        vec_offsets[0] = 0
+        np.cumsum(dimensions_np, out=vec_offsets[1:])
+        vec_flat_size = int(vec_offsets[-1])
 
         # Update the allocation meta-data the specified system dimensions
         self.num_blocks = len(self.dimensions)

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/hybrid_llt_solver.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/hybrid_llt_solver.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-block dispatcher for dense and semi-sparse Cholesky kernels."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from ......core.types import override
+from .. import factorize
+from ..core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
+from ..linear import LLTBlockedSolver
+from .llt_blocked_rcm_solver import LLTBlockedRCMSolver, _fixed_symbolic_data
+
+__all__ = ["HybridLLTBlockedSolver"]
+
+
+@wp.kernel(enable_backward=False)
+def _gather_block_dimensions(
+    block_indices: wp.array[wp.int32],
+    dimensions: wp.array[wp.int32],
+    gathered_dimensions: wp.array[wp.int32],
+):
+    block = wp.tid()
+    gathered_dimensions[block] = dimensions[block_indices[block]]
+
+
+@wp.kernel(enable_backward=False)
+def _gather_block_info(
+    block_indices: wp.array[wp.int32],
+    dimensions: wp.array[wp.int32],
+    matrix_offsets: wp.array[wp.int32],
+    vector_offsets: wp.array[wp.int32],
+    gathered_dimensions: wp.array[wp.int32],
+    gathered_matrix_offsets: wp.array[wp.int32],
+    gathered_vector_offsets: wp.array[wp.int32],
+):
+    block = wp.tid()
+    source = block_indices[block]
+    gathered_dimensions[block] = dimensions[source]
+    gathered_matrix_offsets[block] = matrix_offsets[source]
+    gathered_vector_offsets[block] = vector_offsets[source]
+
+
+@wp.kernel(enable_backward=False)
+def _initialize_identity_permutations(
+    dimensions: wp.array[wp.int32],
+    vector_offsets: wp.array[wp.int32],
+    permutation: wp.array[wp.int32],
+    inverse_permutation: wp.array[wp.int32],
+):
+    block, index = wp.tid()
+    if index < dimensions[block]:
+        offset = vector_offsets[block] + index
+        permutation[offset] = index
+        inverse_permutation[offset] = index
+
+
+@wp.kernel(enable_backward=False)
+def _scatter_subset_permutations(
+    block_indices: wp.array[wp.int32],
+    source_max_dimensions: wp.array[wp.int32],
+    source_vector_offsets: wp.array[wp.int32],
+    compact_vector_offsets: wp.array[wp.int32],
+    compact_permutation: wp.array[wp.int32],
+    compact_inverse_permutation: wp.array[wp.int32],
+    permutation: wp.array[wp.int32],
+    inverse_permutation: wp.array[wp.int32],
+):
+    block, index = wp.tid()
+    source = block_indices[block]
+    if index < source_max_dimensions[source]:
+        compact_offset = compact_vector_offsets[block] + index
+        source_offset = source_vector_offsets[source] + index
+        permutation[source_offset] = compact_permutation[compact_offset]
+        inverse_permutation[source_offset] = compact_inverse_permutation[compact_offset]
+
+
+class _SubsetLLTBlockedRCMSolver(LLTBlockedRCMSolver):
+    """Apply the existing RCM implementation to selected packed blocks."""
+
+    def __init__(
+        self,
+        operator: DenseLinearOperatorData,
+        block_indices: Sequence[int],
+        symbolic_adjacency: Sequence[Sequence[Sequence[int]]],
+        shared_factor: wp.array,
+        shared_intermediate: wp.array,
+        **kwargs: Any,
+    ):
+        info = operator.info
+        if not isinstance(info, DenseSquareMultiLinearInfo):
+            raise ValueError("Hybrid RCM factorization requires a square matrix.")
+        selected_indices = tuple(int(index) for index in block_indices)
+        if not selected_indices:
+            raise ValueError("Hybrid RCM block selection must not be empty.")
+        if len(set(selected_indices)) != len(selected_indices):
+            raise ValueError("Hybrid RCM block selection must be unique.")
+        if any(index < 0 or index >= info.num_blocks for index in selected_indices):
+            raise ValueError("Hybrid RCM block selection is out of range.")
+        if len(symbolic_adjacency) != info.num_blocks:
+            raise ValueError("symbolic_adjacency must contain one graph per matrix block.")
+
+        dimensions_np = np.asarray(info.dimensions, dtype=np.int32)
+        selected_dimensions = dimensions_np[np.asarray(selected_indices, dtype=np.int32)].tolist()
+        selected_adjacency = [symbolic_adjacency[index] for index in selected_indices]
+
+        subset_info = DenseSquareMultiLinearInfo()
+        subset_info.finalize(
+            selected_dimensions,
+            dtype=info.dtype,
+            itype=info.itype,
+            device=info.device,
+        )
+        compact_vector_offsets = subset_info.vio
+        subset_info.mio = wp.empty(len(selected_indices), dtype=info.itype, device=info.device)
+        subset_info.vio = wp.empty(len(selected_indices), dtype=info.itype, device=info.device)
+        subset_operator = DenseLinearOperatorData(info=subset_info, mat=operator.mat)
+
+        self._source_dimensions = info.dim
+        self._source_block_indices = wp.array(selected_indices, dtype=wp.int32, device=info.device)
+        wp.launch(
+            _gather_block_info,
+            dim=len(selected_indices),
+            inputs=[self._source_block_indices, info.dim, info.mio, info.vio],
+            outputs=[subset_info.dim, subset_info.mio, subset_info.vio],
+            device=info.device,
+        )
+        super().__init__(operator=subset_operator, symbolic_adjacency=selected_adjacency, **kwargs)
+
+        with wp.ScopedDevice(info.device):
+            self._A_hat = wp.zeros(info.total_mat_size, dtype=info.dtype)
+            self._x_hat = wp.zeros(info.total_vec_size, dtype=info.dtype)
+            full_permutation = wp.empty(info.total_vec_size, dtype=wp.int32)
+            full_inverse = wp.empty(info.total_vec_size, dtype=wp.int32)
+        wp.launch(
+            _initialize_identity_permutations,
+            dim=(info.num_blocks, info.max_dimension),
+            inputs=[info.maxdim, info.vio],
+            outputs=[full_permutation, full_inverse],
+            device=info.device,
+        )
+        wp.launch(
+            _scatter_subset_permutations,
+            dim=(len(selected_indices), max(selected_dimensions)),
+            inputs=[
+                self._source_block_indices,
+                info.maxdim,
+                info.vio,
+                compact_vector_offsets,
+                self._P,
+                self._inv_P,
+            ],
+            outputs=[full_permutation, full_inverse],
+            device=info.device,
+        )
+        self._P = full_permutation
+        self._inv_P = full_inverse
+        self._L = shared_factor
+        self._y = shared_intermediate
+
+    @override
+    def _factorize_impl(self, A: wp.array) -> None:
+        wp.launch(
+            _gather_block_dimensions,
+            dim=self._source_block_indices.shape[0],
+            inputs=[self._source_block_indices, self._source_dimensions],
+            outputs=[self._operator.info.dim],
+            device=self._device,
+        )
+        super()._factorize_impl(A)
+
+
+class HybridLLTBlockedSolver(LLTBlockedSolver):
+    """Dispatch independent matrix blocks to an appropriate LLT kernel.
+
+    Small blocks use the sequential kernels, intermediate and structurally
+    dense blocks use ordinary tiled LLT, and sufficiently large sparse blocks
+    with fixed symbolic adjacency use RCM-reordered semi-sparse tiled LLT.
+    All paths retain the original packed offsets and share one factor buffer.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        sequential_block_size: int = 6,
+        rcm_min_dimension: int = 256,
+        rcm_max_fill_ratio: float = 0.75,
+        symbolic_adjacency: Sequence[Sequence[Sequence[int]]] | None = None,
+        rcm_block_size: int = 32,
+        rcm_parallel_factorization: bool = True,
+        **kwargs: Any,
+    ):
+        if sequential_block_size < 0:
+            raise ValueError("sequential_block_size must be nonnegative.")
+        if rcm_min_dimension <= sequential_block_size:
+            raise ValueError("rcm_min_dimension must exceed sequential_block_size.")
+        if not 0.0 <= rcm_max_fill_ratio <= 1.0:
+            raise ValueError("rcm_max_fill_ratio must be between zero and one.")
+
+        self._sequential_block_size = sequential_block_size
+        self._rcm_min_dimension = rcm_min_dimension
+        self._rcm_max_fill_ratio = rcm_max_fill_ratio
+        self._symbolic_adjacency = symbolic_adjacency
+        self._rcm_block_size = rcm_block_size
+        self._rcm_parallel_factorization = rcm_parallel_factorization
+        self._rcm_block_decisions: dict[tuple[int, int], bool] = {}
+        self._sequential_block_indices_host: tuple[int, ...] = ()
+        self._tiled_block_indices_host: tuple[int, ...] = ()
+        self._rcm_block_indices_host: tuple[int, ...] = ()
+        self._sequential_dim: wp.array[wp.int32] | None = None
+        self._sequential_mio: wp.array[wp.int32] | None = None
+        self._sequential_vio: wp.array[wp.int32] | None = None
+        self._sequential_block_indices: wp.array[wp.int32] | None = None
+        self._tiled_dim: wp.array[wp.int32] | None = None
+        self._tiled_mio: wp.array[wp.int32] | None = None
+        self._tiled_vio: wp.array[wp.int32] | None = None
+        self._tiled_block_indices: wp.array[wp.int32] | None = None
+        self._rcm_solver: _SubsetLLTBlockedRCMSolver | None = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def block_size(self) -> int:
+        """Return the tile size used by the ordinary solve kernels."""
+        return self._solve_block_size
+
+    @property
+    def sequential_block_indices(self) -> tuple[int, ...]:
+        """Return blocks assigned to sequential LLT kernels."""
+        return self._sequential_block_indices_host
+
+    @property
+    def tiled_block_indices(self) -> tuple[int, ...]:
+        """Return blocks assigned to dense tiled LLT kernels."""
+        return self._tiled_block_indices_host
+
+    @property
+    def rcm_block_indices(self) -> tuple[int, ...]:
+        """Return blocks assigned to RCM semi-sparse LLT kernels."""
+        return self._rcm_block_indices_host
+
+    @property
+    def uses_reordering(self) -> bool:
+        """Return whether any block uses an RCM permutation."""
+        return self._rcm_solver is not None
+
+    @property
+    def P(self) -> wp.array[wp.int32]:
+        """Return packed permutations, including identity on non-RCM blocks."""
+        if self._rcm_solver is None:
+            raise ValueError("No blocks use an RCM permutation.")
+        return self._rcm_solver.P
+
+    @property
+    def inv_P(self) -> wp.array[wp.int32]:
+        """Return packed inverse permutations, including identity elsewhere."""
+        if self._rcm_solver is None:
+            raise ValueError("No blocks use an RCM permutation.")
+        return self._rcm_solver.inv_P
+
+    @override
+    def _allocate_impl(self, A: DenseLinearOperatorData, **kwargs: Any) -> None:
+        super()._allocate_impl(A, **kwargs)
+        info = self._operator.info
+        dimensions = info.dimensions
+        if dimensions is None:
+            raise ValueError("Hybrid LLT requires host-side block dimensions.")
+        if self._symbolic_adjacency is not None and len(self._symbolic_adjacency) != info.num_blocks:
+            raise ValueError("symbolic_adjacency must contain one graph per matrix block.")
+
+        dimensions_np = np.asarray(dimensions, dtype=np.int32)
+        sequential_mask = dimensions_np <= self._sequential_block_size
+        sequential_indices = np.flatnonzero(sequential_mask).astype(np.int32).tolist()
+        tiled_indices = np.flatnonzero(~sequential_mask).astype(np.int32).tolist()
+        rcm_indices = []
+        if self._symbolic_adjacency is not None:
+            rcm_indices = []
+            retained_tiled_indices = []
+            for block in tiled_indices:
+                if self._is_rcm_block(block, dimensions[block]):
+                    rcm_indices.append(block)
+                else:
+                    retained_tiled_indices.append(block)
+            tiled_indices = retained_tiled_indices
+
+        self._sequential_block_indices_host = tuple(sequential_indices)
+        self._tiled_block_indices_host = tuple(tiled_indices)
+        self._rcm_block_indices_host = tuple(rcm_indices)
+        with wp.ScopedDevice(self._device):
+            if sequential_indices:
+                self._sequential_block_indices = wp.array(sequential_indices, dtype=wp.int32)
+                self._sequential_dim = wp.empty(len(sequential_indices), dtype=wp.int32)
+                self._sequential_mio = wp.empty(len(sequential_indices), dtype=wp.int32)
+                self._sequential_vio = wp.empty(len(sequential_indices), dtype=wp.int32)
+            if tiled_indices:
+                self._tiled_block_indices = wp.array(tiled_indices, dtype=wp.int32)
+                self._tiled_dim = wp.empty(len(tiled_indices), dtype=wp.int32)
+                self._tiled_mio = wp.empty(len(tiled_indices), dtype=wp.int32)
+                self._tiled_vio = wp.empty(len(tiled_indices), dtype=wp.int32)
+
+        if sequential_indices:
+            wp.launch(
+                _gather_block_info,
+                dim=len(sequential_indices),
+                inputs=[self._sequential_block_indices, info.dim, info.mio, info.vio],
+                outputs=[self._sequential_dim, self._sequential_mio, self._sequential_vio],
+                device=self._device,
+            )
+        if tiled_indices:
+            wp.launch(
+                _gather_block_info,
+                dim=len(tiled_indices),
+                inputs=[self._tiled_block_indices, info.dim, info.mio, info.vio],
+                outputs=[self._tiled_dim, self._tiled_mio, self._tiled_vio],
+                device=self._device,
+            )
+
+        if rcm_indices:
+            self._rcm_solver = _SubsetLLTBlockedRCMSolver(
+                operator=A,
+                block_indices=rcm_indices,
+                shared_factor=self._L,
+                shared_intermediate=self._y,
+                block_size=self._rcm_block_size,
+                solve_block_dim=self._solve_block_dim,
+                factorize_block_dim=self._factorize_block_dim,
+                symbolic_adjacency=self._symbolic_adjacency,
+                parallel_factorization=self._rcm_parallel_factorization,
+                dtype=self._dtype,
+                device=self._device,
+            )
+
+    def _is_rcm_block(self, block: int, dimension: int) -> bool:
+        if self._symbolic_adjacency is None or dimension < self._rcm_min_dimension:
+            return False
+        adjacency = self._symbolic_adjacency[block]
+        cache_key = (dimension, id(adjacency))
+        decision = self._rcm_block_decisions.get(cache_key)
+        if decision is not None:
+            return decision
+        _, _, tile_pattern, _ = _fixed_symbolic_data([dimension], [adjacency], self._rcm_block_size)
+        tile_count = (dimension + self._rcm_block_size - 1) // self._rcm_block_size
+        lower_tile_count = tile_count * (tile_count + 1) // 2
+        fill_ratio = sum(tile_pattern) / lower_tile_count
+        decision = fill_ratio <= self._rcm_max_fill_ratio
+        self._rcm_block_decisions[cache_key] = decision
+        return decision
+
+    @override
+    def _reset_impl(self) -> None:
+        super()._reset_impl()
+        if self._rcm_solver is not None:
+            self._rcm_solver._reset_impl()
+
+    def _gather_dimensions(self) -> None:
+        info = self._operator.info
+        if self._sequential_block_indices_host:
+            wp.launch(
+                _gather_block_dimensions,
+                dim=len(self._sequential_block_indices_host),
+                inputs=[self._sequential_block_indices, info.dim],
+                outputs=[self._sequential_dim],
+                device=self._device,
+            )
+        if self._tiled_block_indices_host:
+            wp.launch(
+                _gather_block_dimensions,
+                dim=len(self._tiled_block_indices_host),
+                inputs=[self._tiled_block_indices, info.dim],
+                outputs=[self._tiled_dim],
+                device=self._device,
+            )
+
+    @override
+    def _factorize_impl(self, A: wp.array) -> None:
+        self._gather_dimensions()
+        if self._sequential_block_indices_host:
+            factorize.llt_sequential_factorize(
+                num_blocks=len(self._sequential_block_indices_host),
+                dim=self._sequential_dim,
+                mio=self._sequential_mio,
+                A=A,
+                L=self._L,
+            )
+        if self._tiled_block_indices_host:
+            factorize.llt_blocked_factorize(
+                kernel=self._factorize_kernel,
+                num_blocks=len(self._tiled_block_indices_host),
+                block_dim=self._factorize_block_dim,
+                dim=self._tiled_dim,
+                mio=self._tiled_mio,
+                A=A,
+                L=self._L,
+            )
+        if self._rcm_solver is not None:
+            self._rcm_solver._factorize_impl(A)
+
+    @override
+    def _solve_impl(self, b: wp.array, x: wp.array) -> None:
+        if self._sequential_block_indices_host:
+            factorize.llt_sequential_solve(
+                num_blocks=len(self._sequential_block_indices_host),
+                dim=self._sequential_dim,
+                mio=self._sequential_mio,
+                vio=self._sequential_vio,
+                L=self._L,
+                b=b,
+                y=self._y,
+                x=x,
+            )
+        if self._tiled_block_indices_host:
+            factorize.llt_blocked_solve(
+                kernel=self._solve_kernel,
+                num_blocks=len(self._tiled_block_indices_host),
+                block_dim=self._solve_block_dim,
+                dim=self._tiled_dim,
+                mio=self._tiled_mio,
+                vio=self._tiled_vio,
+                L=self._L,
+                b=b,
+                y=self._y,
+                x=x,
+            )
+        if self._rcm_solver is not None:
+            self._rcm_solver._solve_impl(b, x)
+
+    @override
+    def _solve_inplace_impl(self, x: wp.array) -> None:
+        if self._sequential_block_indices_host:
+            factorize.llt_sequential_solve_inplace(
+                num_blocks=len(self._sequential_block_indices_host),
+                dim=self._sequential_dim,
+                mio=self._sequential_mio,
+                vio=self._sequential_vio,
+                L=self._L,
+                x=x,
+            )
+        if self._tiled_block_indices_host:
+            factorize.llt_blocked_solve_inplace(
+                kernel=self._solve_inplace_kernel,
+                num_blocks=len(self._tiled_block_indices_host),
+                block_dim=self._solve_block_dim,
+                dim=self._tiled_dim,
+                mio=self._tiled_mio,
+                vio=self._tiled_vio,
+                L=self._L,
+                y=self._y,
+                x=x,
+            )
+        if self._rcm_solver is not None:
+            self._rcm_solver._solve_inplace_impl(x)

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm.py
@@ -48,6 +48,7 @@ from ._tile_builtins import (
 __all__ = [
     "llt_blocked_rcm_factorize",
     "llt_blocked_rcm_fused_permute_and_tp",
+    "llt_blocked_rcm_permute_matrix",
     "llt_blocked_rcm_permute_vector",
     "llt_blocked_rcm_solve",
     "llt_blocked_rcm_solve_inplace",
@@ -55,6 +56,7 @@ __all__ = [
     "make_llt_blocked_rcm_factorize_kernel",
     "make_llt_blocked_rcm_fused_permute_and_tp_kernel",
     "make_llt_blocked_rcm_parallel_factorize_kernels",
+    "make_llt_blocked_rcm_permute_matrix_kernel",
     "make_llt_blocked_rcm_permute_vector_kernel",
     "make_llt_blocked_rcm_solve_inplace_kernel",
     "make_llt_blocked_rcm_solve_kernel",
@@ -205,6 +207,44 @@ def make_llt_blocked_rcm_fused_permute_and_tp_kernel(block_size: int, max_dim: i
             wp.atomic_max(tile_pattern, tp_off + tr * n_tiles + tc, int(1))
 
     return fused_permute_and_tp_kernel
+
+
+@cache
+def make_llt_blocked_rcm_permute_matrix_kernel(max_dim: int):
+    """Build the lower triangle of ``A_hat = P A P^T`` for a fixed permutation."""
+    del max_dim
+
+    @wp.kernel
+    def permute_matrix_kernel(
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        P: wp.array[wp.int32],
+        A: wp.array[wp.float32],
+        A_hat: wp.array[wp.float32],
+    ):
+        b, triangular_index = wp.tid()
+        n_i = dim[b]
+        triangular_size = n_i * (n_i + 1) // 2
+        if triangular_index >= triangular_size:
+            return
+
+        r = int((wp.sqrt(float(8 * triangular_index + 1)) - float(1)) * float(0.5))
+        row_start = r * (r + 1) // 2
+        if row_start > triangular_index:
+            r -= 1
+            row_start = r * (r + 1) // 2
+        elif (r + 1) * (r + 2) // 2 <= triangular_index:
+            r += 1
+            row_start = r * (r + 1) // 2
+        c = triangular_index - row_start
+        mat_off = mio[b]
+        vec_off = vio[b]
+        p_r = P[vec_off + r]
+        p_c = P[vec_off + c]
+        A_hat[mat_off + r * n_i + c] = A[mat_off + p_r * n_i + p_c]
+
+    return permute_matrix_kernel
 
 
 @cache
@@ -510,7 +550,7 @@ def make_llt_blocked_rcm_parallel_factorize_kernels(block_size: int):
 
 
 @cache
-def make_llt_blocked_rcm_solve_kernel(block_size: int):
+def make_llt_blocked_rcm_solve_kernel(block_size: int, compact_traversal: bool = False):
     """RCM solve with tile skipping and fused output un-permutation.
 
     The solve gathers the RHS into permuted coordinates, writes ``x_hat`` in
@@ -528,6 +568,7 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
         P: wp.array[wp.int32],
         L: wp.array[wp.float32],
         tile_pattern: wp.array[wp.int32],
+        tile_traversal: wp.array[wp.int32],
         b: wp.array[wp.float32],
         # Outputs:
         y: wp.array[wp.float32],
@@ -575,13 +616,24 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
                 wp.tile_scatter_masked(rhs_tile, row, 0, value, active)
             L_diag = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, i))
             if i > 0:
-                for j in range(0, i, block_size):
-                    tile_j = j // block_size
-                    if TP_i[tile_i, tile_j] == int(0):
-                        continue
-                    L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
-                    y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
-                    wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
+                if wp.static(compact_traversal):
+                    traversal_offset = 2 * tp_i_start + tile_i * n_tiles
+                    for slot in range(n_tiles):
+                        tile_j = tile_traversal[traversal_offset + slot]
+                        if tile_j < 0:
+                            break
+                        j = tile_j * block_size
+                        L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
+                        y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
+                        wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
+                else:
+                    for j in range(0, i, block_size):
+                        tile_j = j // block_size
+                        if TP_i[tile_i, tile_j] == int(0):
+                            continue
+                        L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
+                        y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
+                        wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
             wp.tile_lower_solve_inplace(L_diag, rhs_tile)
             wp.tile_store(y_i, rhs_tile, offset=(i, 0))
 
@@ -606,21 +658,40 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
-                for j in range(i_end, n_i_padded, block_size):
-                    tile_j = j // block_size
-                    if TP_i[tile_j, tile_i] == int(0):
-                        continue
-                    L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
-                    x_tile = wp.tile_load(x_hat_i, shape=(block_size, 1), offset=(j, 0))
-                    if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
-                        wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
-                    elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
-                        wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
-                            rhs_tile, L_tile, x_tile, -1.0
-                        )
-                    else:
-                        L_T_tile = wp.tile_transpose(L_tile)
-                        wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
+                if wp.static(compact_traversal):
+                    traversal_offset = 2 * tp_i_start + n_tiles * n_tiles + tile_i * n_tiles
+                    for slot in range(n_tiles):
+                        tile_j = tile_traversal[traversal_offset + slot]
+                        if tile_j < 0:
+                            break
+                        j = tile_j * block_size
+                        L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
+                        x_tile = wp.tile_load(x_hat_i, shape=(block_size, 1), offset=(j, 0))
+                        if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
+                        elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
+                                rhs_tile, L_tile, x_tile, -1.0
+                            )
+                        else:
+                            L_T_tile = wp.tile_transpose(L_tile)
+                            wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
+                else:
+                    for j in range(i_end, n_i_padded, block_size):
+                        tile_j = j // block_size
+                        if TP_i[tile_j, tile_i] == int(0):
+                            continue
+                        L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
+                        x_tile = wp.tile_load(x_hat_i, shape=(block_size, 1), offset=(j, 0))
+                        if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
+                        elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
+                                rhs_tile, L_tile, x_tile, -1.0
+                            )
+                        else:
+                            L_T_tile = wp.tile_transpose(L_tile)
+                            wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
 
             wp.tile_upper_solve_inplace(wp.tile_transpose(L_diag), rhs_tile)
             wp.tile_store(x_hat_i, rhs_tile, offset=(i, 0))
@@ -636,7 +707,7 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
 
 
 @cache
-def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
+def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int, compact_traversal: bool = False):
     """Clone of :func:`llt_blocked.make_llt_blocked_solve_inplace_kernel` with tile skipping.
 
     Takes ``x`` as in/out; forward substitution reads from ``x`` (as b) and
@@ -652,6 +723,7 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
         tpo: wp.array[wp.int32],
         L: wp.array[wp.float32],
         tile_pattern: wp.array[wp.int32],
+        tile_traversal: wp.array[wp.int32],
         # Outputs:
         y: wp.array[wp.float32],
         x: wp.array[wp.float32],
@@ -683,13 +755,24 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
             rhs_tile = wp.tile_load(x_i, shape=(block_size, 1), offset=(i, 0))
             L_diag = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, i))
             if i > 0:
-                for j in range(0, i, block_size):
-                    tile_j = j // block_size
-                    if TP_i[tile_i, tile_j] == int(0):
-                        continue
-                    L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
-                    y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
-                    wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
+                if wp.static(compact_traversal):
+                    traversal_offset = 2 * tp_i_start + tile_i * n_tiles
+                    for slot in range(n_tiles):
+                        tile_j = tile_traversal[traversal_offset + slot]
+                        if tile_j < 0:
+                            break
+                        j = tile_j * block_size
+                        L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
+                        y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
+                        wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
+                else:
+                    for j in range(0, i, block_size):
+                        tile_j = j // block_size
+                        if TP_i[tile_i, tile_j] == int(0):
+                            continue
+                        L_block = wp.tile_load(L_i, shape=(block_size, block_size), offset=(i, j))
+                        y_block = wp.tile_load(y_i, shape=(block_size, 1), offset=(j, 0))
+                        wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
             wp.tile_lower_solve_inplace(L_diag, rhs_tile)
             wp.tile_store(y_i, rhs_tile, offset=(i, 0))
 
@@ -714,21 +797,40 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
-                for j in range(i_end, n_i_padded, block_size):
-                    tile_j = j // block_size
-                    if TP_i[tile_j, tile_i] == int(0):
-                        continue
-                    L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
-                    x_tile = wp.tile_load(x_i, shape=(block_size, 1), offset=(j, 0))
-                    if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
-                        wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
-                    elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
-                        wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
-                            rhs_tile, L_tile, x_tile, -1.0
-                        )
-                    else:
-                        L_T_tile = wp.tile_transpose(L_tile)
-                        wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
+                if wp.static(compact_traversal):
+                    traversal_offset = 2 * tp_i_start + n_tiles * n_tiles + tile_i * n_tiles
+                    for slot in range(n_tiles):
+                        tile_j = tile_traversal[traversal_offset + slot]
+                        if tile_j < 0:
+                            break
+                        j = tile_j * block_size
+                        L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
+                        x_tile = wp.tile_load(x_i, shape=(block_size, 1), offset=(j, 0))
+                        if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
+                        elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
+                                rhs_tile, L_tile, x_tile, -1.0
+                            )
+                        else:
+                            L_T_tile = wp.tile_transpose(L_tile)
+                            wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
+                else:
+                    for j in range(i_end, n_i_padded, block_size):
+                        tile_j = j // block_size
+                        if TP_i[tile_j, tile_i] == int(0):
+                            continue
+                        L_tile = wp.tile_load(L_i, shape=(block_size, block_size), offset=(j, i))
+                        x_tile = wp.tile_load(x_i, shape=(block_size, 1), offset=(j, 0))
+                        if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.tile_matmul_left_transpose_update(rhs_tile, L_tile, x_tile, alpha=-1.0)
+                        elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                            wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
+                                rhs_tile, L_tile, x_tile, -1.0
+                            )
+                        else:
+                            L_T_tile = wp.tile_transpose(L_tile)
+                            wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
 
             wp.tile_upper_solve_inplace(wp.tile_transpose(L_diag), rhs_tile)
             wp.tile_store(x_i, rhs_tile, offset=(i, 0))
@@ -786,6 +888,27 @@ def llt_blocked_rcm_fused_permute_and_tp(
         kernel=kernel,
         dim=(num_blocks, max_dim * (max_dim + 1) // 2),
         inputs=[dim, mio, vio, tpo, float(tol), P, A, A_hat, inv_P, tile_pattern],
+        device=device,
+    )
+
+
+def llt_blocked_rcm_permute_matrix(
+    kernel,
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    P: wp.array[wp.int32],
+    A: wp.array[wp.float32],
+    A_hat: wp.array[wp.float32],
+    num_blocks: int,
+    max_dim: int,
+    device: wp.DeviceLike = None,
+):
+    """Permute a batched matrix using an already initialized permutation."""
+    wp.launch(
+        kernel=kernel,
+        dim=(num_blocks, max_dim * (max_dim + 1) // 2),
+        inputs=[dim, mio, vio, P, A, A_hat],
         device=device,
     )
 
@@ -873,6 +996,7 @@ def llt_blocked_rcm_solve(
     P: wp.array[wp.int32],
     L: wp.array[wp.float32],
     tile_pattern: wp.array[wp.int32],
+    tile_traversal: wp.array[wp.int32],
     b: wp.array[wp.float32],
     y: wp.array[wp.float32],
     x_hat: wp.array[wp.float32],
@@ -885,7 +1009,7 @@ def llt_blocked_rcm_solve(
     wp.launch_tiled(
         kernel=kernel,
         dim=num_blocks,
-        inputs=[dim, mio, vio, tpo, P, L, tile_pattern, b, y, x_hat, x],
+        inputs=[dim, mio, vio, tpo, P, L, tile_pattern, tile_traversal, b, y, x_hat, x],
         block_dim=block_dim,
         device=device,
     )
@@ -899,6 +1023,7 @@ def llt_blocked_rcm_solve_inplace(
     tpo: wp.array[wp.int32],
     L: wp.array[wp.float32],
     tile_pattern: wp.array[wp.int32],
+    tile_traversal: wp.array[wp.int32],
     y: wp.array[wp.float32],
     x: wp.array[wp.float32],
     num_blocks: int = 1,
@@ -909,7 +1034,7 @@ def llt_blocked_rcm_solve_inplace(
     wp.launch_tiled(
         kernel=kernel,
         dim=num_blocks,
-        inputs=[dim, mio, vio, tpo, L, tile_pattern, y, x],
+        inputs=[dim, mio, vio, tpo, L, tile_pattern, tile_traversal, y, x],
         block_dim=block_dim,
         device=device,
     )

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
@@ -24,8 +24,12 @@ for debugging/introspection.
 
 from __future__ import annotations
 
+from collections import deque
+from collections.abc import Sequence
+from functools import lru_cache
 from typing import Any
 
+import numpy as np
 import warp as wp
 
 from ......core.types import override
@@ -37,6 +41,7 @@ from .llt_blocked_rcm import (
     llt_blocked_rcm_factorize,
     llt_blocked_rcm_factorize_parallel,
     llt_blocked_rcm_fused_permute_and_tp,
+    llt_blocked_rcm_permute_matrix,
     llt_blocked_rcm_permute_vector,
     llt_blocked_rcm_solve,
     llt_blocked_rcm_solve_inplace,
@@ -44,6 +49,7 @@ from .llt_blocked_rcm import (
     make_llt_blocked_rcm_factorize_kernel,
     make_llt_blocked_rcm_fused_permute_and_tp_kernel,
     make_llt_blocked_rcm_parallel_factorize_kernels,
+    make_llt_blocked_rcm_permute_matrix_kernel,
     make_llt_blocked_rcm_permute_vector_kernel,
     make_llt_blocked_rcm_solve_inplace_kernel,
     make_llt_blocked_rcm_solve_kernel,
@@ -62,6 +68,123 @@ __all__ = ["LLTBlockedRCMSolver"]
 ###
 
 wp.set_module_options({"enable_backward": False})
+
+
+def _reverse_cuthill_mckee(adjacency: Sequence[set[int]]) -> list[int]:
+    """Compute a deterministic RCM permutation for a host-side graph."""
+    degrees = [len(neighbors) for neighbors in adjacency]
+    remaining = set(range(len(adjacency)))
+    order = []
+    while remaining:
+        root = min(remaining, key=lambda vertex: (degrees[vertex], vertex))
+        queue = deque([root])
+        remaining.remove(root)
+        while queue:
+            vertex = queue.popleft()
+            order.append(vertex)
+            neighbors = sorted(
+                (neighbor for neighbor in adjacency[vertex] if neighbor in remaining),
+                key=lambda neighbor: (degrees[neighbor], neighbor),
+            )
+            for neighbor in neighbors:
+                remaining.remove(neighbor)
+                queue.append(neighbor)
+    order.reverse()
+    return order
+
+
+@lru_cache(maxsize=32)
+def _fixed_symbolic_block_data(
+    dimension: int,
+    adjacency_rows: tuple[tuple[int, ...], ...],
+    block_size: int,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Build reusable symbolic data for one matrix block."""
+    if len(adjacency_rows) != dimension:
+        raise ValueError("Each symbolic adjacency graph must match its matrix dimension.")
+    adjacency = []
+    for row, neighbors in enumerate(adjacency_rows):
+        neighbor_set = {int(neighbor) for neighbor in neighbors}
+        if any(neighbor < 0 or neighbor >= dimension for neighbor in neighbor_set):
+            raise ValueError("Symbolic adjacency indices must reference their matrix block.")
+        neighbor_set.discard(row)
+        adjacency.append(neighbor_set)
+    if any(row not in adjacency[neighbor] for row, neighbors in enumerate(adjacency) for neighbor in neighbors):
+        raise ValueError("symbolic_adjacency must be symmetric.")
+
+    permutation = _reverse_cuthill_mckee(adjacency)
+    inverse = [0] * dimension
+    for reordered, original in enumerate(permutation):
+        inverse[original] = reordered
+
+    tile_count = (dimension + block_size - 1) // block_size
+    tile_pattern = [0] * (tile_count * tile_count)
+    for tile in range(tile_count):
+        tile_pattern[tile * tile_count + tile] = 1
+    for original_row, neighbors in enumerate(adjacency):
+        tile_row = inverse[original_row] // block_size
+        for original_col in neighbors:
+            tile_col = inverse[original_col] // block_size
+            high = max(tile_row, tile_col)
+            low = min(tile_row, tile_col)
+            tile_pattern[high * tile_count + low] = 1
+
+    for column in range(tile_count):
+        for row in range(column + 1, tile_count):
+            if tile_pattern[row * tile_count + column] != 0:
+                continue
+            for previous in range(column):
+                if tile_pattern[row * tile_count + previous] != 0 and tile_pattern[column * tile_count + previous] != 0:
+                    tile_pattern[row * tile_count + column] = 1
+                    break
+
+    tile_traversal = [-1] * (2 * tile_count * tile_count)
+    backward_offset = tile_count * tile_count
+    for row in range(tile_count):
+        forward = [column for column in range(row) if tile_pattern[row * tile_count + column] != 0]
+        backward = [
+            following for following in range(row + 1, tile_count) if tile_pattern[following * tile_count + row] != 0
+        ]
+        row_offset = row * tile_count
+        tile_traversal[row_offset : row_offset + len(forward)] = forward
+        tile_traversal[backward_offset + row_offset : backward_offset + row_offset + len(backward)] = backward
+    return tuple(permutation), tuple(inverse), tuple(tile_pattern), tuple(tile_traversal)
+
+
+def _fixed_symbolic_data(
+    dimensions: Sequence[int],
+    adjacency_blocks: Sequence[Sequence[Sequence[int]]],
+    block_size: int,
+) -> tuple[list[int], list[int], list[int], list[int]]:
+    """Build packed permutations, filled tile patterns, and ordered solve work."""
+    if len(adjacency_blocks) != len(dimensions):
+        raise ValueError("symbolic_adjacency must contain one graph per matrix block.")
+
+    packed_permutation = []
+    packed_inverse = []
+    packed_tile_pattern = []
+    packed_tile_traversal = []
+    block_cache = {}
+    for dimension, adjacency_rows in zip(dimensions, adjacency_blocks, strict=True):
+        cache_key = (dimension, id(adjacency_rows))
+        block_data = block_cache.get(cache_key)
+        if block_data is None:
+            try:
+                hash(adjacency_rows)
+                normalized_adjacency = adjacency_rows
+            except TypeError:
+                normalized_adjacency = tuple(
+                    tuple(int(neighbor) for neighbor in neighbors) for neighbors in adjacency_rows
+                )
+            block_data = _fixed_symbolic_block_data(dimension, normalized_adjacency, block_size)
+            block_cache[cache_key] = block_data
+        permutation, inverse, tile_pattern, tile_traversal = block_data
+        packed_permutation.extend(permutation)
+        packed_inverse.extend(inverse)
+        packed_tile_pattern.extend(tile_pattern)
+        packed_tile_traversal.extend(tile_traversal)
+
+    return packed_permutation, packed_inverse, packed_tile_pattern, packed_tile_traversal
 
 
 class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
@@ -111,6 +234,7 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
         rcm_max_bfs_iters: int | None = None,
         reuse_permutation: bool = True,
         parallel_factorization: bool = False,
+        symbolic_adjacency: Sequence[Sequence[Sequence[int]]] | None = None,
         dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
@@ -131,6 +255,10 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
                 pattern is still rebuilt each time. Defaults to ``True``.
             parallel_factorization: whether to solve off-diagonal tiles of
                 each Cholesky panel in parallel. Defaults to ``False``.
+            symbolic_adjacency: optional fixed structural adjacency for every
+                matrix block. When provided, ordering and symbolic Cholesky
+                fill are computed once during allocation and reused by every
+                numeric factorization.
         """
         # The underlying kernels (factorize / solve / permute / tile-pattern)
         # are hard-coded to wp.float32, so reject any other dtype up front
@@ -147,6 +275,7 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
         self._P: wp.array[wp.int32] | None = None
         self._inv_P: wp.array[wp.int32] | None = None
         self._tile_pattern: wp.array[wp.int32] | None = None
+        self._tile_traversal: wp.array[wp.int32] | None = None
         self._tpo: wp.array[wp.int32] | None = None
         # Batched-RCM scratch (owned here so the recorded launches in
         # ``_reorder_callback`` never reference buffers that outlive our
@@ -173,15 +302,18 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
         self._rcm_max_bfs_iters = rcm_max_bfs_iters
         self._reuse_permutation = reuse_permutation
         self._parallel_factorization = parallel_factorization
+        self._symbolic_adjacency = symbolic_adjacency
 
         # Build kernels (cached by block_size / max_dim at allocate time).
         self._factorize_kernel = make_llt_blocked_rcm_factorize_kernel(block_size)
         self._parallel_factorize_kernels = make_llt_blocked_rcm_parallel_factorize_kernels(block_size)
-        self._solve_kernel = make_llt_blocked_rcm_solve_kernel(block_size)
-        self._solve_inplace_kernel = make_llt_blocked_rcm_solve_inplace_kernel(block_size)
+        compact_traversal = symbolic_adjacency is not None
+        self._solve_kernel = make_llt_blocked_rcm_solve_kernel(block_size, compact_traversal)
+        self._solve_inplace_kernel = make_llt_blocked_rcm_solve_inplace_kernel(block_size, compact_traversal)
         # Auxiliary kernels resolved in _allocate_impl once we know max_dim.
         self._permute_vector_kernel = None
         self._fused_permute_and_tp_kernel = None
+        self._permute_matrix_kernel = None
         self._symbolic_fill_in_kernel = None
 
         # Initialize base class members
@@ -232,6 +364,11 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
             raise ValueError("Tile pattern array has not been allocated!")
         return self._tile_pattern
 
+    @property
+    def block_size(self) -> int:
+        """Return the tile size used by factorization and solve kernels."""
+        return self._block_size
+
     ###
     # Implementation
     ###
@@ -256,18 +393,24 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
         self._fused_permute_and_tp_kernel = make_llt_blocked_rcm_fused_permute_and_tp_kernel(
             self._block_size, self._max_dim
         )
+        self._permute_matrix_kernel = make_llt_blocked_rcm_permute_matrix_kernel(self._max_dim)
         max_n_tiles = (self._max_dim + self._block_size - 1) // self._block_size
         self._symbolic_fill_in_kernel = make_llt_blocked_rcm_symbolic_fill_in_kernel(max_n_tiles)
 
         # Per-block tile-pattern layout: n_tiles_i^2 entries per block.
-        # Computed on host once from info.dimensions (a cheap list).
+        # Compute all offsets at once from the cached host dimensions.
         dims = list(info.dimensions)
         bs = self._block_size
-        tp_sizes = [((d + bs - 1) // bs) ** 2 for d in dims]
-        tp_offsets = [0]
-        for s in tp_sizes:
-            tp_offsets.append(tp_offsets[-1] + s)
-        total_tp_size = tp_offsets[-1]
+        dims_np = np.asarray(dims, dtype=np.int64)
+        tile_counts = (dims_np + bs - 1) // bs
+        tp_offsets = np.empty(len(dims) + 1, dtype=np.int64)
+        tp_offsets[0] = 0
+        np.cumsum(tile_counts * tile_counts, out=tp_offsets[1:])
+        total_tp_size = int(tp_offsets[-1])
+
+        fixed_symbolic_data = None
+        if self._symbolic_adjacency is not None:
+            fixed_symbolic_data = _fixed_symbolic_data(dims, self._symbolic_adjacency, self._block_size)
 
         with wp.ScopedDevice(self._device):
             # Factorization + intermediate buffers.
@@ -284,6 +427,8 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
 
             # Tile-pattern flat storage + offsets.
             self._tile_pattern = wp.zeros(shape=(total_tp_size,), dtype=wp.int32)
+            traversal_size = len(fixed_symbolic_data[3]) if fixed_symbolic_data is not None else 0
+            self._tile_traversal = wp.empty(shape=(max(1, traversal_size),), dtype=wp.int32)
             self._tpo = to_warp_int32_array(tp_offsets[:-1])
 
             # Batched-RCM scratch. Owning these here matches how the other
@@ -294,6 +439,14 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
                 num_blocks=info.num_blocks,
                 device=self._device,
             )
+
+            if fixed_symbolic_data is not None:
+                permutation, inverse, tile_pattern, tile_traversal = fixed_symbolic_data
+                self._P.assign(permutation)
+                self._inv_P.assign(inverse)
+                self._tile_pattern.assign(tile_pattern)
+                if tile_traversal:
+                    self._tile_traversal.assign(tile_traversal)
 
         # The batched-RCM launch callback (``self._reorder_callback``) is
         # (re)built lazily in ``_ensure_reorder_launches_bound`` the first
@@ -308,14 +461,15 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
         self._y.zero_()
         self._A_hat.zero_()
         self._x_hat.zero_()
-        self._P.zero_()
-        self._rcm_scratch["permutation_valid"].zero_()
-        self._rcm_scratch["permutation_dim"].zero_()
-        self._inv_P.zero_()
-        self._permutation_initialized = False
-        self._permutation_initialized_during_capture = False
-        self._permutation_capture_id = None
-        self._tile_pattern.zero_()
+        if self._symbolic_adjacency is None:
+            self._P.zero_()
+            self._rcm_scratch["permutation_valid"].zero_()
+            self._rcm_scratch["permutation_dim"].zero_()
+            self._inv_P.zero_()
+            self._permutation_initialized = False
+            self._permutation_initialized_during_capture = False
+            self._permutation_capture_id = None
+            self._tile_pattern.zero_()
         self._has_factors = False
 
     def _ensure_reorder_launches_bound(self, A: wp.array[Any]) -> None:
@@ -349,6 +503,56 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
 
     @override
     def _factorize_impl(self, A: wp.array[Any]) -> None:
+        info = self._operator.info
+        num_blocks = info.num_blocks
+
+        if self._symbolic_adjacency is not None:
+            llt_blocked_rcm_permute_matrix(
+                kernel=self._permute_matrix_kernel,
+                dim=info.dim,
+                mio=info.mio,
+                vio=info.vio,
+                P=self._P,
+                A=A,
+                A_hat=self._A_hat,
+                num_blocks=num_blocks,
+                max_dim=self._max_dim,
+                device=self._device,
+            )
+        else:
+            self._factorize_symbolic_and_permute(A)
+
+        # Numeric factorization with tile-pattern skips.
+        if self._parallel_factorization:
+            llt_blocked_rcm_factorize_parallel(
+                kernels=self._parallel_factorize_kernels,
+                dim=info.dim,
+                mio=info.mio,
+                tpo=self._tpo,
+                A=self._A_hat,
+                tile_pattern=self._tile_pattern,
+                L=self._L,
+                num_blocks=num_blocks,
+                max_tiles=(self._max_dim + self._block_size - 1) // self._block_size,
+                block_dim=self._factorize_block_dim,
+                device=self._device,
+            )
+        else:
+            llt_blocked_rcm_factorize(
+                kernel=self._factorize_kernel,
+                dim=info.dim,
+                mio=info.mio,
+                tpo=self._tpo,
+                A=self._A_hat,
+                tile_pattern=self._tile_pattern,
+                L=self._L,
+                num_blocks=num_blocks,
+                block_dim=self._factorize_block_dim,
+                device=self._device,
+            )
+
+    def _factorize_symbolic_and_permute(self, A: wp.array[Any]) -> None:
+        """Refresh numeric-derived symbolic data for the compatibility path."""
         info = self._operator.info
         num_blocks = info.num_blocks
         is_capturing = bool(self._device.is_capturing)
@@ -424,35 +628,6 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
             device=self._device,
         )
 
-        # 4. Numeric factorization with tile-pattern skips.
-        if self._parallel_factorization:
-            llt_blocked_rcm_factorize_parallel(
-                kernels=self._parallel_factorize_kernels,
-                dim=info.dim,
-                mio=info.mio,
-                tpo=self._tpo,
-                A=self._A_hat,
-                tile_pattern=self._tile_pattern,
-                L=self._L,
-                num_blocks=num_blocks,
-                max_tiles=(self._max_dim + self._block_size - 1) // self._block_size,
-                block_dim=self._factorize_block_dim,
-                device=self._device,
-            )
-        else:
-            llt_blocked_rcm_factorize(
-                kernel=self._factorize_kernel,
-                dim=info.dim,
-                mio=info.mio,
-                tpo=self._tpo,
-                A=self._A_hat,
-                tile_pattern=self._tile_pattern,
-                L=self._L,
-                num_blocks=num_blocks,
-                block_dim=self._factorize_block_dim,
-                device=self._device,
-            )
-
     @override
     def _reconstruct_impl(self, A: wp.array[Any]) -> None:
         raise NotImplementedError("LLT matrix reconstruction is not yet implemented.")
@@ -472,6 +647,7 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
             P=self._P,
             L=self._L,
             tile_pattern=self._tile_pattern,
+            tile_traversal=self._tile_traversal,
             b=b,
             y=self._y,
             x_hat=self._x_hat,
@@ -508,6 +684,7 @@ class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
             tpo=self._tpo,
             L=self._L,
             tile_pattern=self._tile_pattern,
+            tile_traversal=self._tile_traversal,
             y=self._y,
             x=self._x_hat,
             num_blocks=num_blocks,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -60,6 +60,7 @@ from .linalg import ConjugateResidualSolver, ConjugateResidualSolverFused, Itera
 from .solvers.common import WarmStartMode
 from .solvers.dvi import DVISolver
 from .solvers.fk import ForwardKinematicsSolver
+from .solvers.lox import LOXSolver
 from .solvers.metrics import SolutionMetrics
 from .solvers.padmm import PADMMSolver
 from .solvers.warmstart import WarmstarterContacts, WarmstarterLimits
@@ -158,6 +159,9 @@ class SolverKaminoImpl(SolverBase):
         elif config.dynamics_solver == "dvi":
             warmstart_mode = config.dvi.warmstart_mode
             contact_warmstart_method = config.dvi.contact_warmstart_method
+        elif config.dynamics_solver == "lox":
+            warmstart_mode = "containers"
+            contact_warmstart_method = config.lox.contact_warmstart_method
         else:
             raise ValueError(f"Unsupported dynamics solver: {config.dynamics_solver}")
         self._warmstart_mode = WarmStartMode.from_string(warmstart_mode)
@@ -239,21 +243,47 @@ class SolverKaminoImpl(SolverBase):
                 contacts=contacts,
             )
 
-        # Allocate the dual problem data on the device
-        self._problem_fd = DualProblem(
-            model=self._model,
-            data=self._data,
-            limits=self._limits,
-            contacts=contacts,
-            jacobians=self._jacobians,
-            config=problem_fd_config,
-            solver=linear_solver_type,
-            solver_kwargs=linear_solver_kwargs,
-            sparse=self._config.sparse_dynamics,
-        )
+        self._problem_fd: DualProblem | None = None
+        self._problem_metrics: DualProblem | None = None
+        if self._config.dynamics_solver != "lox":
+            # Allocate the dual problem data on the device
+            self._problem_fd = DualProblem(
+                model=self._model,
+                data=self._data,
+                limits=self._limits,
+                contacts=contacts,
+                jacobians=self._jacobians,
+                config=problem_fd_config,
+                solver=linear_solver_type,
+                solver_kwargs=linear_solver_kwargs,
+                sparse=self._config.sparse_dynamics,
+            )
 
         # Allocate the forward dynamics solver on the device
-        if self._config.dynamics_solver == "padmm":
+        if self._config.dynamics_solver == "lox":
+            self._solver_fd = LOXSolver(
+                model=self._model,
+                data=self._data,
+                jacobians=self._jacobians,
+                limits=self._limits,
+                contacts=contacts,
+                config=self._config.lox,
+                constraints=self._config.constraints,
+                rotation_correction=self._rotation_correction,
+            )
+            if self._config.compute_solution_metrics and self._model.size.sum_of_max_total_cts > 0:
+                self._problem_metrics = DualProblem(
+                    model=self._model,
+                    data=self._data,
+                    limits=self._limits,
+                    contacts=contacts,
+                    jacobians=self._jacobians,
+                    config=problem_fd_config,
+                    solver=linear_solver_type,
+                    solver_kwargs=linear_solver_kwargs,
+                    sparse=False,
+                )
+        elif self._config.dynamics_solver == "padmm":
             self._solver_fd = PADMMSolver(
                 model=self._model,
                 config=self._config.padmm,
@@ -284,19 +314,30 @@ class SolverKaminoImpl(SolverBase):
         if self._config.use_fk_solver:
             self._solver_fk = ForwardKinematicsSolver(model=self._model, config=self._config.fk)
 
-        # Contacts generated externally are evaluated at the start of a step, so they require
-        # Euler integration. Moreau-Jean is valid only with the internal mid-step detector.
+        integrate_singular_bodies = self._config.dynamics_solver == "lox"
         if self._config.integrator == "euler":
-            self._integrator = IntegratorEuler(model=self._model)
+            self._integrator = IntegratorEuler(
+                model=self._model,
+                alpha=self._config.angular_velocity_damping,
+                integrate_singular_bodies=integrate_singular_bodies,
+            )
         elif self._config.integrator == "moreau":
             if self._config.use_collision_detector:
-                self._integrator = IntegratorMoreauJean(model=self._model)
+                self._integrator = IntegratorMoreauJean(
+                    model=self._model,
+                    alpha=self._config.angular_velocity_damping,
+                    integrate_singular_bodies=integrate_singular_bodies,
+                )
             else:
                 msg.warning(
                     "Falling back to the 'euler' integrator: 'moreau' requires "
                     "`use_collision_detector=True` to generate contacts at the mid-point."
                 )
-                self._integrator = IntegratorEuler(model=self._model)
+                self._integrator = IntegratorEuler(
+                    model=self._model,
+                    alpha=self._config.angular_velocity_damping,
+                    integrate_singular_bodies=integrate_singular_bodies,
+                )
         else:
             raise ValueError(
                 f"Unsupported integrator type: Expected 'euler' or 'moreau', but got {self._config.integrator}."
@@ -332,6 +373,11 @@ class SolverKaminoImpl(SolverBase):
         self._mid_step_cb: SolverKaminoImpl.StepCallbackType | None = None
         self._post_step_cb: SolverKaminoImpl.StepCallbackType | None = None
 
+        if self._config.dynamics_solver == "lox":
+            self._forward_dynamics = self._solver_fd.solve_forward_dynamics
+        else:
+            self._forward_dynamics = self._solve_dual_forward_dynamics
+
         # Initialize all internal solver data
         with wp.ScopedDevice(self._model.device):
             self._reset()
@@ -362,19 +408,21 @@ class SolverKaminoImpl(SolverBase):
         return self._data
 
     @property
-    def problem_fd(self) -> DualProblem:
+    def problem_fd(self) -> DualProblem | None:
         """
-        Returns the dual forward dynamics problem.
+        Returns the forward dynamics problem.
         """
         return self._problem_fd
 
     @property
     def solver_status(self) -> wp.array[Any]:
         """Returns the active forward dynamics backend's per-world status array."""
+        if self._config.dynamics_solver == "lox":
+            return self._solver_fd.status
         return self._solver_fd.data.status
 
     @property
-    def solver_fd(self) -> PADMMSolver | DVISolver:
+    def solver_fd(self) -> PADMMSolver | DVISolver | LOXSolver:
         """
         Returns the forward dynamics solver.
         """
@@ -774,11 +822,13 @@ class SolverKaminoImpl(SolverBase):
     def notify_model_changed(self, flags: ModelFlags | int) -> None:
         if self._solver_fk is not None:
             self._solver_fk.notify_model_changed(flags)
+        self._solver_fd.notify_model_changed(flags)
 
     def validate_model_changed(self, flags: ModelFlags | int) -> None:
         """Validate solver-specific structural invariants before model updates."""
         if self._solver_fk is not None:
             self._solver_fk.validate_model_changed(flags)
+        self._solver_fd.validate_model_changed()
 
     @override
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
@@ -1003,11 +1053,14 @@ class SolverKaminoImpl(SolverBase):
         Updates the forward kinematics by building the system Jacobians (of actuation and
         constraints) based on the current state of the system and set of active constraints.
         """
+        jacobian_contacts = contacts
+        if self._config.dynamics_solver == "lox" and not self._config.compute_solution_metrics:
+            jacobian_contacts = None
         self._jacobians.build(
             model=self._model,
             data=self._data,
             limits=self._limits,
-            contacts=contacts,
+            contacts=jacobian_contacts,
             reset_to_zero=True,
         )
 
@@ -1039,9 +1092,6 @@ class SolverKaminoImpl(SolverBase):
         # If warm-starting is enabled, initialize unilateral
         # constraints containers from the current solver data
         if self._warmstart_mode > WarmStartMode.NONE:
-            if self._warmstart_mode == WarmStartMode.CONTAINERS:
-                self._ws_limits.warmstart(self._limits)
-                self._ws_contacts.warmstart(self._model, self._data, contacts)
             self._solver_fd.warmstart(
                 problem=self._problem_fd,
                 model=self._model,
@@ -1079,13 +1129,6 @@ class SolverKaminoImpl(SolverBase):
             contacts=contacts,
         )
 
-        # If warmstarting is enabled, update the limits and contacts caches
-        # with the constraint reactions generated by the dynamics solver
-        # NOTE: This needs to happen after unpacking the multipliers
-        if self._warmstart_mode == WarmStartMode.CONTAINERS:
-            self._ws_limits.update(self._limits)
-            self._ws_contacts.update(contacts)
-
     def _update_wrenches(self):
         """
         Computes the total (i.e. net) body wrenches by summing up all individual contributions,
@@ -1093,7 +1136,9 @@ class SolverKaminoImpl(SolverBase):
         """
         update_body_wrenches(self._model.bodies, self._data.bodies)
 
-    def _forward(self, contacts: ContactsKamino | None = None):
+    def _solve_dual_forward_dynamics(
+        self, state_in: StateKamino, state_out: StateKamino, contacts: ContactsKamino | None = None
+    ):
         """
         Solves the forward dynamics sub-problem to compute constraint reactions
         and total effective body wrenches applied to each body of the system.
@@ -1107,7 +1152,7 @@ class SolverKaminoImpl(SolverBase):
         # Post-processing
         self._update_wrenches()
 
-    def _solve_forward_dynamics(
+    def _prepare_forward_dynamics(
         self,
         state_in: StateKamino,
         state_out: StateKamino,
@@ -1117,8 +1162,7 @@ class SolverKaminoImpl(SolverBase):
         detector: CollisionDetector | None = None,
     ):
         """
-        Solves the forward dynamics sub-problem to compute constraint reactions
-        and total effective body wrenches applied to each body of the system.
+        Prepares kinematics, topology, and actuation for a forward solve.
 
         Args:
             state_in: State of the system at the current time-step.
@@ -1165,8 +1209,47 @@ class SolverKaminoImpl(SolverBase):
         # Run the pre-step callback if it has been set
         self._run_prestep_callback(state_in, state_out, control, contacts)
 
-        # Solve the forward dynamics sub-problem to compute constraint reactions and body wrenches
-        self._forward(contacts=contacts)
+    def _solve_forward_dynamics(
+        self,
+        state_in: StateKamino,
+        state_out: StateKamino,
+        control: ControlKamino,
+        limits: LimitsKamino | None = None,
+        contacts: ContactsKamino | None = None,
+        detector: CollisionDetector | None = None,
+    ):
+        """Prepare and solve the forward dynamics sub-problem."""
+        self._prepare_forward_dynamics(
+            state_in=state_in,
+            state_out=state_out,
+            control=control,
+            limits=limits,
+            contacts=contacts,
+            detector=detector,
+        )
+
+        if self._ws_limits is not None:
+            self._ws_limits.warmstart(self._limits)
+        if self._ws_contacts is not None and contacts is not None:
+            self._ws_contacts.warmstart(self._model, self._data, contacts)
+
+        if self._problem_metrics is not None:
+            self._problem_metrics.build(
+                model=self._model,
+                data=self._data,
+                limits=limits,
+                contacts=contacts,
+                jacobians=self._jacobians,
+                reset_to_zero=True,
+            )
+
+        # Solve the forward dynamics sub-problem and prepare the integrator inputs.
+        self._forward_dynamics(state_in, state_out, contacts)
+
+        if self._ws_limits is not None:
+            self._ws_limits.update(self._limits)
+        if self._ws_contacts is not None:
+            self._ws_contacts.update(contacts)
 
         # Run the mid-step callback if it has been set
         self._run_midstep_callback(state_in, state_out, control, contacts)
@@ -1177,18 +1260,40 @@ class SolverKaminoImpl(SolverBase):
         """
         if self._config.compute_solution_metrics:
             self.metrics.reset()
-            self._metrics.evaluate(
-                sigma=self._solver_fd.data.state.sigma,
-                lambdas=self._solver_fd.data.solution.lambdas,
-                v_plus=self._solver_fd.data.solution.v_plus,
-                model=self._model,
-                data=self._data,
-                state_p=state_in,
-                problem=self._problem_fd,
-                jacobians=self._jacobians,
-                limits=self._limits,
-                contacts=contacts,
-            )
+            if self._problem_metrics is not None:
+                self._metrics.evaluate_from_constraint_forces(
+                    model=self._model,
+                    data=self._data,
+                    state_p=state_in,
+                    problem=self._problem_metrics,
+                    jacobians=self._jacobians,
+                    limits=self._limits,
+                    contacts=contacts,
+                )
+            elif self._problem_fd is None:
+                self._metrics.evaluate_primal(
+                    model=self._model,
+                    data=self._data,
+                    state_p=state_in,
+                    jacobians=self._jacobians,
+                    limits=self._limits,
+                    contacts=contacts,
+                )
+            else:
+                self._metrics.evaluate(
+                    sigma=self._solver_fd.data.state.sigma,
+                    lambdas=self._solver_fd.data.solution.lambdas,
+                    v_plus=self._solver_fd.data.solution.v_plus,
+                    model=self._model,
+                    data=self._data,
+                    state_p=state_in,
+                    problem=self._problem_fd,
+                    jacobians=self._jacobians,
+                    limits=self._limits,
+                    contacts=contacts,
+                )
+            if self._config.dynamics_solver == "lox":
+                self._solver_fd.update_status_metrics(self._metrics.data)
 
     def _advance_time(self):
         """

--- a/newton/_src/solvers/kamino/_src/solvers/dvi/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/dvi/solver.py
@@ -355,6 +355,12 @@ class DVISolver:
         if self._sparse_path is not None:
             self._sparse_path.contacts = contacts
 
+    def notify_model_changed(self, flags: object) -> None:
+        del flags
+
+    def validate_model_changed(self) -> None:
+        pass
+
     def reset(self, problem: DualProblem | None = None, world_mask: wp.array[wp.bool] | None = None):
         """Reset scratch state and cached solution data."""
         if world_mask is None:

--- a/newton/_src/solvers/kamino/_src/solvers/lox/__init__.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rigid-body primal splitting for Kamino.
+
+``solver`` orchestrates the solve; ``problem`` owns its topology and rows.
+``adapter`` converts Kamino inputs and outputs, while ``system`` assembles
+and solves the primal body operator. ``projection`` supplies shared local
+operations to the ``jacobi`` and ``colored_gauss_seidel`` schedules.
+``types`` owns splitting state and ``kernels`` updates it and its residuals.
+"""
+
+from .solver import LOXSolver
+
+__all__ = ["LOXSolver"]

--- a/newton/_src/solvers/kamino/_src/solvers/lox/adapter.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/adapter.py
@@ -1,0 +1,695 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Warp kernels bridging Kamino containers with LOX solver storage.
+
+Preparation kernels materialize compact, coalesced row data once per nonlinear
+evaluation. LOX reuses those rows across its projection iterations; consumers
+therefore avoid repeated sparse-Jacobian indirection and contact preprocessing.
+"""
+
+import warp as wp
+
+from ...core.joints import JointActuationType
+from ...core.math import contact_wrench_matrix_from_points
+from ...core.types import mat36f, vec6f
+from ...geometry.contacts import ContactMode
+from .bias import compute_contact_velocity_target, compute_limit_velocity_target
+from .kernels import _inverse_mass_quadratic_form
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _load_sparse_jacobian_row(index: wp.int32, jacobian_data: wp.array[vec6f]) -> vec6f:
+    if index >= 0:
+        return jacobian_data[index]
+    return vec6f(0.0)
+
+
+@wp.kernel
+def _prepare_dynamic_rows(
+    row_world: wp.array[wp.int32],
+    uses_dof_jacobian: wp.array[wp.bool],
+    body_first_global: wp.array[wp.int32],
+    body_second_global: wp.array[wp.int32],
+    value_index: wp.array[wp.int32],
+    dof_index: wp.array[wp.int32],
+    sparse_first_index: wp.array[wp.int32],
+    sparse_second_index: wp.array[wp.int32],
+    sparse_jacobian_data: wp.array[vec6f],
+    sparse_dof_jacobian_data: wp.array[vec6f],
+    joint_inertia: wp.array[wp.float32],
+    joint_free_velocity: wp.array[wp.float32],
+    dynamic_effort_index: wp.array[wp.int32],
+    effort_value_index: wp.array[wp.int32],
+    effort_inverse_inertia: wp.array[wp.float32],
+    effort_free_velocity: wp.array[wp.float32],
+    joint_armature: wp.array[wp.float32],
+    joint_position_stiffness: wp.array[wp.float32],
+    joint_actuation_type: wp.array[wp.int32],
+    joint_velocity: wp.array[wp.float32],
+    joint_velocity_begin: wp.array[wp.float32],
+    external_effort: wp.array[wp.float32],
+    velocity_stiffness: wp.array[wp.float32],
+    effort_limit: wp.array[wp.float32],
+    linearization_twist: wp.array[vec6f],
+    time_step: wp.array[wp.float32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_inertia: wp.array[wp.float32],
+    free_velocity: wp.array[wp.float32],
+    effort_intercept: wp.array[wp.float32],
+    effort_slope: wp.array[wp.float32],
+    effort_impulse_bound: wp.array[wp.float32],
+):
+    row = wp.tid()
+    world = row_world[row]
+    dt = time_step[world]
+    if uses_dof_jacobian[row]:
+        jacobian_first[row] = _load_sparse_jacobian_row(sparse_first_index[row], sparse_dof_jacobian_data)
+        jacobian_second[row] = _load_sparse_jacobian_row(sparse_second_index[row], sparse_dof_jacobian_data)
+    else:
+        jacobian_first[row] = _load_sparse_jacobian_row(sparse_first_index[row], sparse_jacobian_data)
+        jacobian_second[row] = _load_sparse_jacobian_row(sparse_second_index[row], sparse_jacobian_data)
+    source = value_index[row]
+    dof = dof_index[row]
+    inertia = wp.float32(0.0)
+    velocity = wp.float32(0.0)
+    if source >= 0:
+        inertia = joint_inertia[source]
+        velocity = joint_free_velocity[source]
+    bounded = dynamic_effort_index[row]
+    if bounded >= 0:
+        effort_source = effort_value_index[bounded]
+        actuator_inverse_inertia = effort_inverse_inertia[effort_source]
+        if actuator_inverse_inertia > 0.0:
+            actuator_inertia = 1.0 / actuator_inverse_inertia
+            velocity = (inertia * velocity + actuator_inertia * effort_free_velocity[effort_source]) / (
+                inertia + actuator_inertia
+            )
+            inertia += actuator_inertia
+    effective_inertia[row] = inertia
+    mode = joint_actuation_type[dof]
+    if inertia > 0.0:
+        velocity += joint_armature[dof] * (joint_velocity_begin[dof] - joint_velocity[dof]) / inertia
+        if (
+            mode == JointActuationType.POSITION
+            or mode == JointActuationType.POSITION_VELOCITY
+            or mode == JointActuationType.POSITION_VELOCITY_FORCE
+        ):
+            linearization_velocity = wp.float32(0.0)
+            first = body_first_global[row]
+            second = body_second_global[row]
+            if first >= 0:
+                linearization_velocity += wp.dot(jacobian_first[row], linearization_twist[first])
+            if second >= 0:
+                linearization_velocity += wp.dot(jacobian_second[row], linearization_twist[second])
+            velocity += dt * dt * joint_position_stiffness[dof] * linearization_velocity / inertia
+    free_velocity[row] = velocity
+    if bounded >= 0:
+        gradient = wp.float32(0.0)
+        if mode == JointActuationType.VELOCITY:
+            gradient = velocity_stiffness[dof]
+        if (
+            mode == JointActuationType.POSITION
+            or mode == JointActuationType.POSITION_VELOCITY
+            or mode == JointActuationType.POSITION_VELOCITY_FORCE
+        ):
+            gradient = velocity_stiffness[dof] + dt * joint_position_stiffness[dof]
+        beta = inertia * velocity
+        effort_intercept[bounded] = (beta - joint_armature[dof] * joint_velocity_begin[dof]) / dt - external_effort[dof]
+        effort_slope[bounded] = gradient
+        effort_impulse_bound[bounded] = dt * effort_limit[dof]
+
+
+@wp.kernel
+def _prepare_joint_frictions(
+    row_world: wp.array[wp.int32],
+    body_first_global: wp.array[wp.int32],
+    body_second_global: wp.array[wp.int32],
+    dof_index: wp.array[wp.int32],
+    multiplier_index: wp.array[wp.int32],
+    sparse_first_index: wp.array[wp.int32],
+    sparse_second_index: wp.array[wp.int32],
+    sparse_jacobian_data: wp.array[vec6f],
+    friction_force: wp.array[wp.float32],
+    source_reaction: wp.array[wp.float32],
+    body_velocity_begin: wp.array[vec6f],
+    time_step: wp.array[wp.float32],
+    import_reactions: wp.bool,
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    impulse_bound: wp.array[wp.float32],
+    reaction: wp.array[wp.float32],
+    velocity: wp.array[wp.float32],
+):
+    row = wp.tid()
+    world = row_world[row]
+    first_jacobian = _load_sparse_jacobian_row(sparse_first_index[row], sparse_jacobian_data)
+    second_jacobian = _load_sparse_jacobian_row(sparse_second_index[row], sparse_jacobian_data)
+    bound = time_step[world] * friction_force[dof_index[row]]
+    jacobian_first[row] = first_jacobian
+    jacobian_second[row] = second_jacobian
+    impulse_bound[row] = bound
+    reaction_guess = reaction[row]
+    if import_reactions:
+        reaction_guess = time_step[world] * source_reaction[multiplier_index[row]]
+        value = wp.float32(0.0)
+        first = body_first_global[row]
+        second = body_second_global[row]
+        if first >= 0:
+            value += wp.dot(first_jacobian, body_velocity_begin[first])
+        if second >= 0:
+            value += wp.dot(second_jacobian, body_velocity_begin[second])
+        velocity[row] = value
+    reaction[row] = wp.clamp(reaction_guess, -bound, bound)
+
+
+@wp.kernel
+def _prepare_structural_rows(
+    body_first_global: wp.array[wp.int32],
+    body_second_global: wp.array[wp.int32],
+    sparse_first_index: wp.array[wp.int32],
+    sparse_second_index: wp.array[wp.int32],
+    sparse_jacobian_data: wp.array[vec6f],
+    inverse_mass: wp.array[wp.float32],
+    inverse_inertia_world: wp.array[wp.mat33f],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_mass: wp.array[wp.float32],
+):
+    row = wp.tid()
+    first_jacobian = _load_sparse_jacobian_row(sparse_first_index[row], sparse_jacobian_data)
+    second_jacobian = _load_sparse_jacobian_row(sparse_second_index[row], sparse_jacobian_data)
+    jacobian_first[row] = first_jacobian
+    jacobian_second[row] = second_jacobian
+
+    inverse_effective_mass = _inverse_mass_quadratic_form(
+        first_jacobian, body_first_global[row], inverse_mass, inverse_inertia_world
+    ) + _inverse_mass_quadratic_form(second_jacobian, body_second_global[row], inverse_mass, inverse_inertia_world)
+    effective_mass[row] = 1.0 / inverse_effective_mass if inverse_effective_mass > 1.0e-12 else 0.0
+
+
+@wp.kernel
+def _accumulate_constraint_incidence(
+    entity_world: wp.array[wp.int32],
+    entity_local: wp.array[wp.int32],
+    world_count: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    body_constraint_count: wp.array[wp.int32],
+    body_has_unilateral: wp.array[wp.int32],
+):
+    entity = wp.tid()
+    world = entity_world[entity]
+    if entity_local[entity] >= world_count[world]:
+        return
+    first = body_first[entity]
+    second = body_second[entity]
+    if first >= 0:
+        wp.atomic_add(body_constraint_count, first, 1)
+        wp.atomic_max(body_has_unilateral, first, 1)
+    if second >= 0 and second != first:
+        wp.atomic_add(body_constraint_count, second, 1)
+        wp.atomic_max(body_has_unilateral, second, 1)
+
+
+@wp.kernel
+def _clear_inactive_limits(
+    entity_world: wp.array[wp.int32],
+    entity_local: wp.array[wp.int32],
+    world_count: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    reaction: wp.array[wp.float32],
+    velocity: wp.array[wp.float32],
+):
+    limit = wp.tid()
+    if entity_local[limit] >= world_count[entity_world[limit]]:
+        body_first[limit] = -1
+        body_second[limit] = -1
+        reaction[limit] = 0.0
+        velocity[limit] = 0.0
+
+
+@wp.kernel
+def _clear_inactive_contacts(
+    entity_world: wp.array[wp.int32],
+    entity_local: wp.array[wp.int32],
+    world_count: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    reaction: wp.array[wp.vec3f],
+    velocity: wp.array[wp.vec3f],
+):
+    contact = wp.tid()
+    if entity_local[contact] >= world_count[entity_world[contact]]:
+        body_first[contact] = -1
+        body_second[contact] = -1
+        reaction[contact] = wp.vec3f(0.0)
+        velocity[contact] = wp.vec3f(0.0)
+
+
+@wp.kernel
+def _copy_clamped_world_counts(
+    source: wp.array[wp.int32],
+    capacity: wp.array[wp.int32],
+    destination: wp.array[wp.int32],
+):
+    world = wp.tid()
+    destination[world] = wp.min(wp.max(source[world], 0), capacity[world])
+
+
+@wp.kernel
+def _mark_worlds_with_unilaterals(
+    contact_count: wp.array[wp.int32],
+    limit_count: wp.array[wp.int32],
+    friction_count: wp.array[wp.int32],
+    world_has_unilateral: wp.array[wp.bool],
+):
+    world = wp.tid()
+    world_has_unilateral[world] = contact_count[world] > 0 or limit_count[world] > 0 or friction_count[world] > 0
+
+
+@wp.kernel
+def _prepare_limits(
+    source_active: wp.array[wp.int32],
+    source_capacity: wp.int32,
+    source_world: wp.array[wp.int32],
+    source_local: wp.array[wp.int32],
+    source_bodies: wp.array[wp.vec2i],
+    source_violation: wp.array[wp.float32],
+    source_reaction: wp.array[wp.float32],
+    body_velocity_begin: wp.array[vec6f],
+    world_capacity: wp.array[wp.int32],
+    world_offset: wp.array[wp.int32],
+    body_vector_index: wp.array[wp.int32],
+    sparse_jacobian_offsets: wp.array[wp.int32],
+    sparse_jacobian_data: wp.array[vec6f],
+    time_step: wp.array[wp.float32],
+    stabilization_fraction: wp.float32,
+    import_reactions: wp.bool,
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    bias: wp.array[wp.float32],
+    reaction: wp.array[wp.float32],
+    velocity: wp.array[wp.float32],
+):
+    source = wp.tid()
+    if source >= wp.min(source_active[0], source_capacity):
+        return
+    world = source_world[source]
+    local = source_local[source]
+    if world < 0 or world >= world_capacity.shape[0] or local < 0 or local >= world_capacity[world]:
+        return
+
+    destination = world_offset[world] + local
+    bodies = source_bodies[source]
+    first_global = bodies[0]
+    second_global = bodies[1]
+    first_dynamic = first_global >= 0 and body_vector_index[first_global] >= 0
+    second_dynamic = second_global >= 0 and body_vector_index[second_global] >= 0
+    if not first_dynamic and not second_dynamic:
+        body_first[destination] = -1
+        body_second[destination] = -1
+        jacobian_first[destination] = vec6f(0.0)
+        jacobian_second[destination] = vec6f(0.0)
+        bias[destination] = 0.0
+        reaction[destination] = 0.0
+        velocity[destination] = 0.0
+        return
+    sparse_offset = sparse_jacobian_offsets[source]
+    first_sparse_index = sparse_offset + 1 if first_global >= 0 else -1
+    first_jacobian = _load_sparse_jacobian_row(first_sparse_index, sparse_jacobian_data)
+    second_jacobian = _load_sparse_jacobian_row(sparse_offset, sparse_jacobian_data)
+    body_first[destination] = first_global
+    body_second[destination] = second_global
+    jacobian_first[destination] = first_jacobian
+    jacobian_second[destination] = second_jacobian
+    velocity_previous = wp.float32(0.0)
+    if first_global >= 0:
+        velocity_previous += wp.dot(first_jacobian, body_velocity_begin[first_global])
+    if second_global >= 0:
+        velocity_previous += wp.dot(second_jacobian, body_velocity_begin[second_global])
+    dt = time_step[world]
+    target = compute_limit_velocity_target(source_violation[source], dt, stabilization_fraction)
+    bias[destination] = -target
+    if import_reactions:
+        reaction[destination] = dt * source_reaction[source]
+        velocity[destination] = velocity_previous
+
+
+@wp.kernel
+def _prepare_contacts(
+    source_active: wp.array[wp.int32],
+    source_capacity: wp.int32,
+    source_world: wp.array[wp.int32],
+    source_local: wp.array[wp.int32],
+    source_bodies: wp.array[wp.vec2i],
+    source_position_a: wp.array[wp.vec3f],
+    source_position_b: wp.array[wp.vec3f],
+    source_frame: wp.array[wp.quatf],
+    source_gap: wp.array[wp.vec4f],
+    source_material: wp.array[wp.vec2f],
+    source_reaction: wp.array[wp.vec3f],
+    body_pose: wp.array[wp.transformf],
+    body_velocity_begin: wp.array[vec6f],
+    world_capacity: wp.array[wp.int32],
+    world_count: wp.array[wp.int32],
+    world_offset: wp.array[wp.int32],
+    body_vector_index: wp.array[wp.int32],
+    time_step: wp.array[wp.float32],
+    stabilization_fraction: wp.float32,
+    dead_zone: wp.float32,
+    impact_velocity_threshold: wp.float32,
+    recoverable_response: wp.bool,
+    import_reactions: wp.bool,
+    compact_contacts: wp.bool,
+    source_to_internal: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[mat36f],
+    jacobian_second: wp.array[mat36f],
+    bias: wp.array[wp.vec3f],
+    friction: wp.array[wp.float32],
+    reaction: wp.array[wp.vec3f],
+    velocity: wp.array[wp.vec3f],
+):
+    source = wp.tid()
+    if source >= wp.min(source_active[0], source_capacity):
+        return
+    world = source_world[source]
+    local = source_local[source]
+    if world < 0 or world >= world_capacity.shape[0] or local < 0 or local >= world_capacity[world]:
+        return
+
+    bodies = source_bodies[source]
+    first_global = bodies[0]
+    second_global = bodies[1]
+    first_dynamic = first_global >= 0 and body_vector_index[first_global] >= 0
+    second_dynamic = second_global >= 0 and body_vector_index[second_global] >= 0
+    if not first_dynamic and not second_dynamic:
+        source_to_internal[source] = -1
+        return
+    destination = source_to_internal[source]
+    if compact_contacts:
+        destination = world_offset[world] + wp.atomic_add(world_count, world, 1)
+        source_to_internal[source] = destination
+    first_jacobian = mat36f(0.0)
+    rotation = wp.quat_to_matrix(source_frame[source])
+    body_position_b = wp.transform_get_translation(body_pose[second_global])
+    jacobian_transpose_b = contact_wrench_matrix_from_points(source_position_b[source], body_position_b) @ rotation
+    second_jacobian = wp.transpose(jacobian_transpose_b)
+    if first_global >= 0:
+        body_position_a = wp.transform_get_translation(body_pose[first_global])
+        jacobian_transpose_a = -contact_wrench_matrix_from_points(source_position_a[source], body_position_a) @ rotation
+        first_jacobian = wp.transpose(jacobian_transpose_a)
+
+    velocity_previous = wp.vec3f(0.0)
+    if first_global >= 0:
+        velocity_previous += first_jacobian @ body_velocity_begin[first_global]
+    if second_global >= 0:
+        velocity_previous += second_jacobian @ body_velocity_begin[second_global]
+    gap = source_gap[source]
+    material = source_material[source]
+    dt = time_step[world]
+    target = compute_contact_velocity_target(
+        gap[3],
+        velocity_previous[2],
+        material[1],
+        dt,
+        stabilization_fraction,
+        dead_zone,
+        impact_velocity_threshold,
+        recoverable_response,
+    )
+
+    body_first[destination] = first_global
+    body_second[destination] = second_global
+    jacobian_first[destination] = first_jacobian
+    jacobian_second[destination] = second_jacobian
+    bias[destination] = wp.vec3f(0.0, 0.0, -target)
+    friction[destination] = material[0]
+    if import_reactions:
+        reaction[destination] = dt * source_reaction[source]
+        velocity[destination] = velocity_previous
+
+
+@wp.kernel
+def _write_dynamic_outputs(
+    inverse_time_step: wp.array[wp.float32],
+    row_world: wp.array[wp.int32],
+    multiplier_index: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_inertia: wp.array[wp.float32],
+    free_velocity: wp.array[wp.float32],
+    body_velocity: wp.array[vec6f],
+    destination: wp.array[wp.float32],
+    destination_wrench: wp.array[vec6f],
+):
+    row = wp.tid()
+    velocity = wp.float32(0.0)
+    first = body_first[row]
+    second = body_second[row]
+    if first >= 0:
+        velocity += wp.dot(jacobian_first[row], body_velocity[first])
+    if second >= 0:
+        velocity += wp.dot(jacobian_second[row], body_velocity[second])
+    force = inverse_time_step[row_world[row]] * effective_inertia[row] * (free_velocity[row] - velocity)
+    destination[multiplier_index[row]] = force
+    if first >= 0:
+        wp.atomic_add(destination_wrench, first, force * jacobian_first[row])
+    if second >= 0:
+        wp.atomic_add(destination_wrench, second, force * jacobian_second[row])
+
+
+@wp.kernel
+def _write_dynamic_outputs_with_effort(
+    inverse_time_step: wp.array[wp.float32],
+    row_world: wp.array[wp.int32],
+    multiplier_index: wp.array[wp.int32],
+    effort_index: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_inertia: wp.array[wp.float32],
+    free_velocity: wp.array[wp.float32],
+    effort_counter_applied: wp.array[wp.float32],
+    effort_net_applied: wp.array[wp.float32],
+    effort_value_index: wp.array[wp.int32],
+    body_velocity: wp.array[vec6f],
+    destination: wp.array[wp.float32],
+    effort_destination: wp.array[wp.float32],
+    destination_wrench: wp.array[vec6f],
+):
+    row = wp.tid()
+    velocity = wp.float32(0.0)
+    first = body_first[row]
+    second = body_second[row]
+    if first >= 0:
+        velocity += wp.dot(jacobian_first[row], body_velocity[first])
+    if second >= 0:
+        velocity += wp.dot(jacobian_second[row], body_velocity[second])
+    inv_dt = inverse_time_step[row_world[row]]
+    multiplier = inv_dt * effective_inertia[row] * (free_velocity[row] - velocity)
+    bounded = effort_index[row]
+    if bounded >= 0:
+        multiplier += inv_dt * effort_counter_applied[bounded]
+        effort_destination[effort_value_index[bounded]] = inv_dt * effort_net_applied[bounded]
+    destination_index = multiplier_index[row]
+    if destination_index >= 0:
+        destination[destination_index] = multiplier
+    elif bounded >= 0:
+        multiplier = inv_dt * effort_net_applied[bounded]
+    else:
+        return
+    if first >= 0:
+        wp.atomic_add(destination_wrench, first, multiplier * jacobian_first[row])
+    if second >= 0:
+        wp.atomic_add(destination_wrench, second, multiplier * jacobian_second[row])
+
+
+@wp.kernel
+def _write_friction_outputs(
+    inverse_time_step: wp.array[wp.float32],
+    row_world: wp.array[wp.int32],
+    multiplier_index: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    source: wp.array[wp.float32],
+    destination: wp.array[wp.float32],
+    destination_wrench: wp.array[vec6f],
+):
+    row = wp.tid()
+    force = inverse_time_step[row_world[row]] * source[row]
+    destination[multiplier_index[row]] = force
+    first = body_first[row]
+    second = body_second[row]
+    if first >= 0:
+        wp.atomic_add(destination_wrench, first, force * jacobian_first[row])
+    if second >= 0:
+        wp.atomic_add(destination_wrench, second, force * jacobian_second[row])
+
+
+@wp.kernel
+def _accumulate_aligned_joint_wrenches(
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    reaction: wp.array[wp.float32],
+    destination: wp.array[vec6f],
+):
+    row = wp.tid()
+    scale = reaction[row]
+    first = body_first[row]
+    second = body_second[row]
+    if first >= 0:
+        wp.atomic_add(destination, first, scale * jacobian_first[row])
+    if second >= 0:
+        wp.atomic_add(destination, second, scale * jacobian_second[row])
+
+
+@wp.kernel
+def _write_limit_outputs(
+    source_active: wp.array[wp.int32],
+    source_capacity: wp.int32,
+    source_world: wp.array[wp.int32],
+    source_local: wp.array[wp.int32],
+    world_capacity: wp.array[wp.int32],
+    world_offset: wp.array[wp.int32],
+    inverse_time_step: wp.array[wp.float32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    reaction: wp.array[wp.float32],
+    velocity: wp.array[wp.float32],
+    destination_reaction: wp.array[wp.float32],
+    destination_velocity: wp.array[wp.float32],
+    destination_wrench: wp.array[vec6f],
+):
+    source = wp.tid()
+    if source >= wp.min(source_active[0], source_capacity):
+        return
+    world = source_world[source]
+    local = source_local[source]
+    if world < 0 or world >= world_capacity.shape[0] or local < 0 or local >= world_capacity[world]:
+        return
+    internal = world_offset[world] + local
+    force = inverse_time_step[world] * reaction[internal]
+    destination_reaction[source] = force
+    destination_velocity[source] = velocity[internal]
+    first = body_first[internal]
+    second = body_second[internal]
+    if first >= 0:
+        wp.atomic_add(destination_wrench, first, force * jacobian_first[internal])
+    if second >= 0:
+        wp.atomic_add(destination_wrench, second, force * jacobian_second[internal])
+
+
+@wp.kernel
+def _write_contact_outputs(
+    source_active: wp.array[wp.int32],
+    source_capacity: wp.int32,
+    source_world: wp.array[wp.int32],
+    source_to_internal: wp.array[wp.int32],
+    inverse_time_step: wp.array[wp.float32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[mat36f],
+    jacobian_second: wp.array[mat36f],
+    reaction: wp.array[wp.vec3f],
+    velocity: wp.array[wp.vec3f],
+    destination_reaction: wp.array[wp.vec3f],
+    destination_velocity: wp.array[wp.vec3f],
+    destination_mode: wp.array[wp.int32],
+    destination_wrench: wp.array[vec6f],
+):
+    source = wp.tid()
+    if source >= wp.min(source_active[0], source_capacity):
+        return
+    internal = source_to_internal[source]
+    if internal < 0:
+        zero_velocity = wp.vec3f(0.0)
+        destination_reaction[source] = wp.vec3f(0.0)
+        destination_velocity[source] = zero_velocity
+        destination_mode[source] = wp.static(ContactMode.make_compute_mode_func())(zero_velocity)
+        return
+    world = source_world[source]
+    force = inverse_time_step[world] * reaction[internal]
+    destination_reaction[source] = force
+    destination_velocity[source] = velocity[internal]
+    destination_mode[source] = wp.static(ContactMode.make_compute_mode_func())(velocity[internal])
+    first = body_first[internal]
+    second = body_second[internal]
+    if first >= 0:
+        wp.atomic_add(destination_wrench, first, wp.transpose(jacobian_first[internal]) @ force)
+    if second >= 0:
+        wp.atomic_add(destination_wrench, second, wp.transpose(jacobian_second[internal]) @ force)
+
+
+@wp.kernel
+def _write_integrator_body_inputs(
+    body_vector_index: wp.array[wp.int32],
+    body_world: wp.array[wp.int32],
+    world_accepted: wp.array[wp.bool],
+    world_time_step: wp.array[wp.float32],
+    body_mass: wp.array[wp.float32],
+    body_inertia: wp.array[wp.mat33f],
+    body_inverse_mass: wp.array[wp.float32],
+    body_inverse_inertia: wp.array[wp.mat33f],
+    world_gravity: wp.array[wp.vec3f],
+    velocity_begin: wp.array[vec6f],
+    velocity_projected: wp.array[vec6f],
+    body_wrench: wp.array[wp.spatial_vectorf],
+    body_velocity: wp.array[wp.spatial_vectorf],
+):
+    """Encode the accepted LOX velocity as inputs to Kamino integration."""
+    body = wp.tid()
+    world = body_world[body]
+    velocity_end = velocity_begin[body]
+    if body_vector_index[body] >= 0 and world_accepted[world]:
+        velocity_end = velocity_projected[body]
+    linear_velocity_begin = wp.vec3f(
+        velocity_begin[body][0],
+        velocity_begin[body][1],
+        velocity_begin[body][2],
+    )
+    angular_velocity_begin = wp.vec3f(velocity_begin[body][3], velocity_begin[body][4], velocity_begin[body][5])
+    linear_velocity_end = wp.vec3f(velocity_end[0], velocity_end[1], velocity_end[2])
+    angular_velocity_end = wp.vec3f(velocity_end[3], velocity_end[4], velocity_end[5])
+    inverse_time_step = 1.0 / world_time_step[world]
+    force = body_mass[body] * (inverse_time_step * (linear_velocity_end - linear_velocity_begin) - world_gravity[world])
+    inertia = body_inertia[body]
+    torque = inertia @ (inverse_time_step * (angular_velocity_end - angular_velocity_begin)) + wp.skew(
+        angular_velocity_begin
+    ) @ (inertia @ angular_velocity_begin)
+    body_wrench[body] = wp.spatial_vectorf(
+        force[0],
+        force[1],
+        force[2],
+        torque[0],
+        torque[1],
+        torque[2],
+    )
+    if body_vector_index[body] >= 0 and (
+        body_inverse_mass[body] == 0.0 or wp.determinant(body_inverse_inertia[body]) == 0.0
+    ):
+        body_velocity[body] = wp.spatial_vectorf(
+            velocity_end[0],
+            velocity_end[1],
+            velocity_end[2],
+            velocity_end[3],
+            velocity_end[4],
+            velocity_end[5],
+        )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/bias.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/bias.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Velocity targets for unilateral LOX constraints."""
+
+from __future__ import annotations
+
+import warp as wp
+
+__all__ = [
+    "compute_contact_velocity_target",
+    "compute_limit_velocity_target",
+]
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def compute_contact_velocity_target(
+    distance: wp.float32,
+    previous_normal_velocity: wp.float32,
+    restitution: wp.float32,
+    time_step: wp.float32,
+    stabilization_fraction: wp.float32,
+    dead_zone: wp.float32,
+    impact_velocity_threshold: wp.float32,
+    recoverable_response: wp.bool,
+) -> wp.float32:
+    """Compute the minimum end-of-step normal contact velocity.
+
+    Args:
+        distance: Margin-shifted signed contact distance [m].
+        previous_normal_velocity: Begin-of-step normal velocity [m/s].
+        restitution: Newton restitution coefficient.
+        time_step: Time step [s].
+        stabilization_fraction: Penetration recovery fraction.
+        dead_zone: Symmetric distance dead zone [m].
+        impact_velocity_threshold: Minimum approaching impact speed [m/s].
+        recoverable_response: Whether to permit restitution-recoverable overlap.
+
+    Returns:
+        Minimum feasible normal velocity [m/s].
+    """
+    distance_effective = wp.sign(distance) * wp.max(wp.abs(distance) - dead_zone, 0.0)
+    velocity_gap = (
+        -(stabilization_fraction * wp.min(distance_effective, 0.0) + wp.max(distance_effective, 0.0)) / time_step
+    )
+    # Permit the overlap whose next-step recovery matches the unreduced
+    # restitution response.
+    if (
+        recoverable_response
+        and distance_effective > 0.0
+        and previous_normal_velocity < velocity_gap
+        and previous_normal_velocity < -impact_velocity_threshold
+        and stabilization_fraction > 0.0
+    ):
+        recoverable_overlap = -time_step * restitution * previous_normal_velocity / stabilization_fraction
+        velocity_gap = -(distance_effective + recoverable_overlap) / time_step
+
+    velocity_target = velocity_gap
+    closed = distance <= dead_zone
+    approaching = previous_normal_velocity < -impact_velocity_threshold
+    if closed and approaching:
+        velocity_bounce = -restitution * previous_normal_velocity
+        velocity_target = wp.max(velocity_gap, velocity_bounce)
+    return velocity_target
+
+
+@wp.func
+def compute_limit_velocity_target(
+    violation: wp.float32,
+    time_step: wp.float32,
+    stabilization_fraction: wp.float32,
+) -> wp.float32:
+    """Compute the minimum end-of-step joint-limit velocity.
+
+    Args:
+        violation: Signed limit residual, negative when violated [m or rad].
+        time_step: Time step [s].
+        stabilization_fraction: Violation recovery fraction.
+
+    Returns:
+        Minimum feasible limit velocity [m/s or rad/s].
+    """
+    return -stabilization_fraction * wp.min(violation, 0.0) / time_step

--- a/newton/_src/solvers/kamino/_src/solvers/lox/colored_gauss_seidel.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/colored_gauss_seidel.py
@@ -1,0 +1,1488 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU-batched Gauss--Seidel projection with final Jacobi smoothing."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from ...core.types import mat36f, mat66f, vec6f
+from .jacobi import project_constraints_jacobi
+from .projection import (
+    PROJECTION_STATUS_INVALID,
+    PROJECTION_STATUS_VALID,
+    _atomic_add_twist,
+    _can_fuse_rigid_projection_by_world,
+    _check_projected_twist,
+    _initialize_jacobi_projection_status,
+    _make_colored_projection_index,
+    _make_project_contacts_kernel,
+    _make_project_scalar_kernel,
+    _make_rigid_projection_state,
+    _project_rigid_contact_colored,
+    _project_rigid_contact_jacobi,
+    _project_rigid_friction_colored,
+    _project_rigid_friction_jacobi,
+    _project_rigid_limit_colored,
+    _project_rigid_limit_jacobi,
+    _RigidContactProjectionData,
+    _RigidProjectionState,
+    _sync_threads,
+    _warmstart_contacts_jacobi,
+    _warmstart_frictions_jacobi,
+    _warmstart_limits_jacobi,
+    compute_limit_delassus,
+    prepare_contact_coulomb,
+    prepare_jacobi_projection_data,
+)
+
+wp.set_module_options({"enable_backward": False})
+
+_COLOR_REPAIR_PASSES = 3
+_COLOR_BLOCK_DIM = 128
+_WORLD_COLOR_BLOCK_DIM = 64
+_COLOR_BLOCKS_PER_SM = 2
+# Avoid parallel-scan setup for the small color counts used by normal workloads.
+_SERIAL_COLOR_PREFIX_LIMIT = 64
+_NO_PROPOSAL = -1
+_LOCK_FREE = 0x7FFFFFFF
+
+
+@wp.struct
+class _RigidColoredWorldData:
+    world_color_count: wp.array2d[wp.int32]
+    world_friction_offset: wp.array[wp.int32]
+    world_friction_count: wp.array[wp.int32]
+    friction_colors: wp.array[wp.int32]
+    friction_body_first: wp.array[wp.int32]
+    friction_body_second: wp.array[wp.int32]
+    friction_jacobian_first: wp.array[vec6f]
+    friction_jacobian_second: wp.array[vec6f]
+    friction_bound: wp.array[wp.float32]
+    friction_colored_delassus: wp.array[wp.float32]
+    friction_jacobi_delassus: wp.array[wp.float32]
+    friction_reaction: wp.array[wp.float32]
+    world_contact_offset: wp.array[wp.int32]
+    world_contact_count: wp.array[wp.int32]
+    contact_colors: wp.array[wp.int32]
+    contact_jacobi_delassus: wp.array[wp.mat33f]
+    world_limit_offset: wp.array[wp.int32]
+    world_limit_count: wp.array[wp.int32]
+    limit_colors: wp.array[wp.int32]
+    limit_body_first: wp.array[wp.int32]
+    limit_body_second: wp.array[wp.int32]
+    limit_jacobian_first: wp.array[vec6f]
+    limit_jacobian_second: wp.array[vec6f]
+    limit_bias: wp.array[wp.float32]
+    limit_colored_delassus: wp.array[wp.float32]
+    limit_jacobi_delassus: wp.array[wp.float32]
+    limit_reaction: wp.array[wp.float32]
+
+
+def _bounded_worker_count(capacity: int, device) -> int:
+    if capacity <= 0:
+        return 0
+    if device.is_cuda:
+        return min(capacity, max(_COLOR_BLOCK_DIM, device.sm_count * _COLOR_BLOCKS_PER_SM * _COLOR_BLOCK_DIM))
+    return capacity
+
+
+@wp.func
+def _mix_color_key(value: wp.uint32) -> wp.uint32:
+    value = (value ^ (value >> wp.uint32(16))) * wp.static(wp.uint32(0x7FEB352D))
+    value = (value ^ (value >> wp.uint32(15))) * wp.static(wp.uint32(0x846CA68B))
+    return value ^ (value >> wp.uint32(16))
+
+
+@wp.func
+def _initial_color(world: int, local: int, first: int, second: int, family: int, color_count: int) -> int:
+    key = wp.uint32(world + 1) * wp.static(wp.uint32(0x9E3779B9))
+    key = key ^ (wp.uint32(local + 1) * wp.static(wp.uint32(0x85EBCA6B)))
+    key = key ^ (wp.uint32(first + 2) * wp.static(wp.uint32(0xC2B2AE35)))
+    key = key ^ (wp.uint32(second + 2) * wp.static(wp.uint32(0x27D4EB2F)))
+    key = key ^ (wp.uint32(family) * wp.static(wp.uint32(0x165667B1)))
+    return int(_mix_color_key(key) % wp.uint32(color_count))
+
+
+@wp.func
+def _occupancy(occupancy: wp.array2d[wp.int32], endpoint: int, color: int) -> int:
+    value = int(0)
+    if endpoint >= 0:
+        value = occupancy[endpoint, color]
+    return value
+
+
+@wp.func
+def _choose_two_endpoint_color(
+    first: int,
+    second: int,
+    current: int,
+    color_count: int,
+    occupancy: wp.array2d[wp.int32],
+) -> int:
+    current_sum = _occupancy(occupancy, first, current)
+    endpoint_count = int(0)
+    if first >= 0:
+        endpoint_count += 1
+    if second >= 0 and second != first:
+        current_sum += _occupancy(occupancy, second, current)
+        endpoint_count += 1
+    best = current
+    best_sum = current_sum
+    best_max = wp.max(_occupancy(occupancy, first, current), _occupancy(occupancy, second, current))
+    for color in range(color_count):
+        candidate_sum = _occupancy(occupancy, first, color)
+        if second >= 0 and second != first:
+            candidate_sum += _occupancy(occupancy, second, color)
+        candidate_max = wp.max(_occupancy(occupancy, first, color), _occupancy(occupancy, second, color))
+        if candidate_sum < best_sum or (candidate_sum == best_sum and candidate_max < best_max):
+            best = color
+            best_sum = candidate_sum
+            best_max = candidate_max
+    # Moving one incidence adds one to the destination and removes one from
+    # the source. This is exactly the strict-improvement condition for sum(m^2).
+    if best != current and best_sum + endpoint_count < current_sum:
+        return best
+    return _NO_PROPOSAL
+
+
+@wp.kernel
+def _assign_two_endpoint_colors(
+    constraint_world: wp.array[wp.int32],
+    constraint_local: wp.array[wp.int32],
+    world_constraint_count: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    family: int,
+    color_count: int,
+    colors: wp.array[wp.int32],
+):
+    constraint = wp.tid()
+    world = constraint_world[constraint]
+    if constraint_local[constraint] >= world_constraint_count[world]:
+        colors[constraint] = _NO_PROPOSAL
+        return
+    colors[constraint] = _initial_color(
+        world,
+        constraint_local[constraint],
+        endpoint_first[constraint],
+        endpoint_second[constraint],
+        family,
+        color_count,
+    )
+
+
+@wp.kernel
+def _count_two_endpoint_occupancy(
+    constraint_world: wp.array[wp.int32],
+    constraint_local: wp.array[wp.int32],
+    world_constraint_count: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    colors: wp.array[wp.int32],
+    occupancy: wp.array2d[wp.int32],
+    world_color_count: wp.array2d[wp.int32],
+):
+    constraint = wp.tid()
+    world = constraint_world[constraint]
+    if constraint_local[constraint] >= world_constraint_count[world]:
+        return
+    color = colors[constraint]
+    wp.atomic_add(world_color_count, world, color, 1)
+    first = endpoint_first[constraint]
+    second = endpoint_second[constraint]
+    if first >= 0:
+        wp.atomic_add(occupancy, first, color, 1)
+    if second >= 0 and second != first:
+        wp.atomic_add(occupancy, second, color, 1)
+
+
+@wp.kernel
+def _propose_and_claim_two_endpoint_repairs(
+    constraint_world: wp.array[wp.int32],
+    constraint_local: wp.array[wp.int32],
+    world_constraint_count: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    color_count: int,
+    key_offset: int,
+    colors: wp.array[wp.int32],
+    occupancy: wp.array2d[wp.int32],
+    proposals: wp.array[wp.int32],
+    locks: wp.array[wp.int32],
+):
+    constraint = wp.tid()
+    world = constraint_world[constraint]
+    if constraint_local[constraint] >= world_constraint_count[world]:
+        proposals[constraint] = _NO_PROPOSAL
+        return
+    proposal = _choose_two_endpoint_color(
+        endpoint_first[constraint],
+        endpoint_second[constraint],
+        colors[constraint],
+        color_count,
+        occupancy,
+    )
+    proposals[constraint] = proposal
+    if proposal < 0:
+        return
+    key = key_offset + constraint
+    first = endpoint_first[constraint]
+    second = endpoint_second[constraint]
+    if first >= 0:
+        wp.atomic_min(locks, first, key)
+    if second >= 0 and second != first:
+        wp.atomic_min(locks, second, key)
+
+
+@wp.kernel
+def _commit_two_endpoint_repairs(
+    constraint_world: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    key_offset: int,
+    colors: wp.array[wp.int32],
+    proposals: wp.array[wp.int32],
+    locks: wp.array[wp.int32],
+    occupancy: wp.array2d[wp.int32],
+    world_color_count: wp.array2d[wp.int32],
+):
+    constraint = wp.tid()
+    candidate = proposals[constraint]
+    if candidate < 0:
+        return
+    key = key_offset + constraint
+    first = endpoint_first[constraint]
+    second = endpoint_second[constraint]
+    if (first >= 0 and locks[first] != key) or (second >= 0 and second != first and locks[second] != key):
+        return
+    current = colors[constraint]
+    world = constraint_world[constraint]
+    wp.atomic_add(world_color_count, world, current, -1)
+    wp.atomic_add(world_color_count, world, candidate, 1)
+    if first >= 0:
+        wp.atomic_add(occupancy, first, current, -1)
+        wp.atomic_add(occupancy, first, candidate, 1)
+    if second >= 0 and second != first:
+        wp.atomic_add(occupancy, second, current, -1)
+        wp.atomic_add(occupancy, second, candidate, 1)
+    colors[constraint] = candidate
+
+
+@wp.kernel
+def _count_colors(colors: wp.array[wp.int32], color_count: int, counts: wp.array[wp.int32]):
+    item = wp.tid()
+    color = colors[item]
+    if color >= 0 and color < color_count:
+        wp.atomic_add(counts, color, 1)
+
+
+@wp.kernel
+def _prefix_color_counts(
+    color_count: int, counts: wp.array[wp.int32], offsets: wp.array[wp.int32], cursors: wp.array[wp.int32]
+):
+    offset = int(0)
+    for color in range(color_count):
+        offsets[color] = offset
+        cursors[color] = offset
+        offset += counts[color]
+
+
+@wp.kernel
+def _scatter_color_order(
+    colors: wp.array[wp.int32],
+    color_count: int,
+    cursors: wp.array[wp.int32],
+    order: wp.array[wp.int32],
+):
+    item = wp.tid()
+    color = colors[item]
+    if color >= 0 and color < color_count:
+        ordered = wp.atomic_add(cursors, color, 1)
+        order[ordered] = item
+
+
+@wp.kernel
+def _prepare_frictions_colored(
+    launch_dim: int,
+    target_color: int,
+    color_counts: wp.array[wp.int32],
+    color_offsets: wp.array[wp.int32],
+    order: wp.array[wp.int32],
+    constraint_world: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    occupancy: wp.array2d[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    lane = wp.tid()
+    begin = color_offsets[target_color] + lane
+    end = color_offsets[target_color] + color_counts[target_color]
+    for ordered in range(begin, end, launch_dim):
+        constraint = order[ordered]
+        first = endpoint_first[constraint]
+        second = endpoint_second[constraint]
+        if first < 0 and second < 0:
+            delassus[constraint] = 0.0
+            continue
+        inverse_first = mat66f(0.0)
+        inverse_second = mat66f(0.0)
+        if first >= 0:
+            inverse_first = wp.float32(wp.max(1, occupancy[first, target_color])) * inverse_weight[first]
+        if second >= 0:
+            inverse_second = wp.float32(wp.max(1, occupancy[second, target_color])) * inverse_weight[second]
+        value = compute_limit_delassus(
+            jacobian_first[constraint], inverse_first, jacobian_second[constraint], inverse_second
+        )
+        delassus[constraint] = value
+        if not wp.isfinite(value) or value <= 0.0:
+            world_status[constraint_world[constraint]] = PROJECTION_STATUS_INVALID
+
+
+@wp.kernel
+def _prepare_contacts_colored(
+    launch_dim: int,
+    target_color: int,
+    color_counts: wp.array[wp.int32],
+    color_offsets: wp.array[wp.int32],
+    order: wp.array[wp.int32],
+    constraint_world: wp.array[wp.int32],
+    endpoint_first: wp.array[wp.int32],
+    endpoint_second: wp.array[wp.int32],
+    jacobian_first: wp.array[mat36f],
+    jacobian_second: wp.array[mat36f],
+    bias: wp.array[wp.vec3f],
+    friction: wp.array[wp.float32],
+    occupancy: wp.array2d[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.mat33f],
+    world_status: wp.array[wp.int32],
+):
+    lane = wp.tid()
+    begin = color_offsets[target_color] + lane
+    end = color_offsets[target_color] + color_counts[target_color]
+    for ordered in range(begin, end, launch_dim):
+        constraint = order[ordered]
+        first = endpoint_first[constraint]
+        second = endpoint_second[constraint]
+        if first < 0 and second < 0:
+            delassus[constraint] = wp.mat33f(0.0)
+            continue
+        inverse_first = mat66f(0.0)
+        inverse_second = mat66f(0.0)
+        if first >= 0:
+            inverse_first = wp.float32(wp.max(1, occupancy[first, target_color])) * inverse_weight[first]
+        if second >= 0:
+            inverse_second = wp.float32(wp.max(1, occupancy[second, target_color])) * inverse_weight[second]
+        data = prepare_contact_coulomb(
+            jacobian_first[constraint],
+            inverse_first,
+            jacobian_second[constraint],
+            inverse_second,
+            bias[constraint],
+            friction[constraint],
+        )
+        delassus[constraint] = data.delassus
+        if data.status == PROJECTION_STATUS_INVALID:
+            world_status[constraint_world[constraint]] = data.status
+
+
+@wp.kernel
+def _prepare_rigid_colored(
+    launch_dim: int,
+    target_color: int,
+    friction_counts: wp.array[wp.int32],
+    friction_offsets: wp.array[wp.int32],
+    friction_order: wp.array[wp.int32],
+    friction_world: wp.array[wp.int32],
+    friction_first: wp.array[wp.int32],
+    friction_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    contact_counts: wp.array[wp.int32],
+    contact_offsets: wp.array[wp.int32],
+    contact_order: wp.array[wp.int32],
+    contact_world: wp.array[wp.int32],
+    contact_first: wp.array[wp.int32],
+    contact_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    limit_counts: wp.array[wp.int32],
+    limit_offsets: wp.array[wp.int32],
+    limit_order: wp.array[wp.int32],
+    limit_world: wp.array[wp.int32],
+    limit_first: wp.array[wp.int32],
+    limit_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    occupancy: wp.array2d[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    friction_delassus: wp.array[wp.float32],
+    contact_delassus: wp.array[wp.mat33f],
+    limit_delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    lane = wp.tid()
+    friction_begin = friction_offsets[target_color] + lane
+    friction_end = friction_offsets[target_color] + friction_counts[target_color]
+    for ordered in range(friction_begin, friction_end, launch_dim):
+        constraint = friction_order[ordered]
+        first = friction_first[constraint]
+        second = friction_second[constraint]
+        if first < 0 and second < 0:
+            friction_delassus[constraint] = 0.0
+            continue
+        inverse_first = mat66f(0.0)
+        inverse_second = mat66f(0.0)
+        if first >= 0:
+            inverse_first = wp.float32(wp.max(1, occupancy[first, target_color])) * inverse_weight[first]
+        if second >= 0:
+            inverse_second = wp.float32(wp.max(1, occupancy[second, target_color])) * inverse_weight[second]
+        value = compute_limit_delassus(
+            friction_jacobian_first[constraint],
+            inverse_first,
+            friction_jacobian_second[constraint],
+            inverse_second,
+        )
+        friction_delassus[constraint] = value
+        if not wp.isfinite(value) or value <= 0.0:
+            world_status[friction_world[constraint]] = PROJECTION_STATUS_INVALID
+
+    contact_begin = contact_offsets[target_color] + lane
+    contact_end = contact_offsets[target_color] + contact_counts[target_color]
+    for ordered in range(contact_begin, contact_end, launch_dim):
+        constraint = contact_order[ordered]
+        first = contact_first[constraint]
+        second = contact_second[constraint]
+        if first < 0 and second < 0:
+            contact_delassus[constraint] = wp.mat33f(0.0)
+            continue
+        inverse_first = mat66f(0.0)
+        inverse_second = mat66f(0.0)
+        if first >= 0:
+            inverse_first = wp.float32(wp.max(1, occupancy[first, target_color])) * inverse_weight[first]
+        if second >= 0:
+            inverse_second = wp.float32(wp.max(1, occupancy[second, target_color])) * inverse_weight[second]
+        data = prepare_contact_coulomb(
+            contact_jacobian_first[constraint],
+            inverse_first,
+            contact_jacobian_second[constraint],
+            inverse_second,
+            contact_bias[constraint],
+            contact_friction[constraint],
+        )
+        contact_delassus[constraint] = data.delassus
+        if data.status == PROJECTION_STATUS_INVALID:
+            world_status[contact_world[constraint]] = data.status
+
+    limit_begin = limit_offsets[target_color] + lane
+    limit_end = limit_offsets[target_color] + limit_counts[target_color]
+    for ordered in range(limit_begin, limit_end, launch_dim):
+        constraint = limit_order[ordered]
+        first = limit_first[constraint]
+        second = limit_second[constraint]
+        if first < 0 and second < 0:
+            limit_delassus[constraint] = 0.0
+            continue
+        inverse_first = mat66f(0.0)
+        inverse_second = mat66f(0.0)
+        if first >= 0:
+            inverse_first = wp.float32(wp.max(1, occupancy[first, target_color])) * inverse_weight[first]
+        if second >= 0:
+            inverse_second = wp.float32(wp.max(1, occupancy[second, target_color])) * inverse_weight[second]
+        value = compute_limit_delassus(
+            limit_jacobian_first[constraint], inverse_first, limit_jacobian_second[constraint], inverse_second
+        )
+        limit_delassus[constraint] = value
+        if not wp.isfinite(value) or value <= 0.0:
+            world_status[limit_world[constraint]] = PROJECTION_STATUS_INVALID
+
+
+@wp.kernel
+def _project_rigid_colored(
+    launch_dim: int,
+    target_color: int,
+    friction_counts: wp.array[wp.int32],
+    friction_offsets: wp.array[wp.int32],
+    friction_order: wp.array[wp.int32],
+    friction_world: wp.array[wp.int32],
+    friction_first: wp.array[wp.int32],
+    friction_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    friction_bound: wp.array[wp.float32],
+    friction_delassus: wp.array[wp.float32],
+    contact_counts: wp.array[wp.int32],
+    contact_offsets: wp.array[wp.int32],
+    contact_order: wp.array[wp.int32],
+    contact_world: wp.array[wp.int32],
+    contact_data: _RigidContactProjectionData,
+    limit_counts: wp.array[wp.int32],
+    limit_offsets: wp.array[wp.int32],
+    limit_order: wp.array[wp.int32],
+    limit_world: wp.array[wp.int32],
+    limit_first: wp.array[wp.int32],
+    limit_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    limit_bias: wp.array[wp.float32],
+    limit_delassus: wp.array[wp.float32],
+    state: _RigidProjectionState,
+    friction_reaction: wp.array[wp.float32],
+    limit_reaction: wp.array[wp.float32],
+):
+    lane = wp.tid()
+    friction_begin = friction_offsets[target_color] + lane
+    friction_end = friction_offsets[target_color] + friction_counts[target_color]
+    for ordered in range(friction_begin, friction_end, launch_dim):
+        constraint = friction_order[ordered]
+        world = friction_world[constraint]
+        if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+            continue
+        _project_rigid_friction_colored(
+            constraint,
+            world,
+            target_color,
+            friction_first,
+            friction_second,
+            friction_jacobian_first,
+            friction_jacobian_second,
+            friction_bound,
+            friction_bound,
+            friction_delassus,
+            friction_reaction,
+            state,
+        )
+
+    contact_begin = contact_offsets[target_color] + lane
+    contact_end = contact_offsets[target_color] + contact_counts[target_color]
+    for ordered in range(contact_begin, contact_end, launch_dim):
+        constraint = contact_order[ordered]
+        world = contact_world[constraint]
+        if state.world_active[world] and state.world_status[world] == PROJECTION_STATUS_VALID:
+            _project_rigid_contact_colored(constraint, world, target_color, contact_data, contact_data.delassus, state)
+
+    limit_begin = limit_offsets[target_color] + lane
+    limit_end = limit_offsets[target_color] + limit_counts[target_color]
+    for ordered in range(limit_begin, limit_end, launch_dim):
+        constraint = limit_order[ordered]
+        world = limit_world[constraint]
+        if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+            continue
+        _project_rigid_limit_colored(
+            constraint,
+            world,
+            target_color,
+            limit_first,
+            limit_second,
+            limit_jacobian_first,
+            limit_jacobian_second,
+            limit_bias,
+            limit_bias,
+            limit_delassus,
+            limit_reaction,
+            state,
+        )
+
+
+@wp.kernel
+def _project_rigid_colored_by_world(
+    iterations: wp.int32,
+    color_count: wp.int32,
+    world_body_offset: wp.array[wp.int32],
+    world_body_count: wp.array[wp.int32],
+    data: _RigidColoredWorldData,
+    contact_data: _RigidContactProjectionData,
+    state: _RigidProjectionState,
+    prepared_status: wp.array[wp.int32],
+):
+    """Project one rigid world per block, including warm start and smoothing."""
+    world, lane = wp.tid()
+    thread_count = wp.block_dim()
+
+    local = lane
+    while local < world_body_count[world]:
+        state.twist_delta[world_body_offset[world] + local] = vec6f(0.0)
+        local += thread_count
+    if state.world_active[world]:
+        state.world_status[world] = prepared_status[world]
+    _sync_threads()
+    if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+        return
+
+    # Apply the existing reactions before the first colored sweep.
+    local = lane
+    while local < data.world_friction_count[world]:
+        constraint = data.world_friction_offset[world] + local
+        first = data.friction_body_first[constraint]
+        second = data.friction_body_second[constraint]
+        friction_reaction = data.friction_reaction[constraint]
+        correction_first = vec6f(0.0)
+        correction_second = vec6f(0.0)
+        if first >= 0:
+            correction_first = data.friction_jacobian_first[constraint] * friction_reaction
+        if second >= 0:
+            correction_second = data.friction_jacobian_second[constraint] * friction_reaction
+        _atomic_add_twist(state.twist_delta, first, correction_first)
+        _atomic_add_twist(state.twist_delta, second, correction_second)
+        local += thread_count
+
+    local = lane
+    while local < data.world_contact_count[world]:
+        constraint = data.world_contact_offset[world] + local
+        first = contact_data.body_first[constraint]
+        second = contact_data.body_second[constraint]
+        contact_reaction = contact_data.reaction[constraint]
+        correction_first = vec6f(0.0)
+        correction_second = vec6f(0.0)
+        if first >= 0:
+            correction_first = wp.transpose(contact_data.jacobian_first[constraint]) @ contact_reaction
+        if second >= 0:
+            correction_second = wp.transpose(contact_data.jacobian_second[constraint]) @ contact_reaction
+        _atomic_add_twist(state.twist_delta, first, correction_first)
+        _atomic_add_twist(state.twist_delta, second, correction_second)
+        local += thread_count
+
+    local = lane
+    while local < data.world_limit_count[world]:
+        constraint = data.world_limit_offset[world] + local
+        first = data.limit_body_first[constraint]
+        second = data.limit_body_second[constraint]
+        limit_reaction = data.limit_reaction[constraint]
+        correction_first = vec6f(0.0)
+        correction_second = vec6f(0.0)
+        if first >= 0:
+            correction_first = data.limit_jacobian_first[constraint] * limit_reaction
+        if second >= 0:
+            correction_second = data.limit_jacobian_second[constraint] * limit_reaction
+        _atomic_add_twist(state.twist_delta, first, correction_first)
+        _atomic_add_twist(state.twist_delta, second, correction_second)
+        local += thread_count
+
+    _sync_threads()
+    local = lane
+    while local < world_body_count[world]:
+        body = world_body_offset[world] + local
+        if state.world_status[world] == PROJECTION_STATUS_VALID:
+            correction = state.inverse_weight[body] @ state.twist_delta[body]
+            state.projected_twist[body] += correction
+        state.twist_delta[body] = vec6f(0.0)
+        local += thread_count
+    _sync_threads()
+
+    # Colors and iterations are block-local for independent rigid worlds.
+    for _iteration in range(iterations):
+        for color in range(color_count):
+            if data.world_color_count[world, color] != 0:
+                if state.world_status[world] == PROJECTION_STATUS_VALID:
+                    local = lane
+                    while local < data.world_friction_count[world]:
+                        constraint = data.world_friction_offset[world] + local
+                        if data.friction_colors[constraint] == color:
+                            _project_rigid_friction_colored(
+                                constraint,
+                                world,
+                                color,
+                                data.friction_body_first,
+                                data.friction_body_second,
+                                data.friction_jacobian_first,
+                                data.friction_jacobian_second,
+                                data.friction_bound,
+                                data.friction_bound,
+                                data.friction_colored_delassus,
+                                data.friction_reaction,
+                                state,
+                            )
+                        local += thread_count
+
+                    local = lane
+                    while local < data.world_contact_count[world]:
+                        constraint = data.world_contact_offset[world] + local
+                        if data.contact_colors[constraint] == color:
+                            _project_rigid_contact_colored(
+                                constraint, world, color, contact_data, contact_data.delassus, state
+                            )
+                        local += thread_count
+
+                    local = lane
+                    while local < data.world_limit_count[world]:
+                        constraint = data.world_limit_offset[world] + local
+                        if data.limit_colors[constraint] == color:
+                            _project_rigid_limit_colored(
+                                constraint,
+                                world,
+                                color,
+                                data.limit_body_first,
+                                data.limit_body_second,
+                                data.limit_jacobian_first,
+                                data.limit_jacobian_second,
+                                data.limit_bias,
+                                data.limit_bias,
+                                data.limit_colored_delassus,
+                                data.limit_reaction,
+                                state,
+                            )
+                        local += thread_count
+
+                _sync_threads()
+                local = lane
+                while local < world_body_count[world]:
+                    body = world_body_offset[world] + local
+                    if state.world_status[world] == PROJECTION_STATUS_VALID:
+                        state.projected_twist[body] += state.twist_delta[body]
+                    state.twist_delta[body] = vec6f(0.0)
+                    local += thread_count
+                _sync_threads()
+
+    # Finish with the same mass-split Jacobi smoothing as the global path.
+    if state.world_status[world] == PROJECTION_STATUS_VALID:
+        local = lane
+        while local < data.world_friction_count[world]:
+            constraint = data.world_friction_offset[world] + local
+            _project_rigid_friction_jacobi(
+                constraint,
+                world,
+                0,
+                data.friction_body_first,
+                data.friction_body_second,
+                data.friction_jacobian_first,
+                data.friction_jacobian_second,
+                data.friction_bound,
+                data.friction_bound,
+                data.friction_jacobi_delassus,
+                data.friction_reaction,
+                state,
+            )
+            local += thread_count
+
+        local = lane
+        while local < data.world_contact_count[world]:
+            constraint = data.world_contact_offset[world] + local
+            _project_rigid_contact_jacobi(
+                constraint,
+                world,
+                0,
+                contact_data,
+                data.contact_jacobi_delassus,
+                state,
+            )
+            local += thread_count
+
+        local = lane
+        while local < data.world_limit_count[world]:
+            constraint = data.world_limit_offset[world] + local
+            _project_rigid_limit_jacobi(
+                constraint,
+                world,
+                0,
+                data.limit_body_first,
+                data.limit_body_second,
+                data.limit_jacobian_first,
+                data.limit_jacobian_second,
+                data.limit_bias,
+                data.limit_bias,
+                data.limit_jacobi_delassus,
+                data.limit_reaction,
+                state,
+            )
+            local += thread_count
+
+    _sync_threads()
+    local = lane
+    while local < world_body_count[world]:
+        body = world_body_offset[world] + local
+        if state.world_status[world] == PROJECTION_STATUS_VALID:
+            correction = state.inverse_weight[body] @ state.twist_delta[body]
+            state.projected_twist[body] += correction
+        _check_projected_twist(body, world, state.projected_twist, state.world_status)
+        state.twist_delta[body] = vec6f(0.0)
+        local += thread_count
+
+
+@wp.kernel
+def _apply_body_delta(
+    body_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    delta: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+):
+    body = wp.tid()
+    world = body_world[body]
+    if world_active[world] and world_status[world] == PROJECTION_STATUS_VALID:
+        projected_twist[body] += delta[body]
+    delta[body] = vec6f(0.0)
+
+
+class _ColorFamily:
+    def __init__(self, capacity: int, color_count: int, device):
+        self.capacity = capacity
+        self.worker_count = _bounded_worker_count(capacity, device)
+        self.colors = wp.full(capacity, _NO_PROPOSAL, dtype=wp.int32, device=device)
+        self.proposals = wp.full(capacity, _NO_PROPOSAL, dtype=wp.int32, device=device)
+        self.counts = wp.zeros(color_count, dtype=wp.int32, device=device)
+        self.offsets = wp.zeros(color_count, dtype=wp.int32, device=device)
+        self.cursors = wp.zeros(color_count, dtype=wp.int32, device=device)
+        self.order = wp.full(capacity, -1, dtype=wp.int32, device=device)
+
+    def _prefix_counts(self, color_count: int, device) -> None:
+        if color_count <= _SERIAL_COLOR_PREFIX_LIMIT:
+            wp.launch(
+                _prefix_color_counts,
+                dim=1,
+                inputs=[color_count, self.counts],
+                outputs=[self.offsets, self.cursors],
+                device=device,
+            )
+        else:
+            wp.utils.array_scan(self.counts, self.offsets, inclusive=False)
+            wp.copy(self.cursors, self.offsets)
+
+    def compact(self, color_count: int, device) -> None:
+        self.counts.zero_()
+        if self.capacity == 0:
+            return
+        wp.launch(
+            _count_colors, dim=self.capacity, inputs=[self.colors, color_count], outputs=[self.counts], device=device
+        )
+        self._prefix_counts(color_count, device)
+        wp.launch(
+            _scatter_color_order,
+            dim=self.capacity,
+            inputs=[self.colors, color_count],
+            outputs=[self.cursors, self.order],
+            device=device,
+        )
+
+
+class ColoredGaussSeidelProjection:
+    """Own fixed-capacity coloring and projection scratch for one LOX solver.
+
+    The effective color count is the requested maximum bounded by total
+    allocated unilateral capacity, with one internal color retained for empty
+    or single-constraint systems. The endpoint occupancy tables use int32
+    atomics. Scratch is allocated only for requested counts of at least two;
+    the one-color endpoint uses the existing Jacobi
+    implementation directly.
+    """
+
+    def __init__(self, problem, color_count: int):
+        if color_count < 2:
+            raise ValueError("Colored Gauss-Seidel requires at least two colors.")
+        self.problem = problem
+        rigid_capacity = problem.friction_capacity + problem.contact_capacity + problem.limit_capacity
+        self.color_count = max(1, min(color_count, rigid_capacity))
+        self.device = problem.device
+        body_count = problem.body_constraint_count.shape[0]
+        self.body_occupancy = wp.zeros((body_count, self.color_count), dtype=wp.int32, device=self.device)
+        self.rigid_world_color_count = wp.zeros(
+            (problem.world_contact_count.shape[0], self.color_count),
+            dtype=wp.int32,
+            device=self.device,
+        )
+        self.body_locks = wp.full(body_count, _LOCK_FREE, dtype=wp.int32, device=self.device)
+        self.friction = _ColorFamily(problem.friction_capacity, self.color_count, self.device)
+        self.contact = _ColorFamily(problem.contact_capacity, self.color_count, self.device)
+        self.limit = _ColorFamily(problem.limit_capacity, self.color_count, self.device)
+        self.friction_delassus = wp.zeros(self.friction.capacity, dtype=wp.float32, device=self.device)
+        self.contact_delassus = wp.zeros(self.contact.capacity, dtype=wp.mat33f, device=self.device)
+        self.limit_delassus = wp.zeros(self.limit.capacity, dtype=wp.float32, device=self.device)
+        self._families = (self.friction, self.contact, self.limit)
+        self.rigid_worker_count = _bounded_worker_count(rigid_capacity, self.device)
+        self._fuse_rigid_families = sum(family.capacity > 0 for family in self._families) > 1
+
+    def _launch_rigid_families(self, kernel, extra_inputs: tuple = ()) -> None:
+        problem = self.problem
+        if problem is None:
+            return
+        entries = (
+            (
+                self.friction,
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                0,
+            ),
+            (
+                self.contact,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                1,
+            ),
+            (
+                self.limit,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                2,
+            ),
+        )
+        key_offset = 0
+        for family, worlds, local, counts, first, second, salt in entries:
+            if family.capacity > 0:
+                if kernel is _assign_two_endpoint_colors:
+                    inputs = [worlds, local, counts, first, second, salt, self.color_count]
+                    outputs = [family.colors]
+                elif kernel is _count_two_endpoint_occupancy:
+                    inputs = [worlds, local, counts, first, second, family.colors]
+                    outputs = [self.body_occupancy, self.rigid_world_color_count]
+                elif kernel is _propose_and_claim_two_endpoint_repairs:
+                    inputs = [
+                        worlds,
+                        local,
+                        counts,
+                        first,
+                        second,
+                        self.color_count,
+                        key_offset,
+                        family.colors,
+                        self.body_occupancy,
+                    ]
+                    outputs = [family.proposals, self.body_locks]
+                else:
+                    inputs = [worlds, first, second, key_offset, family.colors, family.proposals, self.body_locks]
+                    outputs = [self.body_occupancy, self.rigid_world_color_count]
+                wp.launch(kernel, dim=family.capacity, inputs=inputs, outputs=outputs, device=self.device)
+            key_offset += family.capacity
+
+    def build_colors(self) -> None:
+        self.body_occupancy.zero_()
+        self.rigid_world_color_count.zero_()
+        self._launch_rigid_families(_assign_two_endpoint_colors)
+        self._launch_rigid_families(_count_two_endpoint_occupancy)
+        for _repair in range(_COLOR_REPAIR_PASSES):
+            self.body_locks.fill_(_LOCK_FREE)
+            self._launch_rigid_families(_propose_and_claim_two_endpoint_repairs)
+            self._launch_rigid_families(_commit_two_endpoint_repairs)
+        for family in self._families:
+            family.compact(self.color_count, self.device)
+
+    def prepare(self, inverse_weight: wp.array[mat66f] | None, prepared_status: wp.array[wp.int32]) -> None:
+        self.build_colors()
+        problem = self.problem
+        if problem is not None:
+            prepare_jacobi_projection_data(
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                problem.friction_jacobian_first,
+                problem.friction_jacobian_second,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                problem.contact_jacobian_first,
+                problem.contact_jacobian_second,
+                problem.contact_bias,
+                problem.contact_friction,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                problem.limit_jacobian_first,
+                problem.limit_jacobian_second,
+                problem.body_constraint_count,
+                problem.static_body_constraint_count,
+                inverse_weight,
+                problem.friction_projection_delassus,
+                problem.contact_projection_delassus,
+                problem.limit_projection_delassus,
+                prepared_status,
+            )
+            if self.rigid_worker_count > 0:
+                for color in range(self.color_count):
+                    if self._fuse_rigid_families:
+                        wp.launch(
+                            _prepare_rigid_colored,
+                            dim=self.rigid_worker_count,
+                            inputs=[
+                                self.rigid_worker_count,
+                                color,
+                                self.friction.counts,
+                                self.friction.offsets,
+                                self.friction.order,
+                                problem.friction_world,
+                                problem.friction_body_first,
+                                problem.friction_body_second,
+                                problem.friction_jacobian_first,
+                                problem.friction_jacobian_second,
+                                self.contact.counts,
+                                self.contact.offsets,
+                                self.contact.order,
+                                problem.contact_world,
+                                problem.contact_body_first,
+                                problem.contact_body_second,
+                                problem.contact_jacobian_first,
+                                problem.contact_jacobian_second,
+                                problem.contact_bias,
+                                problem.contact_friction,
+                                self.limit.counts,
+                                self.limit.offsets,
+                                self.limit.order,
+                                problem.limit_world,
+                                problem.limit_body_first,
+                                problem.limit_body_second,
+                                problem.limit_jacobian_first,
+                                problem.limit_jacobian_second,
+                                self.body_occupancy,
+                                inverse_weight,
+                            ],
+                            outputs=[
+                                self.friction_delassus,
+                                self.contact_delassus,
+                                self.limit_delassus,
+                                prepared_status,
+                            ],
+                            device=self.device,
+                            block_dim=_COLOR_BLOCK_DIM,
+                        )
+                    else:
+                        if self.friction.capacity > 0:
+                            wp.launch(
+                                _prepare_frictions_colored,
+                                dim=self.friction.worker_count,
+                                inputs=[
+                                    self.friction.worker_count,
+                                    color,
+                                    self.friction.counts,
+                                    self.friction.offsets,
+                                    self.friction.order,
+                                    problem.friction_world,
+                                    problem.friction_body_first,
+                                    problem.friction_body_second,
+                                    problem.friction_jacobian_first,
+                                    problem.friction_jacobian_second,
+                                    self.body_occupancy,
+                                    inverse_weight,
+                                ],
+                                outputs=[self.friction_delassus, prepared_status],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                        elif self.contact.capacity > 0:
+                            wp.launch(
+                                _prepare_contacts_colored,
+                                dim=self.contact.worker_count,
+                                inputs=[
+                                    self.contact.worker_count,
+                                    color,
+                                    self.contact.counts,
+                                    self.contact.offsets,
+                                    self.contact.order,
+                                    problem.contact_world,
+                                    problem.contact_body_first,
+                                    problem.contact_body_second,
+                                    problem.contact_jacobian_first,
+                                    problem.contact_jacobian_second,
+                                    problem.contact_bias,
+                                    problem.contact_friction,
+                                    self.body_occupancy,
+                                    inverse_weight,
+                                ],
+                                outputs=[self.contact_delassus, prepared_status],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                        else:
+                            wp.launch(
+                                _prepare_frictions_colored,
+                                dim=self.limit.worker_count,
+                                inputs=[
+                                    self.limit.worker_count,
+                                    color,
+                                    self.limit.counts,
+                                    self.limit.offsets,
+                                    self.limit.order,
+                                    problem.limit_world,
+                                    problem.limit_body_first,
+                                    problem.limit_body_second,
+                                    problem.limit_jacobian_first,
+                                    problem.limit_jacobian_second,
+                                    self.body_occupancy,
+                                    inverse_weight,
+                                ],
+                                outputs=[self.limit_delassus, prepared_status],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+        else:
+            prepared_status.fill_(PROJECTION_STATUS_VALID)
+
+    def project(
+        self,
+        iterations: int,
+        world_active: wp.array[wp.bool],
+        body_world: wp.array[wp.int32] | None,
+        inverse_weight: wp.array[mat66f] | None,
+        projected_twist: wp.array[vec6f] | None,
+        twist_delta: wp.array[vec6f] | None,
+        prepared_status: wp.array[wp.int32],
+        projection_status: wp.array[wp.int32],
+    ) -> None:
+        problem = self.problem
+        world_count = world_active.shape[0]
+        world_body_offset = None
+        world_body_count = None
+        world_friction_offset = None
+        world_contact_offset = None
+        world_limit_offset = None
+        if problem is not None:
+            model_info = getattr(getattr(problem, "model", None), "info", None)
+            if model_info is not None:
+                world_body_offset = model_info.bodies_offset
+                world_body_count = model_info.num_bodies
+            world_friction_offset = getattr(problem, "world_friction_offset", None)
+            world_contact_offset = getattr(problem, "world_contact_offset", None)
+            world_limit_offset = getattr(problem, "world_limit_offset", None)
+        use_world_projection = _can_fuse_rigid_projection_by_world(
+            self.device,
+            world_count,
+            required_world_arrays=(
+                world_body_offset,
+                world_body_count,
+                world_friction_offset,
+                world_contact_offset,
+                world_limit_offset,
+            ),
+            parallel_constraint_capacity=(
+                problem.friction_capacity + problem.contact_capacity + problem.limit_capacity + self.color_count - 1
+            )
+            // self.color_count
+            if problem is not None
+            else None,
+            world_block_dim=_WORLD_COLOR_BLOCK_DIM,
+            minimum_blocks_per_sm=1,
+        )
+        if use_world_projection:
+            state = _make_rigid_projection_state(
+                world_active, projected_twist, twist_delta, projection_status, self.body_occupancy, inverse_weight
+            )
+            contact_data = _RigidContactProjectionData()
+            contact_data.body_first = problem.contact_body_first
+            contact_data.body_second = problem.contact_body_second
+            contact_data.jacobian_first = problem.contact_jacobian_first
+            contact_data.jacobian_second = problem.contact_jacobian_second
+            contact_data.delassus = self.contact_delassus
+            contact_data.bias = problem.contact_bias
+            contact_data.friction = problem.contact_friction
+            contact_data.reaction = problem.contact_reaction
+            data = _RigidColoredWorldData()
+            data.world_color_count = self.rigid_world_color_count
+            data.world_friction_offset = world_friction_offset
+            data.world_friction_count = problem.world_friction_count
+            data.friction_colors = self.friction.colors
+            data.friction_body_first = problem.friction_body_first
+            data.friction_body_second = problem.friction_body_second
+            data.friction_jacobian_first = problem.friction_jacobian_first
+            data.friction_jacobian_second = problem.friction_jacobian_second
+            data.friction_bound = problem.friction_impulse_bound
+            data.friction_colored_delassus = self.friction_delassus
+            data.friction_jacobi_delassus = problem.friction_projection_delassus
+            data.friction_reaction = problem.friction_reaction
+            data.world_contact_offset = world_contact_offset
+            data.world_contact_count = problem.world_contact_count
+            data.contact_colors = self.contact.colors
+            data.contact_jacobi_delassus = problem.contact_projection_delassus
+            data.world_limit_offset = world_limit_offset
+            data.world_limit_count = problem.world_limit_count
+            data.limit_colors = self.limit.colors
+            data.limit_body_first = problem.limit_body_first
+            data.limit_body_second = problem.limit_body_second
+            data.limit_jacobian_first = problem.limit_jacobian_first
+            data.limit_jacobian_second = problem.limit_jacobian_second
+            data.limit_bias = problem.limit_bias
+            data.limit_colored_delassus = self.limit_delassus
+            data.limit_jacobi_delassus = problem.limit_projection_delassus
+            data.limit_reaction = problem.limit_reaction
+            wp.launch(
+                _project_rigid_colored_by_world,
+                dim=(world_count, _WORLD_COLOR_BLOCK_DIM),
+                block_dim=_WORLD_COLOR_BLOCK_DIM,
+                inputs=[
+                    iterations,
+                    self.color_count,
+                    world_body_offset,
+                    world_body_count,
+                    data,
+                    contact_data,
+                    state,
+                    prepared_status,
+                ],
+                device=self.device,
+            )
+            return
+        if problem is not None:
+            wp.launch(
+                _initialize_jacobi_projection_status,
+                dim=world_active.shape[0],
+                inputs=[world_active, prepared_status],
+                outputs=[projection_status],
+                device=self.device,
+            )
+            twist_delta.zero_()
+            if self.friction.capacity > 0:
+                wp.launch(
+                    _warmstart_frictions_jacobi,
+                    dim=self.friction.capacity,
+                    inputs=[
+                        problem.friction_world,
+                        problem.friction_local,
+                        world_active,
+                        prepared_status,
+                        problem.world_friction_count,
+                        problem.friction_body_first,
+                        problem.friction_body_second,
+                        problem.friction_jacobian_first,
+                        problem.friction_jacobian_second,
+                        inverse_weight,
+                        True,
+                        problem.friction_reaction,
+                    ],
+                    outputs=[twist_delta],
+                    device=self.device,
+                )
+            if self.contact.capacity > 0:
+                wp.launch(
+                    _warmstart_contacts_jacobi,
+                    dim=self.contact.capacity,
+                    inputs=[
+                        problem.contact_world,
+                        problem.contact_local,
+                        world_active,
+                        prepared_status,
+                        problem.world_contact_count,
+                        problem.contact_body_first,
+                        problem.contact_body_second,
+                        problem.contact_jacobian_first,
+                        problem.contact_jacobian_second,
+                        inverse_weight,
+                        True,
+                        problem.contact_reaction,
+                    ],
+                    outputs=[twist_delta],
+                    device=self.device,
+                )
+            if self.limit.capacity > 0:
+                wp.launch(
+                    _warmstart_limits_jacobi,
+                    dim=self.limit.capacity,
+                    inputs=[
+                        problem.limit_world,
+                        problem.limit_local,
+                        world_active,
+                        prepared_status,
+                        problem.world_limit_count,
+                        problem.limit_body_first,
+                        problem.limit_body_second,
+                        problem.limit_jacobian_first,
+                        problem.limit_jacobian_second,
+                        inverse_weight,
+                        True,
+                        problem.limit_reaction,
+                    ],
+                    outputs=[twist_delta],
+                    device=self.device,
+                )
+            wp.launch(
+                _apply_body_delta,
+                dim=projected_twist.shape[0],
+                inputs=[body_world, world_active, projection_status],
+                outputs=[twist_delta, projected_twist],
+                device=self.device,
+            )
+        else:
+            wp.copy(projection_status, prepared_status)
+        rigid_projection_state = None
+        rigid_contact_data = None
+        friction_index = None
+        contact_index = None
+        limit_index = None
+        if problem is not None:
+            rigid_projection_state = _make_rigid_projection_state(
+                world_active, projected_twist, twist_delta, projection_status, self.body_occupancy, inverse_weight
+            )
+            rigid_contact_data = _RigidContactProjectionData()
+            rigid_contact_data.body_first = problem.contact_body_first
+            rigid_contact_data.body_second = problem.contact_body_second
+            rigid_contact_data.jacobian_first = problem.contact_jacobian_first
+            rigid_contact_data.jacobian_second = problem.contact_jacobian_second
+            rigid_contact_data.delassus = self.contact_delassus
+            rigid_contact_data.bias = problem.contact_bias
+            rigid_contact_data.friction = problem.contact_friction
+            rigid_contact_data.reaction = problem.contact_reaction
+            friction_index = _make_colored_projection_index(
+                problem.friction_world, self.friction.counts, self.friction.offsets, self.friction.order
+            )
+            contact_index = _make_colored_projection_index(
+                problem.contact_world, self.contact.counts, self.contact.offsets, self.contact.order
+            )
+            limit_index = _make_colored_projection_index(
+                problem.limit_world, self.limit.counts, self.limit.offsets, self.limit.order
+            )
+        for _iteration in range(iterations):
+            for color in range(self.color_count):
+                if problem is not None:
+                    if self.rigid_worker_count > 0:
+                        if self._fuse_rigid_families:
+                            wp.launch(
+                                _project_rigid_colored,
+                                dim=self.rigid_worker_count,
+                                inputs=[
+                                    self.rigid_worker_count,
+                                    color,
+                                    self.friction.counts,
+                                    self.friction.offsets,
+                                    self.friction.order,
+                                    problem.friction_world,
+                                    problem.friction_body_first,
+                                    problem.friction_body_second,
+                                    problem.friction_jacobian_first,
+                                    problem.friction_jacobian_second,
+                                    problem.friction_impulse_bound,
+                                    self.friction_delassus,
+                                    self.contact.counts,
+                                    self.contact.offsets,
+                                    self.contact.order,
+                                    problem.contact_world,
+                                    rigid_contact_data,
+                                    self.limit.counts,
+                                    self.limit.offsets,
+                                    self.limit.order,
+                                    problem.limit_world,
+                                    problem.limit_body_first,
+                                    problem.limit_body_second,
+                                    problem.limit_jacobian_first,
+                                    problem.limit_jacobian_second,
+                                    problem.limit_bias,
+                                    self.limit_delassus,
+                                    rigid_projection_state,
+                                ],
+                                outputs=[problem.friction_reaction, problem.limit_reaction],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                        elif self.friction.capacity > 0:
+                            wp.launch(
+                                _make_project_scalar_kernel(True, False),
+                                dim=self.friction.worker_count,
+                                inputs=[
+                                    self.friction.worker_count,
+                                    color,
+                                    friction_index,
+                                    problem.friction_body_first,
+                                    problem.friction_body_second,
+                                    problem.friction_jacobian_first,
+                                    problem.friction_jacobian_second,
+                                    problem.friction_impulse_bound,
+                                    problem.friction_impulse_bound,
+                                    self.friction_delassus,
+                                    problem.friction_reaction,
+                                    rigid_projection_state,
+                                ],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                        elif self.contact.capacity > 0:
+                            wp.launch(
+                                _make_project_contacts_kernel(True),
+                                dim=self.contact.worker_count,
+                                inputs=[
+                                    self.contact.worker_count,
+                                    color,
+                                    contact_index,
+                                    rigid_contact_data,
+                                    rigid_projection_state,
+                                ],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                        else:
+                            wp.launch(
+                                _make_project_scalar_kernel(True, True),
+                                dim=self.limit.worker_count,
+                                inputs=[
+                                    self.limit.worker_count,
+                                    color,
+                                    limit_index,
+                                    problem.limit_body_first,
+                                    problem.limit_body_second,
+                                    problem.limit_jacobian_first,
+                                    problem.limit_jacobian_second,
+                                    problem.limit_bias,
+                                    problem.limit_bias,
+                                    self.limit_delassus,
+                                    problem.limit_reaction,
+                                    rigid_projection_state,
+                                ],
+                                device=self.device,
+                                block_dim=_COLOR_BLOCK_DIM,
+                            )
+                if problem is not None:
+                    wp.launch(
+                        _apply_body_delta,
+                        dim=projected_twist.shape[0],
+                        inputs=[body_world, world_active, projection_status],
+                        outputs=[twist_delta, projected_twist],
+                        device=self.device,
+                    )
+        if problem is not None:
+            project_constraints_jacobi(
+                1,
+                world_active,
+                body_world,
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                problem.friction_jacobian_first,
+                problem.friction_jacobian_second,
+                problem.friction_impulse_bound,
+                problem.friction_projection_delassus,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                problem.contact_jacobian_first,
+                problem.contact_jacobian_second,
+                problem.contact_bias,
+                problem.contact_friction,
+                problem.contact_projection_delassus,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                problem.limit_jacobian_first,
+                problem.limit_jacobian_second,
+                problem.limit_bias,
+                problem.limit_projection_delassus,
+                inverse_weight,
+                projected_twist,
+                twist_delta,
+                problem.contact_reaction,
+                problem.limit_reaction,
+                problem.friction_reaction,
+                prepared_status,
+                projection_status,
+                warm_start=False,
+            )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/contact.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/contact.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local isotropic Coulomb-contact numerical primitives.
+
+This module is deliberately independent of Kamino containers. Contact vectors
+use Kamino's normal-last convention ``(tangent_0, tangent_1, normal)``.
+
+The local solve expects a symmetric positive-definite ``3 x 3`` Delassus
+block. Degenerate blocks must be regularized during contact preprocessing.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+__all__ = [
+    "compute_contact_scaled_alart_curnier_residual",
+    "project_contact_coulomb_cone",
+    "solve_contact_coulomb_newton",
+]
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _solve_symmetric_mat22(
+    a00: wp.float32,
+    a01: wp.float32,
+    a11: wp.float32,
+    b0: wp.float32,
+    b1: wp.float32,
+) -> wp.vec2f:
+    det = a00 * a11 - a01 * a01
+    inv_det = 1.0 / det
+    return wp.vec2f((a11 * b0 - a01 * b1) * inv_det, (a00 * b1 - a01 * b0) * inv_det)
+
+
+@wp.func
+def _compute_sliding_root_value(
+    tangent00: wp.float32,
+    tangent01: wp.float32,
+    tangent11: wp.float32,
+    tangent_rhs: wp.vec2f,
+    friction_normal_tangent: wp.vec2f,
+    friction_normal_rhs: wp.float32,
+    alpha: wp.float32,
+) -> wp.float32:
+    shifted00 = tangent00 + alpha
+    shifted11 = tangent11 + alpha
+    s = _solve_symmetric_mat22(
+        shifted00,
+        tangent01,
+        shifted11,
+        tangent_rhs[0],
+        tangent_rhs[1],
+    )
+    return wp.length(s) - wp.dot(friction_normal_tangent, s) + friction_normal_rhs
+
+
+@wp.func
+def _compute_sliding_root_data(
+    tangent00: wp.float32,
+    tangent01: wp.float32,
+    tangent11: wp.float32,
+    tangent_rhs: wp.vec2f,
+    friction_normal_tangent: wp.vec2f,
+    friction_normal_rhs: wp.float32,
+    alpha: wp.float32,
+) -> wp.vec4f:
+    shifted00 = tangent00 + alpha
+    shifted11 = tangent11 + alpha
+    determinant = shifted00 * shifted11 - tangent01 * tangent01
+    inverse_determinant = 1.0 / determinant
+    s = wp.vec2f(
+        (shifted11 * tangent_rhs[0] - tangent01 * tangent_rhs[1]) * inverse_determinant,
+        (shifted00 * tangent_rhs[1] - tangent01 * tangent_rhs[0]) * inverse_determinant,
+    )
+    t = wp.vec2f(
+        (shifted11 * s[0] - tangent01 * s[1]) * inverse_determinant,
+        (shifted00 * s[1] - tangent01 * s[0]) * inverse_determinant,
+    )
+    s_norm = wp.length(s)
+    value = s_norm - wp.dot(friction_normal_tangent, s) + friction_normal_rhs
+    derivative = wp.float32(0.0)
+    if s_norm > 1.0e-30:
+        derivative = -(wp.dot(s, t)) / s_norm + wp.dot(friction_normal_tangent, t)
+    return wp.vec4f(value, derivative, s[0], s[1])
+
+
+@wp.func
+def _solve_contact_coulomb_newton_components(
+    normal_delassus: wp.float32,
+    normal_tangent: wp.vec2f,
+    tangent_delassus00: wp.float32,
+    tangent_delassus01: wp.float32,
+    tangent_delassus11: wp.float32,
+    normal_rhs: wp.float32,
+    tangent_rhs_raw: wp.vec2f,
+    friction: wp.float32,
+) -> wp.vec3f:
+    """Solve from layout-independent normal and tangential components."""
+    # These branches also avoid touching an unused, potentially ill-conditioned
+    # tangential block for separating or frictionless contacts.
+    if normal_rhs >= 0.0:
+        return wp.vec3f(0.0, 0.0, 0.0)
+    if friction <= 0.0:
+        return wp.vec3f(0.0, 0.0, -normal_rhs / normal_delassus)
+
+    inverse_normal_delassus = 1.0 / normal_delassus
+    tangent00 = tangent_delassus00 - normal_tangent[0] * normal_tangent[0] * inverse_normal_delassus
+    tangent01 = tangent_delassus01 - normal_tangent[0] * normal_tangent[1] * inverse_normal_delassus
+    tangent11 = tangent_delassus11 - normal_tangent[1] * normal_tangent[1] * inverse_normal_delassus
+    tangent_rhs = tangent_rhs_raw - (normal_rhs * inverse_normal_delassus) * normal_tangent
+    friction_over_normal = friction * inverse_normal_delassus
+    friction_normal_tangent = friction_over_normal * normal_tangent
+    friction_normal_rhs = friction_over_normal * normal_rhs
+
+    unshifted = _solve_symmetric_mat22(
+        tangent00,
+        tangent01,
+        tangent11,
+        tangent_rhs[0],
+        tangent_rhs[1],
+    )
+    value_at_zero = wp.length(unshifted) - wp.dot(friction_normal_tangent, unshifted) + friction_normal_rhs
+    if value_at_zero <= 1.0e-7:
+        tangent_reaction = -unshifted
+        normal_reaction = -(wp.dot(normal_tangent, tangent_reaction) + normal_rhs) * inverse_normal_delassus
+        return wp.vec3f(tangent_reaction[0], tangent_reaction[1], normal_reaction)
+
+    # Normalizing alpha by the Schur-complement scale keeps the fixed root
+    # tolerances useful across contact blocks with different magnitudes.
+    alpha_scale = wp.max(wp.abs(tangent00), wp.abs(tangent01))
+    alpha_scale = wp.max(alpha_scale, wp.abs(tangent11))
+    alpha_scale = wp.max(alpha_scale, 1.0e-20)
+
+    lower = wp.float32(0.0)
+    upper = wp.float32(1.0)
+    last_s = unshifted
+    for _ in range(64):
+        upper_value = _compute_sliding_root_value(
+            tangent00,
+            tangent01,
+            tangent11,
+            tangent_rhs,
+            friction_normal_tangent,
+            friction_normal_rhs,
+            upper * alpha_scale,
+        )
+        if upper_value <= 0.0:
+            break
+        upper = upper * 2.0
+
+    alpha = 0.5 * (lower + upper)
+    for _ in range(12):
+        root_data = _compute_sliding_root_data(
+            tangent00,
+            tangent01,
+            tangent11,
+            tangent_rhs,
+            friction_normal_tangent,
+            friction_normal_rhs,
+            alpha * alpha_scale,
+        )
+        value = root_data[0]
+        derivative = root_data[1] * alpha_scale
+        last_s = wp.vec2f(root_data[2], root_data[3])
+
+        if wp.abs(value) <= 1.0e-7 or wp.abs(upper - lower) <= 1.0e-7 * (1.0 + upper):
+            break
+
+        if value > 0.0:
+            lower = alpha
+        else:
+            upper = alpha
+
+        width = upper - lower
+        next_alpha = 0.5 * (lower + upper)
+        if derivative != 0.0 and wp.isfinite(derivative):
+            newton_alpha = alpha - value / derivative
+            if (
+                newton_alpha > lower
+                and newton_alpha < upper
+                and wp.abs(newton_alpha - alpha) > 1.0e-7 * wp.max(1.0, width)
+            ):
+                next_alpha = newton_alpha
+        alpha = next_alpha
+
+    tangent_reaction = -last_s
+    normal_reaction = -(wp.dot(normal_tangent, tangent_reaction) + normal_rhs) * inverse_normal_delassus
+    return wp.vec3f(tangent_reaction[0], tangent_reaction[1], normal_reaction)
+
+
+@wp.func
+def solve_contact_coulomb_newton(
+    delassus: wp.mat33f,
+    free_velocity: wp.vec3f,
+    friction: wp.float32,
+) -> wp.vec3f:
+    """Solve one normal-last isotropic Coulomb contact.
+
+    The returned impulse ``reaction`` satisfies the contact law for
+    ``velocity = delassus @ reaction + free_velocity``. Sliding contacts are
+    reduced to a scalar root and solved by bracketed Newton. Every rejected or
+    unusable Newton step falls back to bisection of the current bracket.
+
+    Args:
+        delassus: Symmetric positive-definite local Delassus block.
+        free_velocity: Contact velocity before applying the local impulse.
+        friction: Nonnegative isotropic Coulomb friction coefficient.
+
+    Returns:
+        The normal-last contact impulse.
+    """
+    return _solve_contact_coulomb_newton_components(
+        delassus[2, 2],
+        wp.vec2f(delassus[0, 2], delassus[1, 2]),
+        delassus[0, 0],
+        delassus[0, 1],
+        delassus[1, 1],
+        free_velocity[2],
+        wp.vec2f(free_velocity[0], free_velocity[1]),
+        friction,
+    )
+
+
+@wp.func
+def project_contact_coulomb_cone(value: wp.vec3f, friction: wp.float32) -> wp.vec3f:
+    """Project a normal-last vector onto an isotropic Coulomb cone.
+
+    Args:
+        value: Normal-last vector to project.
+        friction: Nonnegative isotropic Coulomb friction coefficient.
+
+    Returns:
+        The Euclidean projection of ``value``. Invalid friction disables the
+        contact and returns zero, while a non-finite vector is preserved for
+        the caller's projection-status check.
+    """
+    if not wp.isfinite(value):
+        return value
+    if not wp.isfinite(friction) or friction < 0.0:
+        return wp.vec3f(0.0)
+
+    tangent_norm = wp.length(wp.vec2f(value[0], value[1]))
+    normal = value[2]
+    if normal + friction * tangent_norm <= 0.0:
+        return wp.vec3f(0.0)
+    if tangent_norm <= friction * normal:
+        return value
+
+    projected_normal = (normal + friction * tangent_norm) / (1.0 + friction * friction)
+    tangent_scale = friction * projected_normal / tangent_norm
+    return wp.vec3f(tangent_scale * value[0], tangent_scale * value[1], projected_normal)
+
+
+@wp.func
+def _compute_contact_delassus_scale(delassus: wp.mat33f) -> wp.float32:
+    trace_scale = (wp.abs(delassus[0, 0]) + wp.abs(delassus[1, 1]) + wp.abs(delassus[2, 2])) / 3.0
+    return wp.sqrt(wp.max(trace_scale, 1.0e-30))
+
+
+@wp.func
+def compute_contact_scaled_alart_curnier_residual(
+    delassus: wp.mat33f,
+    reaction: wp.vec3f,
+    velocity: wp.vec3f,
+    friction: wp.float32,
+) -> wp.vec3f:
+    """Compute the Delassus-scaled Alart--Curnier contact residual.
+
+    Args:
+        delassus: Symmetric positive-definite local Delassus block.
+        reaction: Normal-last contact impulse.
+        velocity: Resulting normal-last contact velocity.
+        friction: Nonnegative isotropic Coulomb friction coefficient.
+
+    Returns:
+        The normal-last scaled natural-map residual.
+    """
+    scale = _compute_contact_delassus_scale(delassus)
+    scaled_reaction = scale * reaction
+    scaled_velocity = velocity / scale
+    modified_velocity = wp.vec3f(
+        scaled_velocity[0],
+        scaled_velocity[1],
+        scaled_velocity[2] + friction * wp.length(wp.vec2f(scaled_velocity[0], scaled_velocity[1])),
+    )
+    projected = project_contact_coulomb_cone(scaled_reaction - modified_velocity, friction)
+    return scaled_reaction - projected

--- a/newton/_src/solvers/kamino/_src/solvers/lox/jacobi.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/jacobi.py
@@ -1,0 +1,1001 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Jacobi scheduling and acceleration for LOX unilateral projections."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from ...core.types import mat36f, mat66f, vec6f
+from .contact import project_contact_coulomb_cone
+from .projection import (
+    PROJECTION_STATUS_VALID,
+    _atomic_add_twist,
+    _can_fuse_rigid_projection_by_world,
+    _check_projected_twist,
+    _initialize_jacobi_projection_status,
+    _make_direct_projection_index,
+    _make_project_contacts_kernel,
+    _make_project_scalar_kernel,
+    _make_rigid_projection_state,
+    _project_rigid_contact_jacobi,
+    _project_rigid_friction_jacobi,
+    _project_rigid_limit_jacobi,
+    _RigidContactProjectionData,
+    _RigidProjectionState,
+    _sync_threads,
+    _validate_projected_twists,
+    _warmstart_contacts_jacobi,
+    _warmstart_frictions_jacobi,
+    _warmstart_limits_jacobi,
+)
+
+__all__ = ["project_constraints_jacobi"]
+
+wp.set_module_options({"enable_backward": False})
+
+_JACOBI_CONTACT_BLOCK_DIM = 128
+_JACOBI_CONTACT_PROJECTION_BLOCKS_PER_SM = 5
+_JACOBI_WORLD_BLOCK_DIM = 128
+
+
+@wp.kernel
+def _project_rigid_constraints_jacobi_by_world(
+    projection_iterations: wp.int32,
+    warm_start: wp.bool,
+    body_offset: wp.array[wp.int32],
+    body_count: wp.array[wp.int32],
+    world_friction_offset: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    friction_impulse_bound: wp.array[wp.float32],
+    friction_delassus: wp.array[wp.float32],
+    world_contact_offset: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    world_limit_offset: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    limit_bias: wp.array[wp.float32],
+    limit_delassus: wp.array[wp.float32],
+    friction_reaction: wp.array[wp.float32],
+    limit_reaction: wp.array[wp.float32],
+    contact_data: _RigidContactProjectionData,
+    state: _RigidProjectionState,
+):
+    world, lane = wp.tid()
+    if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+        return
+
+    thread_count = wp.block_dim()
+    local = lane
+    while local < body_count[world]:
+        state.twist_delta[body_offset[world] + local] = vec6f(0.0)
+        local += thread_count
+    _sync_threads()
+
+    if warm_start:
+        local = lane
+        while local < world_friction_count[world]:
+            friction = world_friction_offset[world] + local
+            friction_first = friction_body_first[friction]
+            friction_second = friction_body_second[friction]
+            friction_impulse = friction_reaction[friction]
+            if friction_first >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    friction_first,
+                    friction_jacobian_first[friction] * friction_impulse,
+                )
+            if friction_second >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    friction_second,
+                    friction_jacobian_second[friction] * friction_impulse,
+                )
+            local += thread_count
+
+        local = lane
+        while local < world_contact_count[world]:
+            contact = world_contact_offset[world] + local
+            contact_first = contact_data.body_first[contact]
+            contact_second = contact_data.body_second[contact]
+            contact_impulse = contact_data.reaction[contact]
+            if contact_first >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    contact_first,
+                    wp.transpose(contact_data.jacobian_first[contact]) @ contact_impulse,
+                )
+            if contact_second >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    contact_second,
+                    wp.transpose(contact_data.jacobian_second[contact]) @ contact_impulse,
+                )
+            local += thread_count
+
+        local = lane
+        while local < world_limit_count[world]:
+            limit = world_limit_offset[world] + local
+            limit_first = limit_body_first[limit]
+            limit_second = limit_body_second[limit]
+            limit_impulse = limit_reaction[limit]
+            if limit_first >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    limit_first,
+                    limit_jacobian_first[limit] * limit_impulse,
+                )
+            if limit_second >= 0:
+                _atomic_add_twist(
+                    state.twist_delta,
+                    limit_second,
+                    limit_jacobian_second[limit] * limit_impulse,
+                )
+            local += thread_count
+
+        _sync_threads()
+        local = lane
+        while local < body_count[world]:
+            body = body_offset[world] + local
+            warmstart_correction = state.inverse_weight[body] @ state.twist_delta[body]
+            state.projected_twist[body] += warmstart_correction
+            state.twist_delta[body] = vec6f(0.0)
+            local += thread_count
+        _sync_threads()
+        if state.world_status[world] != PROJECTION_STATUS_VALID:
+            return
+
+    for _sweep in range(projection_iterations):
+        local = lane
+        while local < world_friction_count[world]:
+            constraint = world_friction_offset[world] + local
+            _project_rigid_friction_jacobi(
+                constraint,
+                world,
+                0,
+                friction_body_first,
+                friction_body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                friction_impulse_bound,
+                friction_impulse_bound,
+                friction_delassus,
+                friction_reaction,
+                state,
+            )
+            local += thread_count
+
+        local = lane
+        while local < world_contact_count[world]:
+            contact = world_contact_offset[world] + local
+            _project_rigid_contact_jacobi(contact, world, 0, contact_data, contact_data.delassus, state)
+            local += thread_count
+
+        local = lane
+        while local < world_limit_count[world]:
+            constraint = world_limit_offset[world] + local
+            _project_rigid_limit_jacobi(
+                constraint,
+                world,
+                0,
+                limit_body_first,
+                limit_body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                limit_bias,
+                limit_bias,
+                limit_delassus,
+                limit_reaction,
+                state,
+            )
+            local += thread_count
+
+        _sync_threads()
+        local = lane
+        while local < body_count[world]:
+            body = body_offset[world] + local
+            if state.world_status[world] == PROJECTION_STATUS_VALID:
+                correction = state.inverse_weight[body] @ state.twist_delta[body]
+                state.projected_twist[body] += correction
+            state.twist_delta[body] = vec6f(0.0)
+            local += thread_count
+        _sync_threads()
+        if state.world_status[world] != PROJECTION_STATUS_VALID:
+            return
+
+    # Validate once after all sweeps, including bodies without constraints.
+    local = lane
+    while local < body_count[world]:
+        body = body_offset[world] + local
+        _check_projected_twist(body, world, state.projected_twist, state.world_status)
+        local += thread_count
+
+
+@wp.kernel
+def _apply_jacobi_twist_delta(
+    body_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    twist_delta: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+):
+    body = wp.tid()
+    world = body_world[body]
+    if world_active[world] and world_status[world] == PROJECTION_STATUS_VALID:
+        correction = inverse_weight[body] @ twist_delta[body]
+        projected_twist[body] += correction
+    twist_delta[body] = vec6f(0.0)
+
+
+@wp.kernel
+def _initialize_acceleration_worlds(
+    world_active: wp.array[wp.bool],
+    prepared_status: wp.array[wp.int32],
+    theta: wp.array[wp.float32],
+    beta: wp.array[wp.float32],
+    restart_dot: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    world = wp.tid()
+    if world_active[world]:
+        theta[world] = 1.0
+        beta[world] = 0.0
+        restart_dot[world] = 0.0
+        world_status[world] = prepared_status[world]
+
+
+@wp.kernel
+def _initialize_accelerated_reactions(
+    friction_capacity: int,
+    contact_capacity: int,
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_bound: wp.array[wp.float32],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_friction: wp.array[wp.float32],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    friction_reaction: wp.array[wp.float32],
+    friction_trial: wp.array[wp.float32],
+    friction_previous: wp.array[wp.float32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_trial: wp.array[wp.vec3f],
+    contact_previous: wp.array[wp.vec3f],
+    limit_reaction: wp.array[wp.float32],
+    limit_trial: wp.array[wp.float32],
+    limit_previous: wp.array[wp.float32],
+):
+    constraint = wp.tid()
+    if constraint < friction_capacity:
+        world = friction_world[constraint]
+        if friction_local[constraint] >= world_friction_count[world] or not world_active[world]:
+            return
+        friction_value = wp.clamp(
+            friction_reaction[constraint], -friction_bound[constraint], friction_bound[constraint]
+        )
+        friction_reaction[constraint] = friction_value
+        friction_trial[constraint] = friction_value
+        friction_previous[constraint] = friction_value
+        return
+
+    constraint -= friction_capacity
+    if constraint < contact_capacity:
+        world = contact_world[constraint]
+        if contact_local[constraint] >= world_contact_count[world] or not world_active[world]:
+            return
+        contact_value = wp.vec3f(0.0)
+        if contact_body_first[constraint] >= 0 or contact_body_second[constraint] >= 0:
+            contact_value = project_contact_coulomb_cone(contact_reaction[constraint], contact_friction[constraint])
+        contact_reaction[constraint] = contact_value
+        contact_trial[constraint] = contact_value
+        contact_previous[constraint] = contact_value
+        return
+
+    constraint -= contact_capacity
+    world = limit_world[constraint]
+    if limit_local[constraint] >= world_limit_count[world] or not world_active[world]:
+        return
+    limit_value = wp.max(0.0, limit_reaction[constraint])
+    limit_reaction[constraint] = limit_value
+    limit_trial[constraint] = limit_value
+    limit_previous[constraint] = limit_value
+
+
+@wp.kernel
+def _accumulate_rigid_restart(
+    friction_capacity: int,
+    contact_capacity: int,
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    friction_reaction: wp.array[wp.float32],
+    friction_trial: wp.array[wp.float32],
+    friction_previous: wp.array[wp.float32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_trial: wp.array[wp.vec3f],
+    contact_previous: wp.array[wp.vec3f],
+    limit_reaction: wp.array[wp.float32],
+    limit_trial: wp.array[wp.float32],
+    limit_previous: wp.array[wp.float32],
+    restart_dot: wp.array[wp.float32],
+):
+    constraint = wp.tid()
+    if constraint < friction_capacity:
+        world = friction_world[constraint]
+        if (
+            friction_local[constraint] < world_friction_count[world]
+            and world_active[world]
+            and world_status[world] == PROJECTION_STATUS_VALID
+        ):
+            friction_current = friction_reaction[constraint]
+            wp.atomic_add(
+                restart_dot,
+                world,
+                (friction_current - friction_trial[constraint]) * (friction_current - friction_previous[constraint]),
+            )
+        return
+    constraint -= friction_capacity
+    if constraint < contact_capacity:
+        world = contact_world[constraint]
+        if (
+            contact_local[constraint] < world_contact_count[world]
+            and world_active[world]
+            and world_status[world] == PROJECTION_STATUS_VALID
+        ):
+            contact_current = contact_reaction[constraint]
+            wp.atomic_add(
+                restart_dot,
+                world,
+                wp.dot(
+                    contact_current - contact_trial[constraint],
+                    contact_current - contact_previous[constraint],
+                ),
+            )
+        return
+    constraint -= contact_capacity
+    world = limit_world[constraint]
+    if (
+        limit_local[constraint] < world_limit_count[world]
+        and world_active[world]
+        and world_status[world] == PROJECTION_STATUS_VALID
+    ):
+        limit_current = limit_reaction[constraint]
+        wp.atomic_add(
+            restart_dot,
+            world,
+            (limit_current - limit_trial[constraint]) * (limit_current - limit_previous[constraint]),
+        )
+
+
+@wp.kernel
+def _finalize_acceleration(
+    world_active: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    restart_dot: wp.array[wp.float32],
+    theta: wp.array[wp.float32],
+    beta: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if not world_active[world]:
+        return
+    value = restart_dot[world]
+    restart_dot[world] = 0.0
+    current = theta[world]
+    if (
+        world_status[world] != PROJECTION_STATUS_VALID
+        or not wp.isfinite(value)
+        or value <= 0.0
+        or not wp.isfinite(current)
+        or current <= 0.0
+    ):
+        theta[world] = 1.0
+        beta[world] = 0.0
+        return
+    next_theta = 2.0 * current / (wp.sqrt(current * current + 4.0) + current)
+    beta[world] = current * (1.0 - current) / (current * current + next_theta)
+    theta[world] = next_theta
+
+
+@wp.kernel
+def _extrapolate_rigid_reactions(
+    friction_capacity: int,
+    contact_capacity: int,
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    world_active: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    beta: wp.array[wp.float32],
+    friction_reaction: wp.array[wp.float32],
+    friction_trial: wp.array[wp.float32],
+    friction_previous: wp.array[wp.float32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_trial: wp.array[wp.vec3f],
+    contact_previous: wp.array[wp.vec3f],
+    limit_reaction: wp.array[wp.float32],
+    limit_trial: wp.array[wp.float32],
+    limit_previous: wp.array[wp.float32],
+    twist_delta: wp.array[vec6f],
+):
+    constraint = wp.tid()
+    if constraint < friction_capacity:
+        world = friction_world[constraint]
+        if (
+            friction_local[constraint] >= world_friction_count[world]
+            or not world_active[world]
+            or world_status[world] != PROJECTION_STATUS_VALID
+        ):
+            return
+        friction_current = friction_reaction[constraint]
+        friction_extrapolated = friction_current + beta[world] * (friction_current - friction_previous[constraint])
+        friction_delta = friction_extrapolated - friction_current
+        friction_previous[constraint] = friction_current
+        friction_trial[constraint] = friction_extrapolated
+        friction_reaction[constraint] = friction_extrapolated
+        first = friction_body_first[constraint]
+        second = friction_body_second[constraint]
+        _atomic_add_twist(twist_delta, first, friction_jacobian_first[constraint] * friction_delta)
+        _atomic_add_twist(twist_delta, second, friction_jacobian_second[constraint] * friction_delta)
+        return
+
+    constraint -= friction_capacity
+    if constraint < contact_capacity:
+        world = contact_world[constraint]
+        if (
+            contact_local[constraint] >= world_contact_count[world]
+            or not world_active[world]
+            or world_status[world] != PROJECTION_STATUS_VALID
+        ):
+            return
+        contact_current = contact_reaction[constraint]
+        contact_extrapolated = contact_current + beta[world] * (contact_current - contact_previous[constraint])
+        contact_delta = contact_extrapolated - contact_current
+        contact_previous[constraint] = contact_current
+        contact_trial[constraint] = contact_extrapolated
+        contact_reaction[constraint] = contact_extrapolated
+        first = contact_body_first[constraint]
+        second = contact_body_second[constraint]
+        if first >= 0:
+            _atomic_add_twist(twist_delta, first, wp.transpose(contact_jacobian_first[constraint]) @ contact_delta)
+        if second >= 0:
+            _atomic_add_twist(twist_delta, second, wp.transpose(contact_jacobian_second[constraint]) @ contact_delta)
+        return
+
+    constraint -= contact_capacity
+    world = limit_world[constraint]
+    if (
+        limit_local[constraint] >= world_limit_count[world]
+        or not world_active[world]
+        or world_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+    limit_current = limit_reaction[constraint]
+    limit_extrapolated = limit_current + beta[world] * (limit_current - limit_previous[constraint])
+    limit_delta = limit_extrapolated - limit_current
+    limit_previous[constraint] = limit_current
+    limit_trial[constraint] = limit_extrapolated
+    limit_reaction[constraint] = limit_extrapolated
+    first = limit_body_first[constraint]
+    second = limit_body_second[constraint]
+    _atomic_add_twist(twist_delta, first, limit_jacobian_first[constraint] * limit_delta)
+    _atomic_add_twist(twist_delta, second, limit_jacobian_second[constraint] * limit_delta)
+
+
+def _apply_jacobi_delta(
+    body_world,
+    world_active,
+    world_status,
+    inverse_weight,
+    twist_delta,
+    projected_twist,
+) -> None:
+    wp.launch(
+        _apply_jacobi_twist_delta,
+        dim=projected_twist.shape[0],
+        inputs=[body_world, world_active, world_status, inverse_weight, twist_delta],
+        outputs=[projected_twist],
+        device=projected_twist.device,
+    )
+
+
+def project_constraints_jacobi(
+    projection_iterations: int,
+    world_active: wp.array[wp.bool],
+    body_world: wp.array[wp.int32],
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    friction_impulse_bound: wp.array[wp.float32],
+    friction_delassus: wp.array[wp.float32],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    contact_delassus: wp.array[wp.mat33f],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    limit_bias: wp.array[wp.float32],
+    limit_delassus: wp.array[wp.float32],
+    inverse_weight: wp.array[mat66f],
+    projected_twist: wp.array[vec6f],
+    twist_delta: wp.array[vec6f],
+    contact_reaction: wp.array[wp.vec3f],
+    limit_reaction: wp.array[wp.float32],
+    friction_reaction: wp.array[wp.float32],
+    prepared_status: wp.array[wp.int32],
+    world_status: wp.array[wp.int32],
+    warm_start: bool = True,
+    world_body_offset: wp.array[wp.int32] | None = None,
+    world_body_count: wp.array[wp.int32] | None = None,
+    world_friction_offset: wp.array[wp.int32] | None = None,
+    world_contact_offset: wp.array[wp.int32] | None = None,
+    world_limit_offset: wp.array[wp.int32] | None = None,
+    accelerated: bool = False,
+    theta: wp.array[wp.float32] | None = None,
+    beta: wp.array[wp.float32] | None = None,
+    restart_dot: wp.array[wp.float32] | None = None,
+    friction_trial: wp.array[wp.float32] | None = None,
+    friction_previous: wp.array[wp.float32] | None = None,
+    contact_trial: wp.array[wp.vec3f] | None = None,
+    contact_previous: wp.array[wp.vec3f] | None = None,
+    limit_trial: wp.array[wp.float32] | None = None,
+    limit_previous: wp.array[wp.float32] | None = None,
+) -> None:
+    """Run mass-split Jacobi sweeps over all body-space unilaterals.
+
+    Set ``warm_start`` to false when the projected state already contains the
+    current reactions, such as for a final smoothing sweep after Gauss--Seidel.
+    """
+    if (
+        not isinstance(projection_iterations, int)
+        or isinstance(projection_iterations, bool)
+        or projection_iterations < 1
+    ):
+        raise ValueError("projection_iterations must be an integer greater than or equal to one.")
+    world_count = world_active.shape[0]
+    if prepared_status.shape[0] != world_count or world_status.shape[0] != world_count:
+        raise ValueError("Active, prepared-status, and status world arrays must have identical lengths.")
+    if body_world.shape[0] != projected_twist.shape[0] or twist_delta.shape[0] != projected_twist.shape[0]:
+        raise ValueError("Body world, projected twist, and Jacobi delta arrays must have identical lengths.")
+    if not isinstance(warm_start, bool):
+        raise ValueError("warm_start must be a boolean.")
+    if not isinstance(accelerated, bool):
+        raise ValueError("accelerated must be a boolean.")
+    acceleration_arrays = (
+        theta,
+        beta,
+        restart_dot,
+        friction_trial,
+        friction_previous,
+        contact_trial,
+        contact_previous,
+        limit_trial,
+        limit_previous,
+    )
+    if accelerated and (not warm_start or any(value is None for value in acceleration_arrays)):
+        raise ValueError("Accelerated Jacobi requires warm start and all acceleration arrays.")
+
+    contact_projection_max_blocks = 0
+    if projected_twist.device.is_cuda:
+        contact_projection_max_blocks = projected_twist.device.sm_count * _JACOBI_CONTACT_PROJECTION_BLOCKS_PER_SM
+
+    use_world_projection = not accelerated and _can_fuse_rigid_projection_by_world(
+        projected_twist.device,
+        world_count,
+        required_world_arrays=(
+            world_body_offset,
+            world_body_count,
+            world_friction_offset,
+            world_contact_offset,
+            world_limit_offset,
+        ),
+        parallel_constraint_capacity=friction_world.shape[0] + contact_world.shape[0] + limit_world.shape[0],
+        world_block_dim=_JACOBI_WORLD_BLOCK_DIM,
+    )
+
+    rigid_capacity = friction_world.shape[0] + contact_world.shape[0] + limit_world.shape[0]
+    if accelerated:
+        wp.launch(
+            _initialize_acceleration_worlds,
+            dim=world_count,
+            inputs=[world_active, prepared_status],
+            outputs=[theta, beta, restart_dot, world_status],
+            device=projected_twist.device,
+        )
+        if rigid_capacity > 0:
+            wp.launch(
+                _initialize_accelerated_reactions,
+                dim=rigid_capacity,
+                inputs=[
+                    friction_world.shape[0],
+                    contact_world.shape[0],
+                    friction_world,
+                    friction_local,
+                    world_friction_count,
+                    friction_impulse_bound,
+                    contact_world,
+                    contact_local,
+                    world_contact_count,
+                    contact_body_first,
+                    contact_body_second,
+                    contact_friction,
+                    limit_world,
+                    limit_local,
+                    world_limit_count,
+                    world_active,
+                ],
+                outputs=[
+                    friction_reaction,
+                    friction_trial,
+                    friction_previous,
+                    contact_reaction,
+                    contact_trial,
+                    contact_previous,
+                    limit_reaction,
+                    limit_trial,
+                    limit_previous,
+                ],
+                device=projected_twist.device,
+            )
+    elif warm_start:
+        wp.launch(
+            _initialize_jacobi_projection_status,
+            dim=world_count,
+            inputs=[world_active, prepared_status],
+            outputs=[world_status],
+            device=projected_twist.device,
+        )
+    if not use_world_projection:
+        twist_delta.zero_()
+    if warm_start and not use_world_projection and contact_world.shape[0] > 0:
+        wp.launch(
+            _warmstart_contacts_jacobi,
+            dim=contact_world.shape[0],
+            inputs=[
+                contact_world,
+                contact_local,
+                world_active,
+                prepared_status,
+                world_contact_count,
+                contact_body_first,
+                contact_body_second,
+                contact_jacobian_first,
+                contact_jacobian_second,
+                inverse_weight,
+                False,
+                contact_reaction,
+            ],
+            outputs=[twist_delta],
+            device=projected_twist.device,
+        )
+    if warm_start and not use_world_projection and friction_world.shape[0] > 0:
+        wp.launch(
+            _warmstart_frictions_jacobi,
+            dim=friction_world.shape[0],
+            inputs=[
+                friction_world,
+                friction_local,
+                world_active,
+                prepared_status,
+                world_friction_count,
+                friction_body_first,
+                friction_body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                inverse_weight,
+                False,
+                friction_reaction,
+            ],
+            outputs=[twist_delta],
+            device=projected_twist.device,
+        )
+    if warm_start and not use_world_projection and limit_world.shape[0] > 0:
+        wp.launch(
+            _warmstart_limits_jacobi,
+            dim=limit_world.shape[0],
+            inputs=[
+                limit_world,
+                limit_local,
+                world_active,
+                prepared_status,
+                world_limit_count,
+                limit_body_first,
+                limit_body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                inverse_weight,
+                False,
+                limit_reaction,
+            ],
+            outputs=[twist_delta],
+            device=projected_twist.device,
+        )
+    if warm_start and not use_world_projection:
+        _apply_jacobi_delta(
+            body_world,
+            world_active,
+            world_status,
+            inverse_weight,
+            twist_delta,
+            projected_twist,
+        )
+
+    projection_state = _make_rigid_projection_state(
+        world_active,
+        projected_twist,
+        twist_delta,
+        world_status,
+        inverse_weight=inverse_weight,
+    )
+    contact_data = _RigidContactProjectionData()
+    contact_data.body_first = contact_body_first
+    contact_data.body_second = contact_body_second
+    contact_data.jacobian_first = contact_jacobian_first
+    contact_data.jacobian_second = contact_jacobian_second
+    contact_data.delassus = contact_delassus
+    contact_data.bias = contact_bias
+    contact_data.friction = contact_friction
+    contact_data.reaction = contact_reaction
+
+    if use_world_projection:
+        wp.launch(
+            _project_rigid_constraints_jacobi_by_world,
+            dim=(world_count, _JACOBI_WORLD_BLOCK_DIM),
+            block_dim=_JACOBI_WORLD_BLOCK_DIM,
+            inputs=[
+                projection_iterations,
+                warm_start,
+                world_body_offset,
+                world_body_count,
+                world_friction_offset,
+                world_friction_count,
+                friction_body_first,
+                friction_body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                friction_impulse_bound,
+                friction_delassus,
+                world_contact_offset,
+                world_contact_count,
+                world_limit_offset,
+                world_limit_count,
+                limit_body_first,
+                limit_body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                limit_bias,
+                limit_delassus,
+            ],
+            outputs=[
+                friction_reaction,
+                limit_reaction,
+                contact_data,
+                projection_state,
+            ],
+            device=projected_twist.device,
+        )
+        return
+
+    friction_index = _make_direct_projection_index(friction_world, friction_local, world_friction_count)
+    contact_index = _make_direct_projection_index(contact_world, contact_local, world_contact_count)
+    limit_index = _make_direct_projection_index(limit_world, limit_local, world_limit_count)
+    for _sweep in range(projection_iterations):
+        if friction_world.shape[0] > 0:
+            wp.launch(
+                _make_project_scalar_kernel(False, False),
+                dim=friction_world.shape[0],
+                inputs=[
+                    friction_world.shape[0],
+                    0,
+                    friction_index,
+                    friction_body_first,
+                    friction_body_second,
+                    friction_jacobian_first,
+                    friction_jacobian_second,
+                    friction_impulse_bound,
+                    friction_impulse_bound,
+                    friction_delassus,
+                    friction_reaction,
+                    projection_state,
+                ],
+                device=projected_twist.device,
+            )
+        if contact_world.shape[0] > 0:
+            contact_inputs = [
+                contact_world.shape[0],
+                0,
+                contact_index,
+                contact_data,
+                projection_state,
+            ]
+            wp.launch(
+                _make_project_contacts_kernel(False),
+                dim=contact_world.shape[0],
+                inputs=contact_inputs,
+                device=projected_twist.device,
+                max_blocks=contact_projection_max_blocks,
+                block_dim=_JACOBI_CONTACT_BLOCK_DIM,
+            )
+        if limit_world.shape[0] > 0:
+            wp.launch(
+                _make_project_scalar_kernel(False, True),
+                dim=limit_world.shape[0],
+                inputs=[
+                    limit_world.shape[0],
+                    0,
+                    limit_index,
+                    limit_body_first,
+                    limit_body_second,
+                    limit_jacobian_first,
+                    limit_jacobian_second,
+                    limit_bias,
+                    limit_bias,
+                    limit_delassus,
+                    limit_reaction,
+                    projection_state,
+                ],
+                device=projected_twist.device,
+            )
+        _apply_jacobi_delta(
+            body_world,
+            world_active,
+            world_status,
+            inverse_weight,
+            twist_delta,
+            projected_twist,
+        )
+        if accelerated and _sweep + 1 < projection_iterations:
+            if rigid_capacity > 0:
+                wp.launch(
+                    _accumulate_rigid_restart,
+                    dim=rigid_capacity,
+                    inputs=[
+                        friction_world.shape[0],
+                        contact_world.shape[0],
+                        friction_world,
+                        friction_local,
+                        world_friction_count,
+                        contact_world,
+                        contact_local,
+                        world_contact_count,
+                        limit_world,
+                        limit_local,
+                        world_limit_count,
+                        world_active,
+                        world_status,
+                        friction_reaction,
+                        friction_trial,
+                        friction_previous,
+                        contact_reaction,
+                        contact_trial,
+                        contact_previous,
+                        limit_reaction,
+                        limit_trial,
+                        limit_previous,
+                    ],
+                    outputs=[restart_dot],
+                    device=projected_twist.device,
+                )
+            wp.launch(
+                _finalize_acceleration,
+                dim=world_count,
+                inputs=[world_active, world_status],
+                outputs=[restart_dot, theta, beta],
+                device=projected_twist.device,
+            )
+            if rigid_capacity > 0:
+                wp.launch(
+                    _extrapolate_rigid_reactions,
+                    dim=rigid_capacity,
+                    inputs=[
+                        friction_world.shape[0],
+                        contact_world.shape[0],
+                        friction_world,
+                        friction_local,
+                        world_friction_count,
+                        friction_body_first,
+                        friction_body_second,
+                        friction_jacobian_first,
+                        friction_jacobian_second,
+                        contact_world,
+                        contact_local,
+                        world_contact_count,
+                        contact_body_first,
+                        contact_body_second,
+                        contact_jacobian_first,
+                        contact_jacobian_second,
+                        limit_world,
+                        limit_local,
+                        world_limit_count,
+                        limit_body_first,
+                        limit_body_second,
+                        limit_jacobian_first,
+                        limit_jacobian_second,
+                        world_active,
+                        world_status,
+                        beta,
+                        friction_reaction,
+                        friction_trial,
+                        friction_previous,
+                        contact_reaction,
+                        contact_trial,
+                        contact_previous,
+                        limit_reaction,
+                        limit_trial,
+                        limit_previous,
+                    ],
+                    outputs=[twist_delta],
+                    device=projected_twist.device,
+                )
+            _apply_jacobi_delta(
+                body_world,
+                world_active,
+                world_status,
+                inverse_weight,
+                twist_delta,
+                projected_twist,
+            )
+
+    wp.launch(
+        _validate_projected_twists,
+        dim=projected_twist.shape[0],
+        inputs=[body_world, world_active, projected_twist],
+        outputs=[world_status],
+        device=projected_twist.device,
+    )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/joint_delassus.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/joint_delassus.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural Delassus assembly for ALM penalty initialization."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from ...core.types import vec6f
+from ...linalg import DenseSquareMultiLinearInfo
+from .joint_factorize import make_batched_body_solve_kernel
+from .system import BatchedPrimalBodySystem
+
+__all__ = ["BatchedStructuralDelassus"]
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.kernel
+def _permute_body_response_rows(
+    body_dimensions: wp.array[wp.int32],
+    body_vector_offsets: wp.array[wp.int32],
+    joint_dimensions: wp.array[wp.int32],
+    response_offsets: wp.array[wp.int32],
+    response_leading_dimensions: wp.array[wp.int32],
+    permutation: wp.array[wp.int32],
+    source: wp.array[wp.float32],
+    destination: wp.array[wp.float32],
+):
+    component, reordered_row, column = wp.tid()
+    if reordered_row >= body_dimensions[component] or column >= joint_dimensions[component]:
+        return
+    original_row = permutation[body_vector_offsets[component] + reordered_row]
+    response_offset = response_offsets[component]
+    leading_dimension = response_leading_dimensions[component]
+    destination[response_offset + reordered_row * leading_dimension + column] = source[
+        response_offset + original_row * leading_dimension + column
+    ]
+
+
+@wp.kernel
+def _unpermute_body_response_rows(
+    body_dimensions: wp.array[wp.int32],
+    body_vector_offsets: wp.array[wp.int32],
+    joint_dimensions: wp.array[wp.int32],
+    response_offsets: wp.array[wp.int32],
+    response_leading_dimensions: wp.array[wp.int32],
+    permutation: wp.array[wp.int32],
+    source: wp.array[wp.float32],
+    destination: wp.array[wp.float32],
+):
+    component, reordered_row, column = wp.tid()
+    if reordered_row >= body_dimensions[component] or column >= joint_dimensions[component]:
+        return
+    original_row = permutation[body_vector_offsets[component] + reordered_row]
+    response_offset = response_offsets[component]
+    leading_dimension = response_leading_dimensions[component]
+    destination[response_offset + original_row * leading_dimension + column] = source[
+        response_offset + reordered_row * leading_dimension + column
+    ]
+
+
+@wp.kernel
+def _build_joint_basis_body_right_hand_sides(
+    body_dimensions: wp.array[wp.int32],
+    joint_dimensions: wp.array[wp.int32],
+    joint_vector_offsets: wp.array[wp.int32],
+    response_offsets: wp.array[wp.int32],
+    response_leading_dimensions: wp.array[wp.int32],
+    vector_row: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    body_value: wp.array[wp.float32],
+):
+    component, row, column = wp.tid()
+    if row >= body_dimensions[component] or column >= joint_dimensions[component]:
+        return
+    value = wp.float32(0.0)
+    flat_row = vector_row[joint_vector_offsets[component] + column]
+    body = row // 6
+    axis = row - 6 * body
+    if body_first[flat_row] == body:
+        value += jacobian_first[flat_row][axis]
+    if body_second[flat_row] == body:
+        value += jacobian_second[flat_row][axis]
+    body_value[response_offsets[component] + row * response_leading_dimensions[component] + column] = value
+
+
+@wp.func
+def _load_body_response(
+    response: wp.array[wp.float32],
+    response_offset: wp.int32,
+    leading_dimension: wp.int32,
+    body: wp.int32,
+    column: wp.int32,
+) -> vec6f:
+    result = vec6f(0.0)
+    if body >= 0:
+        offset = response_offset + 6 * body * leading_dimension + column
+        for axis in range(6):
+            result[axis] = response[offset + axis * leading_dimension]
+    return result
+
+
+@wp.kernel
+def _assemble_from_body_response(
+    joint_dimensions: wp.array[wp.int32],
+    joint_matrix_offsets: wp.array[wp.int32],
+    joint_vector_offsets: wp.array[wp.int32],
+    response_offsets: wp.array[wp.int32],
+    response_leading_dimensions: wp.array[wp.int32],
+    vector_row: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    response: wp.array[wp.float32],
+    matrix: wp.array[wp.float32],
+):
+    component, row, column = wp.tid()
+    joint_dimension = joint_dimensions[component]
+    if row >= joint_dimension or column >= joint_dimension:
+        return
+    flat_row = vector_row[joint_vector_offsets[component] + row]
+    value = wp.float32(0.0)
+    first = body_first[flat_row]
+    second = body_second[flat_row]
+    response_offset = response_offsets[component]
+    leading_dimension = response_leading_dimensions[component]
+    if first >= 0:
+        value += wp.dot(
+            jacobian_first[flat_row],
+            _load_body_response(response, response_offset, leading_dimension, first, column),
+        )
+    if second >= 0:
+        value += wp.dot(
+            jacobian_second[flat_row],
+            _load_body_response(response, response_offset, leading_dimension, second, column),
+        )
+    matrix[joint_matrix_offsets[component] + row * joint_dimension + column] = value
+
+
+class BatchedStructuralDelassus:
+    """Assemble structural Delassus blocks for ALM penalty initialization."""
+
+    def __init__(
+        self,
+        body_system: BatchedPrimalBodySystem,
+        body_first_global: wp.array[wp.int32],
+        body_second_global: wp.array[wp.int32],
+        jacobian_first: wp.array[vec6f],
+        jacobian_second: wp.array[vec6f],
+    ):
+        self.body_system = body_system
+        self.device = body_system.device
+        self.row_count = body_first_global.shape[0]
+        self.jacobian_first = jacobian_first
+        self.jacobian_second = jacobian_second
+
+        if any(array.shape[0] != self.row_count for array in (body_second_global, jacobian_first, jacobian_second)):
+            raise ValueError("Structural row arrays must have identical lengths.")
+
+        first_global = body_first_global.numpy().astype(int).tolist()
+        second_global = body_second_global.numpy().astype(int).tolist()
+        row_components = [-1] * self.row_count
+        body_first_local: list[int] = []
+        body_second_local: list[int] = []
+        component_row_counts = [0] * body_system.num_blocks
+        component_row_local = [-1] * self.row_count
+        for row, (first, second) in enumerate(zip(first_global, second_global, strict=True)):
+            if first < 0 and second < 0:
+                raise ValueError("Each structural row must reference at least one body.")
+            if first >= body_system.num_bodies or second >= body_system.num_bodies:
+                raise ValueError("Structural row body indices must reference packed bodies.")
+            first_local = body_system.body_local_host[first] if first >= 0 else -1
+            second_local = body_system.body_local_host[second] if second >= 0 else -1
+            body_first_local.append(first_local)
+            body_second_local.append(second_local)
+            if first_local < 0 and second_local < 0:
+                continue
+            component = body_system.body_block_host[first] if first_local >= 0 else body_system.body_block_host[second]
+            if second_local >= 0 and body_system.body_block_host[second] != component:
+                raise ValueError("A structural row cannot connect independent body components.")
+            row_components[row] = component
+            component_row_local[row] = component_row_counts[component]
+            component_row_counts[component] += 1
+
+        storage_dimensions = [max(1, count) for count in component_row_counts]
+        vector_offsets = [0]
+        for dimension in storage_dimensions:
+            vector_offsets.append(vector_offsets[-1] + dimension)
+        row_vector_index = [-1] * self.row_count
+        for row, (component, local) in enumerate(zip(row_components, component_row_local, strict=True)):
+            if component >= 0:
+                row_vector_index[row] = vector_offsets[component] + local
+
+        self.component_row_counts = tuple(component_row_counts)
+        self.component_world_host = body_system.block_world_host
+        self.body_first_local = wp.array(body_first_local, dtype=wp.int32, device=self.device)
+        self.body_second_local = wp.array(body_second_local, dtype=wp.int32, device=self.device)
+
+        self.info = DenseSquareMultiLinearInfo()
+        self.info.finalize(dimensions=storage_dimensions, dtype=wp.float32, itype=wp.int32, device=self.device)
+        self.info.dim = wp.array(component_row_counts, dtype=wp.int32, device=self.device)
+
+        response_leading_dimensions = storage_dimensions
+        response_sizes = [
+            6 * body_count * joint_dimension
+            for body_count, joint_dimension in zip(
+                body_system.block_body_counts, response_leading_dimensions, strict=True
+            )
+        ]
+        response_offsets = [0]
+        for size in response_sizes:
+            response_offsets.append(response_offsets[-1] + size)
+        self.response_offsets = wp.array(response_offsets[:-1], dtype=wp.int32, device=self.device)
+        self.response_leading_dimensions = wp.array(response_leading_dimensions, dtype=wp.int32, device=self.device)
+        self.body_response = wp.zeros(response_offsets[-1], dtype=wp.float32, device=self.device)
+        self.body_response_intermediate = wp.zeros_like(self.body_response)
+        self.body_response_permuted = (
+            wp.zeros_like(self.body_response) if body_system.linear_solver.uses_reordering else self.body_response
+        )
+        vector_row = [-1] * self.info.total_vec_size
+        for row, vector_index in enumerate(row_vector_index):
+            if vector_index >= 0:
+                vector_row[vector_index] = row
+        self.vector_row = wp.array(vector_row, dtype=wp.int32, device=self.device)
+        self.matrix = wp.zeros(self.info.total_mat_size, dtype=wp.float32, device=self.device)
+
+        right_hand_side_tile_size = 4
+        self._right_hand_side_block_count = (
+            self.info.max_dimension + right_hand_side_tile_size - 1
+        ) // right_hand_side_tile_size
+        self._body_solve_kernel = make_batched_body_solve_kernel(
+            body_system.linear_solver.block_size,
+            right_hand_side_tile_size,
+        )
+
+    def assemble(self) -> None:
+        """Assemble the structural Delassus from the factored body system."""
+        wp.launch(
+            _build_joint_basis_body_right_hand_sides,
+            dim=(self.body_system.num_blocks, self.body_system.info.max_dimension, self.info.max_dimension),
+            inputs=[
+                self.body_system.info.dim,
+                self.info.dim,
+                self.info.vio,
+                self.response_offsets,
+                self.response_leading_dimensions,
+                self.vector_row,
+                self.body_first_local,
+                self.body_second_local,
+                self.jacobian_first,
+                self.jacobian_second,
+            ],
+            outputs=[self.body_response],
+            device=self.device,
+        )
+        if self.body_response_permuted is not self.body_response:
+            wp.launch(
+                _permute_body_response_rows,
+                dim=(self.body_system.num_blocks, self.body_system.info.max_dimension, self.info.max_dimension),
+                inputs=[
+                    self.body_system.info.dim,
+                    self.body_system.info.vio,
+                    self.info.dim,
+                    self.response_offsets,
+                    self.response_leading_dimensions,
+                    self.body_system.linear_solver.P,
+                    self.body_response,
+                ],
+                outputs=[self.body_response_permuted],
+                device=self.device,
+            )
+        wp.launch_tiled(
+            self._body_solve_kernel,
+            dim=(self.body_system.num_blocks, self._right_hand_side_block_count),
+            block_dim=128,
+            inputs=[
+                self.body_system.info.dim,
+                self.body_system.info.mio,
+                self.info.dim,
+                self.response_offsets,
+                self.response_leading_dimensions,
+                self.body_system.linear_solver.L,
+                self.body_response_permuted,
+            ],
+            outputs=[self.body_response_intermediate],
+            device=self.device,
+        )
+        if self.body_response_permuted is not self.body_response:
+            wp.launch(
+                _unpermute_body_response_rows,
+                dim=(self.body_system.num_blocks, self.body_system.info.max_dimension, self.info.max_dimension),
+                inputs=[
+                    self.body_system.info.dim,
+                    self.body_system.info.vio,
+                    self.info.dim,
+                    self.response_offsets,
+                    self.response_leading_dimensions,
+                    self.body_system.linear_solver.P,
+                    self.body_response_permuted,
+                ],
+                outputs=[self.body_response],
+                device=self.device,
+            )
+        wp.launch(
+            _assemble_from_body_response,
+            dim=(self.body_system.num_blocks, self.info.max_dimension, self.info.max_dimension),
+            inputs=[
+                self.info.dim,
+                self.info.mio,
+                self.info.vio,
+                self.response_offsets,
+                self.response_leading_dimensions,
+                self.vector_row,
+                self.body_first_local,
+                self.body_second_local,
+                self.jacobian_first,
+                self.jacobian_second,
+                self.body_response,
+            ],
+            outputs=[self.matrix],
+            device=self.device,
+        )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/joint_factorize.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/joint_factorize.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tiled multi-right-hand-side kernels for structural Delassus assembly."""
+
+from functools import cache
+
+import warp as wp
+
+from ...linalg.factorize._tile_builtins import (
+    HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE,
+    HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE,
+    make_tile_matmul_left_transpose_update_func,
+)
+from ...linalg.factorize.llt_blocked import get_float32_array_offset_ptr
+
+wp.set_module_options({"enable_backward": False})
+
+
+@cache
+def make_batched_body_solve_kernel(block_size: int, right_hand_side_tile_size: int):
+    """Build a tiled Cholesky solve kernel for a packed matrix of right-hand sides."""
+
+    @wp.kernel(enable_backward=False)
+    def solve_joint_basis_body_right_hand_sides(
+        body_dimensions: wp.array[wp.int32],
+        body_matrix_offsets: wp.array[wp.int32],
+        joint_dimensions: wp.array[wp.int32],
+        response_offsets: wp.array[wp.int32],
+        response_leading_dimensions: wp.array[wp.int32],
+        factor: wp.array[wp.float32],
+        value: wp.array[wp.float32],
+        intermediate: wp.array[wp.float32],
+    ):
+        world, right_hand_side_block, thread = wp.tid()
+        thread_count = wp.block_dim()
+        column = right_hand_side_block * right_hand_side_tile_size
+        right_hand_side_count = joint_dimensions[world]
+        if column >= right_hand_side_count:
+            return
+
+        dimension = body_dimensions[world]
+        matrix_offset = body_matrix_offsets[world]
+        response_offset = response_offsets[world]
+        leading_dimension = response_leading_dimensions[world]
+        factor_pointer = get_float32_array_offset_ptr(factor, matrix_offset)
+        value_pointer = get_float32_array_offset_ptr(value, response_offset)
+        intermediate_pointer = get_float32_array_offset_ptr(intermediate, response_offset)
+        factor_matrix = wp.array(ptr=factor_pointer, shape=(dimension, dimension), dtype=wp.float32)
+        value_matrix = wp.array(
+            ptr=value_pointer,
+            shape=(dimension, leading_dimension),
+            dtype=wp.float32,
+        )
+        intermediate_matrix = wp.array(
+            ptr=intermediate_pointer,
+            shape=(dimension, leading_dimension),
+            dtype=wp.float32,
+        )
+        padded_dimension = ((dimension + block_size - 1) // block_size) * block_size
+
+        for row in range(0, padded_dimension, block_size):
+            right_hand_side = wp.tile_load(
+                value_matrix,
+                shape=(block_size, right_hand_side_tile_size),
+                offset=(row, column),
+            )
+            diagonal = wp.tile_load(factor_matrix, shape=(block_size, block_size), offset=(row, row))
+            if row > 0:
+                for inner in range(0, row, block_size):
+                    factor_block = wp.tile_load(
+                        factor_matrix,
+                        shape=(block_size, block_size),
+                        offset=(row, inner),
+                    )
+                    solved_block = wp.tile_load(
+                        intermediate_matrix,
+                        shape=(block_size, right_hand_side_tile_size),
+                        offset=(inner, column),
+                    )
+                    wp.tile_matmul(factor_block, solved_block, right_hand_side, alpha=-1.0)
+            wp.tile_lower_solve_inplace(diagonal, right_hand_side)
+            wp.tile_store(intermediate_matrix, right_hand_side, offset=(row, column))
+
+        for row in range(padded_dimension - block_size, -1, -block_size):
+            row_end = row + block_size
+            right_hand_side = wp.tile_load(
+                intermediate_matrix,
+                shape=(block_size, right_hand_side_tile_size),
+                offset=(row, column),
+            )
+            diagonal = wp.tile_load(factor_matrix, shape=(block_size, block_size), offset=(row, row))
+            if row + block_size > dimension:
+                tile_element_count = block_size * block_size
+                iteration_count = (tile_element_count + thread_count - 1) // thread_count
+                for iteration in range(iteration_count):
+                    index = (thread + iteration * thread_count) % tile_element_count
+                    local_row = index // block_size
+                    local_column = index % block_size
+                    diagonal_value = diagonal[local_row, local_column]
+                    if row + local_row >= dimension:
+                        diagonal_value = wp.where(
+                            local_row == local_column,
+                            wp.float32(1.0),
+                            wp.float32(0.0),
+                        )
+                    diagonal[local_row, local_column] = diagonal_value
+            if row_end < padded_dimension:
+                for inner in range(row_end, padded_dimension, block_size):
+                    factor_block = wp.tile_load(
+                        factor_matrix,
+                        shape=(block_size, block_size),
+                        offset=(inner, row),
+                    )
+                    solved_block = wp.tile_load(
+                        value_matrix,
+                        shape=(block_size, right_hand_side_tile_size),
+                        offset=(inner, column),
+                    )
+                    if wp.static(HAS_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE):
+                        wp.tile_matmul_left_transpose_update(
+                            right_hand_side,
+                            factor_block,
+                            solved_block,
+                            alpha=-1.0,
+                        )
+                    elif wp.static(HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE and right_hand_side_tile_size == 1):
+                        wp.static(make_tile_matmul_left_transpose_update_func(block_size))(
+                            right_hand_side, factor_block, solved_block, -1.0
+                        )
+                    else:
+                        wp.tile_matmul(
+                            wp.tile_transpose(factor_block),
+                            solved_block,
+                            right_hand_side,
+                            alpha=-1.0,
+                        )
+            wp.tile_upper_solve_inplace(wp.tile_transpose(diagonal), right_hand_side)
+            wp.tile_store(value_matrix, right_hand_side, offset=(row, column))
+
+    return solve_joint_basis_body_right_hand_sides

--- a/newton/_src/solvers/kamino/_src/solvers/lox/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/kernels.py
@@ -1,0 +1,996 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""LOX splitting updates and convergence reductions."""
+
+from functools import cache
+
+import warp as wp
+
+from ...core.joints import JointCorrectionMode
+from ...core.math import compute_body_pose_update_with_logmap
+from ...core.types import mat36f, mat66f, vec6f
+from ...kinematics.joints import compute_joint_pose_and_relative_motion, make_write_joint_data
+from .projection import PROJECTION_STATUS_VALID
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.kernel
+def _initialize_bodies(
+    body_world: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
+    initial_twist: wp.array[vec6f],
+    reset_dual: wp.bool,
+    projected_twist: wp.array[vec6f],
+    projected_twist_previous: wp.array[vec6f],
+    global_twist: wp.array[vec6f],
+    global_twist_previous: wp.array[vec6f],
+    splitting_dual: wp.array[vec6f],
+    splitting_dual_impulse: wp.array[vec6f],
+):
+    body = wp.tid()
+    if world_mask and not world_mask[body_world[body]]:
+        return
+    value = vec6f(0.0)
+    if initial_twist:
+        value = initial_twist[body]
+    projected_twist[body] = value
+    projected_twist_previous[body] = value
+    global_twist[body] = value
+    global_twist_previous[body] = value
+    if reset_dual:
+        splitting_dual[body] = vec6f(0.0)
+        splitting_dual_impulse[body] = vec6f(0.0)
+
+
+@wp.kernel
+def _initialize_worlds(
+    world_mask: wp.array[wp.bool],
+    world_active: wp.array[wp.bool],
+    world_converged: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    world_iteration_limit: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+    residual_change: wp.array[wp.float32],
+    residual_split: wp.array[wp.float32],
+    residual_structural: wp.array[wp.float32],
+    residual_structural_projected: wp.array[wp.float32],
+    residual_cross_iterate: wp.array[wp.float32],
+    residual_lagged_velocity: wp.array[wp.float32],
+    residual_total: wp.array[wp.float32],
+    iteration_failed: wp.array[wp.int32],
+):
+    world = wp.tid()
+    if world_mask and not world_mask[world]:
+        return
+    world_active[world] = True
+    world_converged[world] = False
+    world_failed[world] = False
+    world_iteration_limit[world] = False
+    iteration_count[world] = 0
+    residual_change[world] = 0.0
+    residual_split[world] = 0.0
+    residual_structural[world] = 0.0
+    residual_structural_projected[world] = 0.0
+    residual_cross_iterate[world] = 0.0
+    residual_lagged_velocity[world] = 0.0
+    residual_total[world] = 0.0
+    iteration_failed[world] = 0
+
+
+@wp.kernel
+def _prepare_projection(
+    body_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    body_split_enabled: wp.array[wp.int32],
+    global_solution: wp.array[vec6f],
+    splitting_dual: wp.array[vec6f],
+    global_twist_previous: wp.array[vec6f],
+    global_twist: wp.array[vec6f],
+    projected_twist_previous: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+):
+    body = wp.tid()
+    world = body_world[body]
+    if not world_active[world]:
+        return
+    global_twist_previous[body] = global_twist[body]
+    global_twist[body] = global_solution[body]
+    projected_twist_previous[body] = projected_twist[body]
+    if not body_split_enabled or body_split_enabled[body] != 0:
+        projected_twist[body] = global_solution[body] - splitting_dual[body]
+    else:
+        projected_twist[body] = global_solution[body]
+        splitting_dual[body] = vec6f(0.0)
+
+
+@wp.kernel
+def _store_dual_impulse(
+    body_has_unilateral: wp.array[wp.int32],
+    weight: wp.array[mat66f],
+    splitting_dual: wp.array[vec6f],
+    splitting_dual_impulse: wp.array[vec6f],
+):
+    body = wp.tid()
+    if body_has_unilateral[body] != 0:
+        splitting_dual_impulse[body] = weight[body] @ splitting_dual[body]
+    else:
+        splitting_dual[body] = vec6f(0.0)
+        splitting_dual_impulse[body] = vec6f(0.0)
+
+
+@wp.kernel
+def _restore_dual_from_impulse(
+    body_has_unilateral: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    splitting_dual_impulse: wp.array[vec6f],
+    splitting_dual: wp.array[vec6f],
+):
+    body = wp.tid()
+    if body_has_unilateral[body] != 0:
+        splitting_dual[body] = inverse_weight[body] @ splitting_dual_impulse[body]
+    else:
+        splitting_dual_impulse[body] = vec6f(0.0)
+        splitting_dual[body] = vec6f(0.0)
+
+
+@wp.kernel
+def _initialize_iteration_residuals(
+    projection_status: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+    iteration_failed: wp.array[wp.int32],
+    residual_change: wp.array[wp.float32],
+    residual_split: wp.array[wp.float32],
+    residual_cross_iterate: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if not world_active[world]:
+        return
+    iteration_count[world] += 1
+    iteration_failed[world] = 0
+    residual_change[world] = 0.0
+    residual_split[world] = 0.0
+    residual_cross_iterate[world] = 0.0
+    if projection_status[world] != PROJECTION_STATUS_VALID:
+        world_active[world] = False
+        world_failed[world] = True
+
+
+@wp.kernel
+def _update_bodies_and_reduce_residuals(
+    time_step: wp.array[wp.float32],
+    position_tolerance: wp.float32,
+    rotation_tolerance: wp.float32,
+    velocity_tolerance: wp.float32,
+    body_world: wp.array[wp.int32],
+    global_twist_previous: wp.array[vec6f],
+    global_twist: wp.array[vec6f],
+    projected_twist_previous: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+    world_active: wp.array[wp.bool],
+    splitting_dual: wp.array[vec6f],
+    iteration_failed: wp.array[wp.int32],
+    residual_change: wp.array[wp.float32],
+    residual_split: wp.array[wp.float32],
+    residual_cross_iterate: wp.array[wp.float32],
+):
+    body = wp.tid()
+    world = body_world[body]
+    dt = time_step[world]
+    if not world_active[world]:
+        return
+
+    previous = global_twist_previous[body]
+    current = global_twist[body]
+    projected_previous = projected_twist_previous[body]
+    projected = projected_twist[body]
+    dual = splitting_dual[body]
+    finite = (
+        wp.isfinite(previous)
+        and wp.isfinite(current)
+        and wp.isfinite(projected_previous)
+        and wp.isfinite(projected)
+        and wp.isfinite(dual)
+    )
+    if not finite:
+        wp.atomic_max(iteration_failed, world, 1)
+        return
+
+    linear_change = wp.float32(0.0)
+    angular_change = wp.float32(0.0)
+    linear_split = wp.float32(0.0)
+    angular_split = wp.float32(0.0)
+    linear_cross_iterate = wp.float32(0.0)
+    angular_cross_iterate = wp.float32(0.0)
+    for axis in range(3):
+        linear_change = wp.max(linear_change, wp.abs(current[axis] - previous[axis]))
+        angular_change = wp.max(angular_change, wp.abs(current[axis + 3] - previous[axis + 3]))
+        linear_split = wp.max(linear_split, wp.abs(current[axis] - projected[axis]))
+        angular_split = wp.max(angular_split, wp.abs(current[axis + 3] - projected[axis + 3]))
+        linear_cross_iterate = wp.max(
+            linear_cross_iterate,
+            wp.abs(current[axis] - projected_previous[axis]),
+        )
+        angular_cross_iterate = wp.max(
+            angular_cross_iterate,
+            wp.abs(current[axis + 3] - projected_previous[axis + 3]),
+        )
+    change = wp.max(
+        dt * linear_change / position_tolerance,
+        dt * angular_change / rotation_tolerance,
+    )
+    split = wp.max(linear_split, angular_split) / velocity_tolerance
+    cross_iterate = wp.max(
+        dt * linear_cross_iterate / position_tolerance,
+        dt * angular_cross_iterate / rotation_tolerance,
+    )
+    wp.atomic_max(residual_change, world, change)
+    wp.atomic_max(residual_split, world, split)
+    wp.atomic_max(residual_cross_iterate, world, cross_iterate)
+    splitting_dual[body] += projected - current
+
+
+@wp.kernel
+def _initialize_fixed_iteration(
+    projection_status: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+):
+    world = wp.tid()
+    if not world_active[world]:
+        return
+    iteration_count[world] += 1
+    if projection_status[world] != PROJECTION_STATUS_VALID:
+        world_active[world] = False
+        world_failed[world] = True
+
+
+@wp.kernel
+def _update_fixed_iteration_bodies(
+    body_world: wp.array[wp.int32],
+    global_twist: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+    world_active: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    splitting_dual: wp.array[vec6f],
+):
+    body = wp.tid()
+    world = body_world[body]
+    if not world_active[world]:
+        return
+    current = global_twist[body]
+    projected = projected_twist[body]
+    dual = splitting_dual[body]
+    finite = wp.isfinite(current) and wp.isfinite(projected) and wp.isfinite(dual)
+    if finite:
+        splitting_dual[body] = dual + projected - current
+    else:
+        world_active[world] = False
+        world_failed[world] = True
+
+
+@wp.kernel
+def _finalize_residual_iteration(
+    structural_residual: wp.array[wp.float32],
+    projected_structural_residual: wp.array[wp.float32],
+    lagged_velocity_residual: wp.array[wp.float32],
+    lagged_velocity_required: wp.array[wp.int32],
+    effort_residual: wp.array[wp.float32],
+    iteration_count: wp.array[wp.int32],
+    iteration_failed: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    world_converged: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    residual_change: wp.array[wp.float32],
+    residual_split: wp.array[wp.float32],
+    residual_structural: wp.array[wp.float32],
+    residual_structural_projected: wp.array[wp.float32],
+    residual_cross_iterate: wp.array[wp.float32],
+    residual_lagged_velocity: wp.array[wp.float32],
+    residual_total: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if not world_active[world]:
+        return
+    if iteration_failed[world] != 0:
+        world_active[world] = False
+        world_failed[world] = True
+        return
+
+    change = residual_change[world]
+    split = residual_split[world]
+    cross_iterate = residual_cross_iterate[world]
+    structural = wp.float32(0.0)
+    if structural_residual:
+        structural = structural_residual[world]
+    projected_structural = wp.float32(0.0)
+    if projected_structural_residual:
+        projected_structural = projected_structural_residual[world]
+    lagged_velocity = wp.float32(0.0)
+    if lagged_velocity_residual:
+        lagged_velocity = lagged_velocity_residual[world]
+    total = wp.max(wp.max(change, split), wp.max(wp.max(structural, cross_iterate), lagged_velocity))
+    if effort_residual:
+        total = wp.max(total, effort_residual[world])
+    residual_structural[world] = structural
+    residual_structural_projected[world] = projected_structural
+    residual_lagged_velocity[world] = lagged_velocity
+    residual_total[world] = total
+    lagged_velocity_is_valid = (
+        not lagged_velocity_required or lagged_velocity_required[world] == 0 or iteration_count[world] >= 2
+    )
+    if total <= 1.0 and lagged_velocity_is_valid:
+        world_active[world] = False
+        world_converged[world] = True
+
+
+@wp.kernel
+def _mark_iteration_limit(
+    world_active: wp.array[wp.bool],
+    world_iteration_limit: wp.array[wp.bool],
+):
+    world = wp.tid()
+    if world_active[world]:
+        world_active[world] = False
+        world_iteration_limit[world] = True
+
+
+@wp.func
+def _inverse_mass_quadratic_form(
+    jacobian: vec6f,
+    body: wp.int32,
+    inverse_mass: wp.array[wp.float32],
+    inverse_inertia_world: wp.array[wp.mat33f],
+) -> wp.float32:
+    if body < 0:
+        return 0.0
+    linear = wp.vec3f(jacobian[0], jacobian[1], jacobian[2])
+    angular = wp.vec3f(jacobian[3], jacobian[4], jacobian[5])
+    return inverse_mass[body] * wp.dot(linear, linear) + wp.dot(angular, inverse_inertia_world[body] @ angular)
+
+
+@wp.func
+def _inverse_mass_bilinear_form(
+    first: vec6f,
+    second: vec6f,
+    body: wp.int32,
+    inverse_mass: wp.array[wp.float32],
+    inverse_inertia_world: wp.array[wp.mat33f],
+) -> wp.float32:
+    if body < 0:
+        return 0.0
+    first_linear = wp.vec3f(first[0], first[1], first[2])
+    second_linear = wp.vec3f(second[0], second[1], second[2])
+    first_angular = wp.vec3f(first[3], first[4], first[5])
+    second_angular = wp.vec3f(second[3], second[4], second[5])
+    return inverse_mass[body] * wp.dot(first_linear, second_linear) + wp.dot(
+        first_angular, inverse_inertia_world[body] @ second_angular
+    )
+
+
+@wp.kernel
+def _evaluate_lagged_scalar_velocity_consistency(
+    row_world: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    world_active: wp.array[wp.bool],
+    global_twist: wp.array[vec6f],
+    projected_twist_previous: wp.array[vec6f],
+    inverse_velocity_tolerance: wp.float32,
+    world_required: wp.array[wp.int32],
+    world_residual: wp.array[wp.float32],
+):
+    row = wp.tid()
+    world = row_world[row]
+    if not world_active[world]:
+        return
+
+    first = body_first[row]
+    second = body_second[row]
+    if first < 0 and second < 0:
+        return
+    value = wp.float32(0.0)
+    if first >= 0:
+        value += wp.dot(jacobian_first[row], global_twist[first] - projected_twist_previous[first])
+    if second >= 0:
+        value += wp.dot(jacobian_second[row], global_twist[second] - projected_twist_previous[second])
+    wp.atomic_max(world_required, world, 1)
+    wp.atomic_max(world_residual, world, wp.abs(value) * inverse_velocity_tolerance)
+
+
+@wp.kernel
+def _evaluate_lagged_contact_velocity_consistency(
+    world_dynamic_offset: wp.array[wp.int32],
+    world_dynamic_count: wp.array[wp.int32],
+    dynamic_body_first: wp.array[wp.int32],
+    dynamic_body_second: wp.array[wp.int32],
+    dynamic_jacobian_first: wp.array[vec6f],
+    dynamic_jacobian_second: wp.array[vec6f],
+    world_structural_offset: wp.array[wp.int32],
+    world_structural_count: wp.array[wp.int32],
+    structural_body_first: wp.array[wp.int32],
+    structural_body_second: wp.array[wp.int32],
+    structural_jacobian_first: wp.array[vec6f],
+    structural_jacobian_second: wp.array[vec6f],
+    world_friction_offset: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    world_limit_offset: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    world_contact_offset: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    world_active: wp.array[wp.bool],
+    global_twist: wp.array[vec6f],
+    projected_twist_previous: wp.array[vec6f],
+    inverse_velocity_tolerance: wp.float32,
+    block_count: wp.int32,
+    world_required: wp.array[wp.int32],
+    world_residual: wp.array[wp.float32],
+):
+    world, block, lane = wp.tid()
+    if not world_active[world]:
+        return
+
+    residual = wp.float32(0.0)
+    if block == 0:
+        scalar_local = lane
+        while scalar_local < world_dynamic_count[world]:
+            row = world_dynamic_offset[world] + scalar_local
+            first = dynamic_body_first[row]
+            second = dynamic_body_second[row]
+            scalar_value = wp.float32(0.0)
+            if first >= 0:
+                scalar_value += wp.dot(
+                    dynamic_jacobian_first[row], global_twist[first] - projected_twist_previous[first]
+                )
+            if second >= 0:
+                scalar_value += wp.dot(
+                    dynamic_jacobian_second[row], global_twist[second] - projected_twist_previous[second]
+                )
+            residual = wp.max(residual, wp.abs(scalar_value) * inverse_velocity_tolerance)
+            scalar_local += wp.block_dim()
+        scalar_local = lane
+        while scalar_local < world_structural_count[world]:
+            row = world_structural_offset[world] + scalar_local
+            first = structural_body_first[row]
+            second = structural_body_second[row]
+            scalar_value = wp.float32(0.0)
+            if first >= 0:
+                scalar_value += wp.dot(
+                    structural_jacobian_first[row], global_twist[first] - projected_twist_previous[first]
+                )
+            if second >= 0:
+                scalar_value += wp.dot(
+                    structural_jacobian_second[row], global_twist[second] - projected_twist_previous[second]
+                )
+            residual = wp.max(residual, wp.abs(scalar_value) * inverse_velocity_tolerance)
+            scalar_local += wp.block_dim()
+        scalar_local = lane
+        while scalar_local < world_friction_count[world]:
+            row = world_friction_offset[world] + scalar_local
+            first = friction_body_first[row]
+            second = friction_body_second[row]
+            scalar_value = wp.float32(0.0)
+            if first >= 0:
+                scalar_value += wp.dot(
+                    friction_jacobian_first[row], global_twist[first] - projected_twist_previous[first]
+                )
+            if second >= 0:
+                scalar_value += wp.dot(
+                    friction_jacobian_second[row], global_twist[second] - projected_twist_previous[second]
+                )
+            residual = wp.max(residual, wp.abs(scalar_value) * inverse_velocity_tolerance)
+            scalar_local += wp.block_dim()
+        scalar_local = lane
+        while scalar_local < world_limit_count[world]:
+            row = world_limit_offset[world] + scalar_local
+            first = limit_body_first[row]
+            second = limit_body_second[row]
+            scalar_value = wp.float32(0.0)
+            if first >= 0:
+                scalar_value += wp.dot(limit_jacobian_first[row], global_twist[first] - projected_twist_previous[first])
+            if second >= 0:
+                scalar_value += wp.dot(
+                    limit_jacobian_second[row], global_twist[second] - projected_twist_previous[second]
+                )
+            residual = wp.max(residual, wp.abs(scalar_value) * inverse_velocity_tolerance)
+            scalar_local += wp.block_dim()
+
+    contact_count = world_contact_count[world]
+    local = block * wp.block_dim() + lane
+    stride = block_count * wp.block_dim()
+    while local < contact_count:
+        contact = world_contact_offset[world] + local
+        first = contact_body_first[contact]
+        second = contact_body_second[contact]
+        contact_value = wp.vec3f(0.0)
+        if first >= 0:
+            contact_value += contact_jacobian_first[contact] @ (global_twist[first] - projected_twist_previous[first])
+        if second >= 0:
+            contact_value += contact_jacobian_second[contact] @ (
+                global_twist[second] - projected_twist_previous[second]
+            )
+        residual = wp.max(residual, wp.max(wp.abs(contact_value)) * inverse_velocity_tolerance)
+        local += stride
+
+    block_residual = wp.tile_max(wp.tile(residual))[0]
+    if lane == 0:
+        if block == 0:
+            scalar_count = (
+                world_dynamic_count[world]
+                + world_structural_count[world]
+                + world_friction_count[world]
+                + world_limit_count[world]
+            )
+            if scalar_count + contact_count > 0:
+                world_required[world] = 1
+        if block * wp.block_dim() < contact_count or block == 0:
+            wp.atomic_max(world_residual, world, block_residual)
+
+
+@wp.kernel
+def _promote_effort_counters(
+    effort_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    counter_next: wp.array[wp.float32],
+    counter_applied: wp.array[wp.float32],
+):
+    effort = wp.tid()
+    if world_active[effort_world[effort]]:
+        counter_applied[effort] = counter_next[effort]
+
+
+@wp.kernel
+def _clear_active_effort_residuals(
+    world_active: wp.array[wp.bool],
+    residual_scaled: wp.array[wp.float32],
+    residual_unscaled: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if world_active[world]:
+        residual_scaled[world] = 0.0
+        residual_unscaled[world] = 0.0
+
+
+@wp.kernel
+def _update_effort_counters(
+    effort_world: wp.array[wp.int32],
+    effort_dynamic_row: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_inertia: wp.array[wp.float32],
+    projected_twist: wp.array[vec6f],
+    intercept: wp.array[wp.float32],
+    slope: wp.array[wp.float32],
+    impulse_bound: wp.array[wp.float32],
+    counter_applied: wp.array[wp.float32],
+    time_step: wp.array[wp.float32],
+    velocity_tolerance: wp.float32,
+    counter_next: wp.array[wp.float32],
+    raw_impulse: wp.array[wp.float32],
+    net_applied: wp.array[wp.float32],
+    net_target: wp.array[wp.float32],
+    velocity: wp.array[wp.float32],
+    residual: wp.array[wp.float32],
+    world_residual_scaled: wp.array[wp.float32],
+    world_residual_unscaled: wp.array[wp.float32],
+):
+    effort = wp.tid()
+    world = effort_world[effort]
+    if not world_active[world]:
+        return
+
+    dynamic_row = effort_dynamic_row[effort]
+    current_velocity = wp.float32(0.0)
+    first = body_first[dynamic_row]
+    second = body_second[dynamic_row]
+    if first >= 0:
+        current_velocity += wp.dot(jacobian_first[dynamic_row], projected_twist[first])
+    if second >= 0:
+        current_velocity += wp.dot(jacobian_second[dynamic_row], projected_twist[second])
+
+    raw = time_step[world] * (intercept[effort] - slope[effort] * current_velocity)
+    bound = impulse_bound[effort]
+    target = wp.clamp(raw, -bound, bound)
+    next_counter = target - raw
+    applied_counter = counter_applied[effort]
+    defect = wp.abs(next_counter - applied_counter)
+    scaled_defect = defect / (wp.max(1.0e-6, effective_inertia[dynamic_row]) * velocity_tolerance)
+
+    counter_next[effort] = next_counter
+    raw_impulse[effort] = raw
+    net_applied[effort] = raw + applied_counter
+    net_target[effort] = target
+    velocity[effort] = current_velocity
+    residual[effort] = defect
+    wp.atomic_max(world_residual_scaled, world, scaled_defect)
+    wp.atomic_max(world_residual_unscaled, world, defect)
+
+
+@cache
+def make_evaluate_candidate_structural_residual_kernel(correction: JointCorrectionMode):
+    """Build a kernel that evaluates exact joint residuals at candidate poses."""
+
+    @wp.kernel
+    def _evaluate_candidate_structural_residual(
+        time_step: wp.array[wp.float32],
+        joint_world: wp.array[wp.int32],
+        joint_dof_type: wp.array[wp.int32],
+        joint_coords_offset: wp.array[wp.int32],
+        joint_dofs_offset: wp.array[wp.int32],
+        joint_kinematic_offset: wp.array[wp.int32],
+        joint_body_first: wp.array[wp.int32],
+        joint_body_second: wp.array[wp.int32],
+        joint_first_position: wp.array[wp.vec3f],
+        joint_second_position: wp.array[wp.vec3f],
+        joint_first_orientation: wp.array[wp.mat33f],
+        joint_second_orientation: wp.array[wp.mat33f],
+        body_pose: wp.array[wp.transformf],
+        candidate_twist: wp.array[vec6f],
+        linearization_twist: wp.array[vec6f],
+        previous_joint_coordinate: wp.array[wp.float32],
+        world_active: wp.array[wp.bool],
+        candidate_residual: wp.array[wp.float32],
+        scratch_residual_velocity: wp.array[wp.float32],
+        scratch_joint_coordinate: wp.array[wp.float32],
+        scratch_joint_velocity: wp.array[wp.float32],
+    ):
+        joint = wp.tid()
+        world = joint_world[joint]
+        if not world_active[world]:
+            return
+        dt = time_step[world]
+
+        first = joint_body_first[joint]
+        second = joint_body_second[joint]
+        first_pose = wp.transform_identity(dtype=wp.float32)
+        if first >= 0:
+            first_delta = candidate_twist[first] - linearization_twist[first]
+            first_pose = compute_body_pose_update_with_logmap(
+                dt,
+                body_pose[first],
+                wp.vec3f(first_delta[0], first_delta[1], first_delta[2]),
+                wp.vec3f(first_delta[3], first_delta[4], first_delta[5]),
+            )
+        second_delta = candidate_twist[second] - linearization_twist[second]
+        second_pose = compute_body_pose_update_with_logmap(
+            dt,
+            body_pose[second],
+            wp.vec3f(second_delta[0], second_delta[1], second_delta[2]),
+            wp.vec3f(second_delta[3], second_delta[4], second_delta[5]),
+        )
+
+        _, relative_position, relative_orientation, relative_twist = compute_joint_pose_and_relative_motion(
+            first_pose,
+            second_pose,
+            wp.spatial_vectorf(0.0),
+            wp.spatial_vectorf(0.0),
+            joint_first_position[joint],
+            joint_second_position[joint],
+            joint_first_orientation[joint],
+            joint_second_orientation[joint],
+        )
+        wp.static(make_write_joint_data(correction))(
+            joint_dof_type[joint],
+            joint_kinematic_offset[joint],
+            joint_dofs_offset[joint],
+            joint_coords_offset[joint],
+            relative_position,
+            relative_orientation,
+            relative_twist,
+            previous_joint_coordinate,
+            candidate_residual,
+            scratch_residual_velocity,
+            scratch_joint_coordinate,
+            scratch_joint_velocity,
+        )
+
+    return _evaluate_candidate_structural_residual
+
+
+@wp.kernel
+def _blend_structural_candidate_twist(
+    global_twist: wp.array[vec6f],
+    projected_twist: wp.array[vec6f],
+    projected_fraction: wp.float32,
+    candidate_twist: wp.array[vec6f],
+):
+    body = wp.tid()
+    candidate_twist[body] = global_twist[body] + projected_fraction * (projected_twist[body] - global_twist[body])
+
+
+@wp.kernel
+def _include_dynamic_compliance_in_structural_effective_mass(
+    joint_body_first: wp.array[wp.int32],
+    joint_body_second: wp.array[wp.int32],
+    joint_structural_offset: wp.array[wp.int32],
+    joint_structural_count: wp.array[wp.int32],
+    joint_dynamic_offset: wp.array[wp.int32],
+    joint_dynamic_count: wp.array[wp.int32],
+    structural_jacobian_first: wp.array[vec6f],
+    structural_jacobian_second: wp.array[vec6f],
+    dynamic_jacobian_first: wp.array[vec6f],
+    dynamic_jacobian_second: wp.array[vec6f],
+    dynamic_effective_inertia: wp.array[wp.float32],
+    inverse_mass: wp.array[wp.float32],
+    inverse_inertia_world: wp.array[wp.mat33f],
+    effective_mass: wp.array[wp.float32],
+):
+    joint = wp.tid()
+    structural_count = joint_structural_count[joint]
+    dynamic_count = joint_dynamic_count[joint]
+    if structural_count == 0 or dynamic_count == 0:
+        return
+
+    first_body = joint_body_first[joint]
+    second_body = joint_body_second[joint]
+    dynamic_offset = joint_dynamic_offset[joint]
+
+    # Factor the mixed dynamic-row Schur block
+    #
+    #   J_d M^-1 J_d^T + diag(m_j^-1).
+    #
+    # Keeping m_j^-1 here retains the full implicit drive compliance for
+    # effort-limited drives independently of whether their multiplier is at
+    # its bound.
+    lower = mat66f(0.0)
+    valid = wp.bool(True)
+    for row in range(6):
+        if row < dynamic_count:
+            first_row = dynamic_jacobian_first[dynamic_offset + row]
+            second_row = dynamic_jacobian_second[dynamic_offset + row]
+            for col in range(6):
+                if col <= row and col < dynamic_count:
+                    first_col = dynamic_jacobian_first[dynamic_offset + col]
+                    second_col = dynamic_jacobian_second[dynamic_offset + col]
+                    value = _inverse_mass_bilinear_form(
+                        first_row, first_col, first_body, inverse_mass, inverse_inertia_world
+                    ) + _inverse_mass_bilinear_form(
+                        second_row, second_col, second_body, inverse_mass, inverse_inertia_world
+                    )
+                    if row == col:
+                        inertia = dynamic_effective_inertia[dynamic_offset + row]
+                        if inertia > 0.0:
+                            value += 1.0 / inertia
+                    for inner in range(6):
+                        if inner < col:
+                            value -= lower[row, inner] * lower[col, inner]
+                    if row == col:
+                        if not wp.isfinite(value) or value <= 1.0e-12:
+                            valid = False
+                        elif valid:
+                            lower[row, col] = wp.sqrt(value)
+                    elif valid:
+                        lower[row, col] = value / lower[col, col]
+
+    if not valid:
+        return
+
+    structural_offset = joint_structural_offset[joint]
+    for structural_local in range(6):
+        if structural_local < structural_count:
+            structural_row = structural_offset + structural_local
+            first_structural = structural_jacobian_first[structural_row]
+            second_structural = structural_jacobian_second[structural_row]
+            inverse_effective_mass = _inverse_mass_bilinear_form(
+                first_structural, first_structural, first_body, inverse_mass, inverse_inertia_world
+            ) + _inverse_mass_bilinear_form(
+                second_structural, second_structural, second_body, inverse_mass, inverse_inertia_world
+            )
+
+            # Subtract the response of the retained mixed drive rows:
+            # J_s M^-1 J_d^T S_d^-1 J_d M^-1 J_s^T.
+            forward = vec6f(0.0)
+            for row in range(6):
+                if row < dynamic_count:
+                    coupling = _inverse_mass_bilinear_form(
+                        first_structural,
+                        dynamic_jacobian_first[dynamic_offset + row],
+                        first_body,
+                        inverse_mass,
+                        inverse_inertia_world,
+                    ) + _inverse_mass_bilinear_form(
+                        second_structural,
+                        dynamic_jacobian_second[dynamic_offset + row],
+                        second_body,
+                        inverse_mass,
+                        inverse_inertia_world,
+                    )
+                    for inner in range(6):
+                        if inner < row:
+                            coupling -= lower[row, inner] * forward[inner]
+                    forward[row] = coupling / lower[row, row]
+                    inverse_effective_mass -= forward[row] * forward[row]
+
+            effective_mass[structural_row] = 1.0 / inverse_effective_mass if inverse_effective_mass > 1.0e-12 else 0.0
+
+
+@wp.kernel
+def _reset_structural_multipliers_masked(
+    row_world: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
+    reaction: wp.array[wp.float32],
+):
+    row = wp.tid()
+    if world_mask[row_world[row]]:
+        reaction[row] = 0.0
+
+
+@wp.kernel
+def _reset_effort_rows_masked(
+    effort_world: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
+    effort_intercept: wp.array[wp.float32],
+    effort_slope: wp.array[wp.float32],
+    effort_impulse_bound: wp.array[wp.float32],
+    effort_raw_impulse: wp.array[wp.float32],
+    effort_counter_applied: wp.array[wp.float32],
+    effort_counter_next: wp.array[wp.float32],
+    effort_net_applied: wp.array[wp.float32],
+    effort_net_target: wp.array[wp.float32],
+    effort_velocity: wp.array[wp.float32],
+    effort_residual: wp.array[wp.float32],
+):
+    effort = wp.tid()
+    if world_mask[effort_world[effort]]:
+        effort_intercept[effort] = 0.0
+        effort_slope[effort] = 0.0
+        effort_impulse_bound[effort] = 0.0
+        effort_raw_impulse[effort] = 0.0
+        effort_counter_applied[effort] = 0.0
+        effort_counter_next[effort] = 0.0
+        effort_net_applied[effort] = 0.0
+        effort_net_target[effort] = 0.0
+        effort_velocity[effort] = 0.0
+        effort_residual[effort] = 0.0
+
+
+@wp.kernel
+def _reset_effort_worlds_masked(
+    world_mask: wp.array[wp.bool],
+    world_effort_residual_max: wp.array[wp.float32],
+    world_effort_defect_max: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if world_mask[world]:
+        world_effort_residual_max[world] = 0.0
+        world_effort_defect_max[world] = 0.0
+
+
+@wp.kernel
+def _reset_friction_reactions_masked(
+    friction_world: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
+    friction_reaction: wp.array[wp.float32],
+):
+    friction = wp.tid()
+    if world_mask[friction_world[friction]]:
+        friction_reaction[friction] = 0.0
+
+
+@wp.kernel
+def _scale_structural_reactions(
+    scale: wp.float32,
+    reaction: wp.array[wp.float32],
+):
+    row = wp.tid()
+    reaction[row] *= scale
+
+
+@wp.kernel
+def _update_structural_multipliers_from_candidate_rows(
+    time_step: wp.array[wp.float32],
+    structural_tolerance: wp.float32,
+    row_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    body_first_global: wp.array[wp.int32],
+    body_second_global: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    candidate_residual: wp.array[wp.float32],
+    proximal_defect: wp.array[wp.float32],
+    frozen_residual: wp.array[wp.float32],
+    penalty: wp.array[wp.float32],
+    linearization_twist: wp.array[vec6f],
+    candidate_twist: wp.array[vec6f],
+    proximal_relaxation: wp.float32,
+    body_vector_index: wp.array[wp.int32],
+    reaction: wp.array[wp.float32],
+    world_residual: wp.array[wp.float32],
+    right_hand_side: wp.array[wp.float32],
+):
+    row = wp.tid()
+    world = row_world[row]
+    dt = time_step[world]
+    if not world_active[world] or projection_status[world] != PROJECTION_STATUS_VALID:
+        return
+
+    first_global = body_first_global[row]
+    second_global = body_second_global[row]
+    first_dynamic = first_global >= 0 and body_vector_index[first_global] >= 0
+    second_dynamic = second_global >= 0 and body_vector_index[second_global] >= 0
+    if not first_dynamic and not second_dynamic:
+        reaction[row] = 0.0
+        return
+    candidate_velocity = wp.float32(0.0)
+    linearization_velocity = wp.float32(0.0)
+    if first_global >= 0:
+        candidate_velocity += wp.dot(jacobian_first[row], candidate_twist[first_global])
+        linearization_velocity += wp.dot(jacobian_first[row], linearization_twist[first_global])
+    if second_global >= 0:
+        candidate_velocity += wp.dot(jacobian_second[row], candidate_twist[second_global])
+        linearization_velocity += wp.dot(jacobian_second[row], linearization_twist[second_global])
+
+    linear_residual = frozen_residual[row] + dt * (candidate_velocity - linearization_velocity)
+    update_residual = linear_residual
+    if proximal_relaxation > 0.0:
+        defect = proximal_defect[row]
+        defect += proximal_relaxation * (candidate_residual[row] - linear_residual - defect)
+        proximal_defect[row] = defect
+        update_residual += defect
+    candidate_residual[row] = update_residual
+    wp.atomic_max(world_residual, world, wp.abs(update_residual) / structural_tolerance)
+
+    reaction_delta = -penalty[row] * update_residual
+    reaction[row] += reaction_delta
+
+    for axis in range(6):
+        if first_global >= 0 and body_vector_index[first_global] >= 0:
+            wp.atomic_add(
+                right_hand_side,
+                body_vector_index[first_global] + axis,
+                dt * reaction_delta * jacobian_first[row][axis],
+            )
+        if second_global >= 0 and body_vector_index[second_global] >= 0:
+            wp.atomic_add(
+                right_hand_side,
+                body_vector_index[second_global] + axis,
+                dt * reaction_delta * jacobian_second[row][axis],
+            )
+
+
+@wp.kernel
+def _reduce_structural_candidate_residual(
+    structural_tolerance: wp.float32,
+    row_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    body_first_global: wp.array[wp.int32],
+    body_second_global: wp.array[wp.int32],
+    candidate_residual: wp.array[wp.float32],
+    body_vector_index: wp.array[wp.int32],
+    world_residual: wp.array[wp.float32],
+):
+    row = wp.tid()
+    world = row_world[row]
+    if not world_active[world] or projection_status[world] != PROJECTION_STATUS_VALID:
+        return
+
+    first = body_first_global[row]
+    second = body_second_global[row]
+    first_dynamic = first >= 0 and body_vector_index[first] >= 0
+    second_dynamic = second >= 0 and body_vector_index[second] >= 0
+    if not first_dynamic and not second_dynamic:
+        return
+    wp.atomic_max(world_residual, world, wp.abs(candidate_residual[row]) / structural_tolerance)

--- a/newton/_src/solvers/kamino/_src/solvers/lox/problem.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/problem.py
@@ -1,0 +1,1675 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent primal problem for the LOX rigid-body backend.
+
+The problem owns persistent rows, capacity mappings, and splitting state.
+Construction may read immutable model arrays on the host; :meth:`LOXProblem.update`
+uses only fixed-size device operations so it remains suitable for graph capture.
+Kamino contact vectors remain normal-last throughout this boundary.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import numpy as np
+import warp as wp
+
+from ......sim import BodyFlags, JointType
+from ...core.bodies import update_body_inertias
+from ...core.data import DataKamino
+from ...core.joints import DofActuationPath, JointActuationType, JointCorrectionMode
+from ...core.model import ModelKamino
+from ...core.types import mat36f, vec6f
+from ...geometry.contacts import ContactsKamino
+from ...kinematics.constraints import update_constraints_info
+from ...kinematics.jacobians import SparseSystemJacobians
+from ...kinematics.joints import compute_joints_data
+from ...kinematics.limits import LimitsKamino
+from .adapter import (
+    _accumulate_aligned_joint_wrenches,
+    _accumulate_constraint_incidence,
+    _clear_inactive_contacts,
+    _clear_inactive_limits,
+    _copy_clamped_world_counts,
+    _mark_worlds_with_unilaterals,
+    _prepare_contacts,
+    _prepare_dynamic_rows,
+    _prepare_joint_frictions,
+    _prepare_limits,
+    _prepare_structural_rows,
+    _write_contact_outputs,
+    _write_dynamic_outputs,
+    _write_dynamic_outputs_with_effort,
+    _write_friction_outputs,
+    _write_limit_outputs,
+)
+from .kernels import (
+    _blend_structural_candidate_twist,
+    _clear_active_effort_residuals,
+    _evaluate_lagged_contact_velocity_consistency,
+    _evaluate_lagged_scalar_velocity_consistency,
+    _include_dynamic_compliance_in_structural_effective_mass,
+    _promote_effort_counters,
+    _reduce_structural_candidate_residual,
+    _reset_effort_rows_masked,
+    _reset_effort_worlds_masked,
+    _reset_friction_reactions_masked,
+    _reset_structural_multipliers_masked,
+    _scale_structural_reactions,
+    _update_effort_counters,
+    _update_structural_multipliers_from_candidate_rows,
+    make_evaluate_candidate_structural_residual_kernel,
+)
+from .system import BatchedPrimalBodySystem
+from .types import SplittingState
+
+__all__ = ["LOXProblem"]
+
+wp.set_module_options({"enable_backward": False})
+
+_LAGGED_CONTACT_BLOCK_DIM = 64
+
+
+def _capacity_offsets(capacities: Sequence[int] | np.ndarray) -> np.ndarray:
+    capacities_np = np.asarray(capacities, dtype=np.int32)
+    offsets = np.empty(capacities_np.size + 1, dtype=np.int32)
+    offsets[0] = 0
+    np.cumsum(capacities_np, out=offsets[1:])
+    return offsets
+
+
+def _segment_local_indices(counts: np.ndarray, offsets: np.ndarray | None = None) -> np.ndarray:
+    """Return packed indices relative to the start of each variable-length segment."""
+    if offsets is None:
+        offsets = _capacity_offsets(counts)
+    return np.arange(int(offsets[-1]), dtype=np.int32) - np.repeat(offsets[:-1], counts)
+
+
+def _connected_component_labels(
+    count: int,
+    first: np.ndarray,
+    second: np.ndarray,
+) -> np.ndarray:
+    """Compute minimum-vertex component labels with vectorized label propagation."""
+    labels = np.arange(count, dtype=np.int32)
+    if first.size == 0:
+        return labels
+    while True:
+        endpoint_labels = np.minimum(labels[first], labels[second])
+        updated = labels.copy()
+        np.minimum.at(updated, first, endpoint_labels)
+        np.minimum.at(updated, second, endpoint_labels)
+        updated = updated[updated]
+        if np.array_equal(updated, labels):
+            return labels
+        labels = updated
+
+
+class LOXProblem:
+    """Own rigid-body topology, constraint rows, and nonlinear splitting state."""
+
+    def __init__(
+        self,
+        model: ModelKamino,
+        data: DataKamino,
+        jacobians: SparseSystemJacobians,
+        limits: LimitsKamino | None = None,
+        contacts: ContactsKamino | None = None,
+        eliminate_fixed_world_islands: bool = True,
+        projection_method: str = "jacobi",
+        rotation_correction: JointCorrectionMode = JointCorrectionMode.TWOPI,
+        joint_proximal_relaxation: float = 0.0,
+    ):
+        self.model = model
+        self.data = data
+        self.jacobians = jacobians
+        self.limits = limits
+        self.contacts = contacts
+        self.device = wp.get_device(model.device)
+        self.num_worlds = model.info.num_worlds
+        self.eliminate_fixed_world_islands = eliminate_fixed_world_islands
+        self.projection_method = projection_method
+        self.rotation_correction = rotation_correction
+        self._evaluate_candidate_structural_residual = make_evaluate_candidate_structural_residual_kernel(
+            rotation_correction
+        )
+        self.joint_proximal_relaxation = joint_proximal_relaxation
+        self._allocate_acceleration_storage = projection_method == "apgd"
+
+        if jacobians._J_cts is None or jacobians._J_dofs is None:
+            raise RuntimeError("Sparse Jacobians must be finalized before constructing the LOX problem.")
+        self._sparse_jacobian_data = jacobians._J_cts.bsm.nzb_values
+        self._sparse_dof_jacobian_data = jacobians._J_dofs.bsm.nzb_values
+        self._sparse_limit_offsets = jacobians._J_cts_limit_nzb_offsets
+
+        self.rebuild_dynamic_body_topology()
+
+    def prepare_joint_penalty_scale_seed(self, time_step: float) -> None:
+        """Prepare the initial rigid state for LOX penalty-scale seeding."""
+        if not math.isfinite(time_step) or time_step <= 0.0:
+            raise ValueError("time_step must be finite and positive.")
+        if np.any(self.data.time.steps.numpy() != 0):
+            raise RuntimeError("joint penalty scale seeding must run before the first step or after a solver reset.")
+
+        self.model.time.set_uniform_timestep(time_step)
+        compute_joints_data(
+            model=self.model,
+            data=self.data,
+            q_j_p=self.data.joints.q_j_p,
+            correction=self.rotation_correction,
+        )
+        update_body_inertias(model=self.model.bodies, data=self.data.bodies)
+        if self.limits is not None:
+            self.limits.detect(q_j=self.data.joints.q_j)
+        update_constraints_info(model=self.model, data=self.data)
+        self.jacobians.build(
+            model=self.model,
+            data=self.data,
+            limits=self.limits,
+            contacts=None,
+            reset_to_zero=True,
+        )
+
+    @staticmethod
+    def _device_array(values: Sequence[int], device: wp.DeviceLike) -> wp.array[wp.int32]:
+        return wp.array(values, dtype=wp.int32, device=device)
+
+    def _build_body_edges(self, dynamic_bodies: Sequence[int]) -> tuple[tuple[int, int], ...]:
+        """Return fixed joint edges whose endpoints are both dynamic bodies."""
+        joint_first = self.model.joints.bid_B.numpy().astype(np.int32, copy=False)
+        joint_second = self.model.joints.bid_F.numpy().astype(np.int32, copy=False)
+        dynamic_mask = np.zeros(self.model.size.sum_of_num_bodies, dtype=bool)
+        dynamic_mask[np.asarray(dynamic_bodies, dtype=np.int32)] = True
+        edge_mask = (joint_first >= 0) & (joint_second >= 0)
+        edge_mask &= dynamic_mask[joint_first.clip(min=0)] & dynamic_mask[joint_second.clip(min=0)]
+        return tuple(map(tuple, np.column_stack((joint_first[edge_mask], joint_second[edge_mask])).tolist()))
+
+    def _build_body_components(
+        self, dynamic_bodies: Sequence[int], body_edges: Sequence[tuple[int, int]]
+    ) -> tuple[tuple[int, ...], ...]:
+        """Return joint-connected dynamic-body components without contact edges."""
+        dynamic_np = np.asarray(dynamic_bodies, dtype=np.int32)
+        if dynamic_np.size == 0:
+            return ()
+        edges_np = np.asarray(body_edges, dtype=np.int32).reshape((-1, 2))
+        labels = _connected_component_labels(
+            self.model.size.sum_of_num_bodies,
+            edges_np[:, 0],
+            edges_np[:, 1],
+        )[dynamic_np]
+        order = np.argsort(labels, kind="stable")
+        sorted_bodies = dynamic_np[order]
+        sorted_labels = labels[order]
+        boundaries = np.flatnonzero(sorted_labels[1:] != sorted_labels[:-1]) + 1
+        return tuple(tuple(component.tolist()) for component in np.split(sorted_bodies, boundaries))
+
+    def _classify_dynamic_bodies(self) -> tuple[int, ...]:
+        """Return dynamic bodies using state flags and fixed-tree world islands."""
+        source_model = self.model._model
+        body_count = self.model.size.sum_of_num_bodies
+        if source_model is None:
+            inverse_mass = self.model.bodies.inv_m_i.numpy()
+            return tuple(np.flatnonzero(inverse_mass > 0.0).tolist())
+
+        body_flags = source_model.body_flags.numpy().astype(np.int32, copy=False)
+        if len(body_flags) != body_count:
+            raise ValueError("Newton body flags must contain one entry per packed Kamino body.")
+        if not self.eliminate_fixed_world_islands:
+            return tuple(np.flatnonzero((body_flags & int(BodyFlags.KINEMATIC)) == 0).tolist())
+
+        joint_type = source_model.joint_type.numpy().astype(np.int32, copy=False)
+        joint_parent = source_model.joint_parent.numpy().astype(np.int32, copy=False)
+        joint_child = source_model.joint_child.numpy().astype(np.int32, copy=False)
+        articulation_start = source_model.articulation_start.numpy().astype(np.int32, copy=False)[:-1]
+        articulation_end = source_model.articulation_end.numpy().astype(np.int32, copy=False)
+        tree_delta = np.zeros(joint_type.size + 1, dtype=np.int32)
+        np.add.at(tree_delta, articulation_start, 1)
+        np.add.at(tree_delta, articulation_end, -1)
+        tree_joint = np.cumsum(tree_delta[:-1]) != 0
+        fixed_joint = tree_joint & (joint_type == int(JointType.FIXED)) & (joint_child >= 0)
+        fixed_to_world = joint_child[fixed_joint & (joint_parent < 0)]
+        fixed_pair = fixed_joint & (joint_parent >= 0)
+        labels = _connected_component_labels(body_count, joint_parent[fixed_pair], joint_child[fixed_pair])
+        prescribed_bodies = np.concatenate(
+            (fixed_to_world, np.flatnonzero(body_flags & int(BodyFlags.KINEMATIC)).astype(np.int32))
+        )
+        prescribed_labels = np.unique(labels[prescribed_bodies])
+        return tuple(np.flatnonzero(~np.isin(labels, prescribed_labels)).tolist())
+
+    def dynamic_body_topology_changed(self) -> bool:
+        """Return whether current body flags require a different primal topology."""
+        return self._classify_dynamic_bodies() != self.system.dynamic_bodies
+
+    def rebuild_dynamic_body_topology(self) -> None:
+        """Reallocate topology-dependent data while preserving adapter identity."""
+        model = self.model
+        body_counts = tuple(model.info.num_bodies.numpy().astype(np.int32, copy=False).tolist())
+        dynamic_bodies = self._classify_dynamic_bodies()
+        body_edges = self._build_body_edges(dynamic_bodies)
+        body_components = self._build_body_components(dynamic_bodies, body_edges)
+        self.system = BatchedPrimalBodySystem(
+            body_counts,
+            body_components=body_components,
+            dynamic_bodies=dynamic_bodies,
+            body_edges=body_edges,
+            device=self.device,
+        )
+        self.splitting = SplittingState(body_counts, device=self.device)
+        self.world_active = self.splitting.world_active
+        self.projected_twist = self.splitting.projected_twist
+        self.body_velocity_begin = wp.zeros(model.size.sum_of_num_bodies, dtype=vec6f, device=self.device)
+        self.joint_velocity_begin = wp.zeros(model.size.sum_of_num_joint_dofs, dtype=wp.float32, device=self.device)
+        self.body_linearization_twist = wp.zeros(model.size.sum_of_num_bodies, dtype=vec6f, device=self.device)
+        self._limit_stabilization_fraction = 0.01
+        self._contact_stabilization_fraction = 0.01
+        self._contact_dead_zone = 1.0e-6
+        self._impact_velocity_threshold = 1.0e-3
+        self._contact_recoverable_response = False
+        self._uniform_joint_penalty_scale = wp.ones(self.num_worlds, dtype=wp.float32, device=self.device)
+
+        self._allocate_joint_rows()
+        self.system.validate_body_pairs("dynamic rows", self.dynamic_body_first_global, self.dynamic_body_second_global)
+        self.system.validate_body_pairs(
+            "structural rows", self.structural_body_first_global, self.structural_body_second_global
+        )
+        self._allocate_effort_rows()
+        self._allocate_joint_frictions()
+        self._allocate_unilaterals()
+        self.world_lagged_velocity_residual = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.world_lagged_velocity_required = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+
+    def _allocate_joint_rows(self) -> None:
+        model = self.model
+        joint_count = model.size.sum_of_num_joints
+        joint_indices = np.arange(joint_count, dtype=np.int32)
+        joint_world = model.joints.wid.numpy().astype(np.int32, copy=False)
+        joint_body_first = model.joints.bid_B.numpy().astype(np.int32, copy=False)
+        joint_body_second = model.joints.bid_F.numpy().astype(np.int32, copy=False)
+        joint_dof_count = model.joints.num_dofs.numpy().astype(np.int32, copy=False)
+        joint_dynamic_count = model.joints.num_dynamic_cts.numpy().astype(np.int32, copy=False)
+        joint_effort_count = model.joints.num_effort_cts.numpy().astype(np.int32, copy=False)
+        joint_dynamic_axis = model.joints.dynamic_cts_axis.numpy().astype(np.int32, copy=False)
+        joint_structural_count = model.joints.num_kinematic_cts.numpy().astype(np.int32, copy=False)
+        joint_dynamic_offset = model.joints.dynamic_cts_offset.numpy().astype(np.int32, copy=False)
+        joint_dof_offset = model.joints.dofs_offset.numpy().astype(np.int32, copy=False)
+        joint_dof_actuation_path = model.joints.dof_act_paths.numpy().astype(np.int32, copy=False)
+        joint_structural_offset = model.joints.kinematic_cts_offset.numpy().astype(np.int32, copy=False)
+        sparse_joint_offsets = self.jacobians._J_cts_joint_nzb_offsets.numpy().astype(np.int32, copy=False)
+        sparse_dof_joint_offsets = self.jacobians._J_dofs_joint_nzb_offsets.numpy().astype(np.int32, copy=False)
+
+        native_joint = np.repeat(joint_indices, joint_dynamic_count)
+        native_offsets = _capacity_offsets(joint_dynamic_count)
+        native_local = _segment_local_indices(joint_dynamic_count, native_offsets)
+        native_axis = joint_dynamic_axis[joint_dynamic_offset[native_joint] + native_local]
+        native_dof = joint_dof_offset[native_joint] + native_axis
+
+        dof_joint = np.repeat(joint_indices, joint_dof_count)
+        dof_offsets = _capacity_offsets(joint_dof_count)
+        dof_axis = _segment_local_indices(joint_dof_count, dof_offsets)
+        dof_index = joint_dof_offset[dof_joint] + dof_axis
+        native_dof_mask = np.zeros(model.size.sum_of_num_joint_dofs, dtype=bool)
+        native_dof_mask[native_dof] = True
+        joint_retains_effort_rows = np.repeat(joint_effort_count > 0, joint_dof_count)
+        extra_mask = (
+            (joint_dof_actuation_path[dof_index] == int(DofActuationPath.EFFORT_CTS))
+            & joint_retains_effort_rows[dof_index]
+            & ~native_dof_mask[dof_index]
+        )
+        extra_joint = dof_joint[extra_mask]
+        extra_axis = dof_axis[extra_mask]
+        extra_dof = dof_index[extra_mask]
+        extra_count = np.bincount(extra_joint, minlength=joint_count).astype(np.int32, copy=False)
+
+        joint_dynamic_row_count = joint_dynamic_count + extra_count
+        joint_dynamic_row_offset = _capacity_offsets(joint_dynamic_row_count)
+        self.dynamic_row_count = int(joint_dynamic_row_offset[-1])
+        dynamic_world = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_joint = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_first_global = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_second_global = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_value_index = np.full(self.dynamic_row_count, -1, dtype=np.int32)
+        dynamic_dof_index = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_multiplier_index = np.full(self.dynamic_row_count, -1, dtype=np.int32)
+        dynamic_sparse_first_index = np.full(self.dynamic_row_count, -1, dtype=np.int32)
+        dynamic_sparse_second_index = np.empty(self.dynamic_row_count, dtype=np.int32)
+        dynamic_uses_dof_jacobian = np.ones(self.dynamic_row_count, dtype=bool)
+
+        native_target = joint_dynamic_row_offset[native_joint] + native_local
+        extra_offsets = _capacity_offsets(extra_count)
+        extra_local = _segment_local_indices(extra_count, extra_offsets)
+        extra_target = joint_dynamic_row_offset[extra_joint] + joint_dynamic_count[extra_joint] + extra_local
+        for target, source_joint in ((native_target, native_joint), (extra_target, extra_joint)):
+            dynamic_world[target] = joint_world[source_joint]
+            dynamic_joint[target] = source_joint
+            dynamic_first_global[target] = joint_body_first[source_joint]
+            dynamic_second_global[target] = joint_body_second[source_joint]
+        dynamic_value_index[native_target] = joint_dynamic_offset[native_joint] + native_local
+        dynamic_dof_index[native_target] = native_dof
+        dynamic_dof_index[extra_target] = extra_dof
+        dynamic_multiplier_index[native_target] = joint_dynamic_offset[native_joint] + native_local
+        native_sparse_first = sparse_joint_offsets[native_joint] + joint_dof_count[native_joint] + native_local
+        dynamic_sparse_first_index[native_target] = np.where(
+            joint_body_first[native_joint] >= 0, native_sparse_first, -1
+        )
+        dynamic_sparse_second_index[native_target] = sparse_joint_offsets[native_joint] + native_local
+        extra_sparse_first = sparse_dof_joint_offsets[extra_joint] + joint_dof_count[extra_joint] + extra_axis
+        dynamic_sparse_first_index[extra_target] = np.where(joint_body_first[extra_joint] >= 0, extra_sparse_first, -1)
+        dynamic_sparse_second_index[extra_target] = sparse_dof_joint_offsets[extra_joint] + extra_axis
+        dynamic_uses_dof_jacobian[native_target] = False
+
+        adapter_world_dynamic_count = np.bincount(dynamic_world, minlength=self.num_worlds).astype(np.int32, copy=False)
+        dynamic_row_offsets = _capacity_offsets(adapter_world_dynamic_count)
+        self.world_dynamic_row_offset = self._device_array(dynamic_row_offsets[:-1], self.device)
+        self.world_dynamic_row_count = self._device_array(adapter_world_dynamic_count, self.device)
+        self.dynamic_row_world = self._device_array(dynamic_world, self.device)
+        self.dynamic_row_joint = self._device_array(dynamic_joint, self.device)
+        self.dynamic_body_first_global = self._device_array(dynamic_first_global, self.device)
+        self.dynamic_body_second_global = self._device_array(dynamic_second_global, self.device)
+        self.dynamic_value_index = self._device_array(dynamic_value_index, self.device)
+        self.dynamic_dof_index = self._device_array(dynamic_dof_index, self.device)
+        self.dynamic_multiplier_index = self._device_array(dynamic_multiplier_index, self.device)
+        self.dynamic_sparse_first_index = self._device_array(dynamic_sparse_first_index, self.device)
+        self.dynamic_sparse_second_index = self._device_array(dynamic_sparse_second_index, self.device)
+        self.dynamic_uses_dof_jacobian = wp.array(dynamic_uses_dof_jacobian, dtype=wp.bool, device=self.device)
+        self.joint_dynamic_row_offset = self._device_array(joint_dynamic_row_offset[:-1], self.device)
+        self.joint_dynamic_row_count = self._device_array(joint_dynamic_row_count, self.device)
+        self.dynamic_jacobian_first = wp.zeros(self.dynamic_row_count, dtype=vec6f, device=self.device)
+        self.dynamic_jacobian_second = wp.zeros(self.dynamic_row_count, dtype=vec6f, device=self.device)
+        self.dynamic_effective_inertia = wp.zeros(self.dynamic_row_count, dtype=wp.float32, device=self.device)
+        self.dynamic_free_velocity = wp.zeros(self.dynamic_row_count, dtype=wp.float32, device=self.device)
+
+        structural_joint = np.repeat(joint_indices, joint_structural_count)
+        structural_offsets = _capacity_offsets(joint_structural_count)
+        structural_local = _segment_local_indices(joint_structural_count, structural_offsets)
+        structural_value_index = joint_structural_offset[structural_joint] + structural_local
+        self.structural_row_count = int(structural_offsets[-1])
+        if not np.array_equal(structural_value_index, np.arange(self.structural_row_count, dtype=np.int32)):
+            raise RuntimeError("LOX structural rows must use Kamino's canonical kinematic-row order.")
+        world_structural_count = model.info.num_joint_kinematic_cts.numpy().astype(np.int32, copy=False)
+        if self.structural_row_count != int(world_structural_count.sum()):
+            raise RuntimeError("LOX structural row count must match Kamino's kinematic constraints.")
+        if any(
+            array.shape[0] != self.structural_row_count
+            for array in (self.data.joints.r_j, self.data.joints.lambda_kin_j)
+        ):
+            raise RuntimeError("Kamino structural residual and reaction arrays must use canonical row storage.")
+        self.world_structural_row_offset = model.info.joint_kinematic_cts_offset
+        self.world_structural_row_count = model.info.num_joint_kinematic_cts
+        structural_world = joint_world[structural_joint]
+        structural_first_global = joint_body_first[structural_joint]
+        structural_second_global = joint_body_second[structural_joint]
+        adjacent_body_count = np.where(joint_body_first >= 0, 2, 1)
+        structural_sparse_start = sparse_joint_offsets + np.where(
+            joint_dynamic_count > 0, adjacent_body_count * joint_dof_count, 0
+        )
+        structural_sparse_first_index = np.where(
+            structural_first_global >= 0,
+            structural_sparse_start[structural_joint] + joint_structural_count[structural_joint] + structural_local,
+            -1,
+        )
+        structural_sparse_second_index = structural_sparse_start[structural_joint] + structural_local
+        self.structural_row_world = self._device_array(structural_world, self.device)
+        self.structural_body_first_global = self._device_array(structural_first_global, self.device)
+        self.structural_body_second_global = self._device_array(structural_second_global, self.device)
+        self.structural_sparse_first_index = self._device_array(structural_sparse_first_index, self.device)
+        self.structural_sparse_second_index = self._device_array(structural_sparse_second_index, self.device)
+        self.structural_jacobian_first = wp.zeros(self.structural_row_count, dtype=vec6f, device=self.device)
+        self.structural_jacobian_second = wp.zeros(self.structural_row_count, dtype=vec6f, device=self.device)
+        self.structural_residual = self.data.joints.r_j
+        self.structural_reaction = self.data.joints.lambda_kin_j
+        self.structural_candidate_twist = wp.empty(model.size.sum_of_num_bodies, dtype=vec6f, device=self.device)
+        self.structural_candidate_residual = wp.zeros(self.structural_row_count, dtype=wp.float32, device=self.device)
+        self.structural_proximal_defect = wp.zeros(self.structural_row_count, dtype=wp.float32, device=self.device)
+        self.structural_residual_velocity_scratch = wp.zeros(
+            self.structural_row_count, dtype=wp.float32, device=self.device
+        )
+        self.joint_coordinate_scratch = wp.zeros(
+            model.size.sum_of_num_joint_coords, dtype=wp.float32, device=self.device
+        )
+        self.joint_velocity_scratch = wp.zeros(model.size.sum_of_num_joint_dofs, dtype=wp.float32, device=self.device)
+        self.world_structural_residual = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.world_projected_structural_residual = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.structural_effective_mass = wp.zeros(self.structural_row_count, dtype=wp.float32, device=self.device)
+        self.structural_penalty = wp.zeros(self.structural_row_count, dtype=wp.float32, device=self.device)
+
+        static_constraint_count = np.zeros(model.size.sum_of_num_bodies, dtype=np.int32)
+        structural_joints = joint_indices[joint_structural_count > 0]
+        structural_first = joint_body_first[structural_joints]
+        structural_second = joint_body_second[structural_joints]
+        np.add.at(static_constraint_count, structural_first[structural_first >= 0], 1)
+        second_mask = (structural_second >= 0) & (structural_second != structural_first)
+        np.add.at(static_constraint_count, structural_second[second_mask], 1)
+        self.static_body_constraint_count = wp.array(static_constraint_count, dtype=wp.int32, device=self.device)
+        self.body_constraint_count = wp.zeros(model.size.sum_of_num_bodies, dtype=wp.int32, device=self.device)
+
+        self._dynamic_row_world_host = dynamic_world
+        self._dynamic_row_joint_host = dynamic_joint
+        self._dynamic_dof_index_host = dynamic_dof_index
+        self._dynamic_body_first_host = dynamic_first_global
+        self._dynamic_body_second_host = dynamic_second_global
+
+    def _allocate_effort_rows(self) -> None:
+        """Allocate finite actuator corrections without changing projection incidence."""
+        model = self.model
+        effort_limits = model.joints.tau_j_max.numpy()
+        if len(effort_limits) != model.size.sum_of_num_joint_dofs:
+            raise ValueError("Joint effort limits must contain one value per joint DOF.")
+        if np.any(np.isnan(effort_limits) | (effort_limits < 0.0)):
+            raise ValueError("Joint effort limits must be nonnegative or positive infinity.")
+
+        dof_actuation = model.joints.dof_act_types.numpy().astype(np.int32, copy=False)
+        dof_actuation_path = model.joints.dof_act_paths.numpy().astype(np.int32, copy=False)
+        joint_dof_offset = model.joints.dofs_offset.numpy().astype(np.int32, copy=False)
+        effort_offset = model.joints.effort_cts_offset.numpy().astype(np.int32, copy=False)
+        effort_axis = model.joints.effort_cts_axis.numpy().astype(np.int32, copy=False)
+        dynamic_world = self._dynamic_row_world_host
+        dynamic_joint = self._dynamic_row_joint_host
+        dynamic_dof = self._dynamic_dof_index_host
+        dynamic_first = self._dynamic_body_first_host
+        dynamic_second = self._dynamic_body_second_host
+
+        effort_mask = (dof_actuation[dynamic_dof] > int(JointActuationType.PASSIVE)) & (
+            dof_actuation_path[dynamic_dof] == int(DofActuationPath.EFFORT_CTS)
+        )
+        effort_dynamic_row = np.flatnonzero(effort_mask).astype(np.int32)
+        effort_world = dynamic_world[effort_dynamic_row]
+        effort_joint = dynamic_joint[effort_dynamic_row]
+        effort_dof = dynamic_dof[effort_dynamic_row]
+        effort_counts = np.diff(effort_offset)
+        source_joint = np.repeat(np.arange(model.size.sum_of_num_joints, dtype=np.int32), effort_counts)
+        source_dof = joint_dof_offset[source_joint] + effort_axis
+        dof_to_effort = np.full(model.size.sum_of_num_joint_dofs, -1, dtype=np.int32)
+        dof_to_effort[source_dof] = np.arange(effort_axis.size, dtype=np.int32)
+        effort_value_index = dof_to_effort[effort_dof]
+        if np.any(effort_value_index < 0):
+            missing = int(np.flatnonzero(effort_value_index < 0)[0])
+            joint = int(effort_joint[missing])
+            axis = int(effort_dof[missing] - joint_dof_offset[joint])
+            raise RuntimeError(f"Missing effort row for joint {joint} axis {axis}.")
+
+        self.effort_capacity = effort_dynamic_row.size
+        self.has_bounded_effort = self.effort_capacity > 0
+        dynamic_effort_index = np.full(self.dynamic_row_count, -1, dtype=np.int32)
+        dynamic_effort_index[effort_dynamic_row] = np.arange(self.effort_capacity, dtype=np.int32)
+        if not self.has_bounded_effort:
+            self.dynamic_effort_index = self._device_array(dynamic_effort_index, self.device)
+            self.effort_world = None
+            self.effort_dynamic_row_index = None
+            self.effort_value_index = self._device_array((), self.device)
+            self.body_effort_offset = None
+            self.body_effort_index = None
+            self.body_effort_side = None
+            self.effort_intercept = wp.zeros(0, dtype=wp.float32, device=self.device)
+            self.effort_slope = wp.zeros(0, dtype=wp.float32, device=self.device)
+            self.effort_impulse_bound = wp.zeros(0, dtype=wp.float32, device=self.device)
+            self.effort_raw_impulse = None
+            self.effort_counter_applied = None
+            self.effort_counter_next = None
+            self.effort_net_applied = None
+            self.effort_net_target = None
+            self.effort_velocity = None
+            self.effort_residual = None
+            self.world_effort_residual_max = None
+            self.world_effort_defect_max = None
+            return
+
+        effort_indices = np.arange(self.effort_capacity, dtype=np.int32)
+        effort_first = dynamic_first[effort_dynamic_row]
+        effort_second = dynamic_second[effort_dynamic_row]
+        incidence_body = np.concatenate((effort_first[effort_first >= 0], effort_second[effort_second >= 0]))
+        incidence_effort = np.concatenate((effort_indices[effort_first >= 0], effort_indices[effort_second >= 0]))
+        incidence_side = np.concatenate(
+            (
+                np.zeros(np.count_nonzero(effort_first >= 0), dtype=np.int32),
+                np.ones(np.count_nonzero(effort_second >= 0), dtype=np.int32),
+            )
+        )
+        incidence_order = np.lexsort((incidence_side, incidence_effort, incidence_body))
+        incidence_body = incidence_body[incidence_order]
+        incidence_effort = incidence_effort[incidence_order]
+        incidence_side = incidence_side[incidence_order]
+        body_counts = np.bincount(incidence_body, minlength=model.size.sum_of_num_bodies).astype(np.int32, copy=False)
+        body_offsets = _capacity_offsets(body_counts)
+
+        self.dynamic_effort_index = self._device_array(dynamic_effort_index, self.device)
+        self.effort_world = self._device_array(effort_world, self.device)
+        self.effort_dynamic_row_index = self._device_array(effort_dynamic_row, self.device)
+        self.effort_value_index = self._device_array(effort_value_index, self.device)
+        self.body_effort_offset = self._device_array(body_offsets, self.device)
+        self.body_effort_index = self._device_array(incidence_effort, self.device)
+        self.body_effort_side = self._device_array(incidence_side, self.device)
+        self.effort_intercept = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_slope = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_impulse_bound = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_raw_impulse = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_counter_applied = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_counter_next = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_net_applied = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_net_target = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_velocity = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.effort_residual = wp.zeros(self.effort_capacity, dtype=wp.float32, device=self.device)
+        self.world_effort_residual_max = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.world_effort_defect_max = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+
+    def _allocate_joint_frictions(self) -> None:
+        """Allocate one bounded scalar constraint for each frictional joint DOF."""
+        source_model = self.model._model
+        if source_model is None or source_model.joint_friction is None:
+            friction_values = np.zeros(self.model.size.sum_of_num_joint_dofs, dtype=np.float32)
+            self._joint_friction_force = wp.zeros(
+                self.model.size.sum_of_num_joint_dofs,
+                dtype=wp.float32,
+                device=self.device,
+            )
+        else:
+            friction_values = source_model.joint_friction.numpy()
+            self._joint_friction_force = source_model.joint_friction
+        if len(friction_values) != self.model.size.sum_of_num_joint_dofs:
+            raise ValueError("Newton joint friction must contain one value per joint DOF.")
+        if np.any(~np.isfinite(friction_values) | (friction_values < 0.0)):
+            raise ValueError("Joint friction values must be finite and nonnegative.")
+
+        joint_worlds = self.model.joints.wid.numpy().astype(np.int32, copy=False)
+        joint_first = self.model.joints.bid_B.numpy().astype(np.int32, copy=False)
+        joint_second = self.model.joints.bid_F.numpy().astype(np.int32, copy=False)
+        joint_dof_offsets = self.model.joints.dofs_offset.numpy().astype(np.int32, copy=False)
+        joint_dof_counts = self.model.joints.num_dofs.numpy().astype(np.int32, copy=False)
+        joint_friction_counts = self.model.joints.num_friction_cts.numpy().astype(np.int32, copy=False)
+        joint_friction_offsets = self.model.joints.friction_cts_offset.numpy().astype(np.int32, copy=False)
+        sparse_offsets = self.jacobians._J_dofs_joint_nzb_offsets.numpy().astype(np.int32, copy=False)
+        invalid_count = (joint_friction_counts != 0) & (joint_friction_counts != joint_dof_counts)
+        if np.any(invalid_count):
+            raise ValueError("Joint friction rows must match the joint DOF count.")
+
+        body_vector_index = np.asarray(self.system.body_vector_index_host, dtype=np.int32)
+        first_dynamic = (joint_first >= 0) & (body_vector_index[joint_first.clip(min=0)] >= 0)
+        second_dynamic = (joint_second >= 0) & (body_vector_index[joint_second.clip(min=0)] >= 0)
+        active_joint_mask = (joint_friction_counts > 0) & (first_dynamic | second_dynamic)
+        active_joints = np.flatnonzero(active_joint_mask).astype(np.int32)
+        row_joint = np.repeat(active_joints, joint_dof_counts[active_joints])
+        active_counts = joint_dof_counts[active_joints]
+        local_dof = _segment_local_indices(active_counts)
+        row_world = joint_worlds[row_joint]
+        order = np.argsort(row_world, kind="stable")
+        row_joint = row_joint[order]
+        local_dof = local_dof[order]
+        row_world = row_world[order]
+        counts = np.bincount(row_world, minlength=self.num_worlds).astype(np.int32, copy=False)
+        offsets = _capacity_offsets(counts)
+        self.friction_capacity = row_joint.size
+        self.world_friction_offset = self._device_array(offsets[:-1], self.device)
+        self.world_friction_count = self._device_array(counts, self.device)
+        self.friction_world = self._device_array(row_world, self.device)
+        self.friction_local = self._device_array(_segment_local_indices(counts, offsets), self.device)
+        self.friction_dof_index = self._device_array(joint_dof_offsets[row_joint] + local_dof, self.device)
+        self.friction_body_first = self._device_array(joint_first[row_joint], self.device)
+        self.friction_body_second = self._device_array(joint_second[row_joint], self.device)
+        self.friction_sparse_first_index = self._device_array(
+            np.where(
+                joint_first[row_joint] >= 0,
+                sparse_offsets[row_joint] + joint_dof_counts[row_joint] + local_dof,
+                -1,
+            ),
+            self.device,
+        )
+        self.friction_sparse_second_index = self._device_array(sparse_offsets[row_joint] + local_dof, self.device)
+        self.friction_multiplier_index = self._device_array(joint_friction_offsets[row_joint] + local_dof, self.device)
+        self.friction_jacobian_first = wp.zeros(self.friction_capacity, dtype=vec6f, device=self.device)
+        self.friction_jacobian_second = wp.zeros(self.friction_capacity, dtype=vec6f, device=self.device)
+        self.friction_impulse_bound = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_reaction = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_velocity = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_residual = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_physical_delassus = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_projection_delassus = wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+        self.friction_acceleration_trial = (
+            wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.friction_acceleration_previous = (
+            wp.zeros(self.friction_capacity, dtype=wp.float32, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.world_friction_residual_max = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+
+    def _allocate_unilaterals(self) -> None:
+        limit_capacities = np.zeros(self.num_worlds, dtype=np.int32)
+        if self.limits is not None and self.limits.model_max_limits_host > 0:
+            limit_capacities = np.asarray(self.limits.world_max_limits_host, dtype=np.int32)
+        contact_capacities = np.zeros(self.num_worlds, dtype=np.int32)
+        if self.contacts is not None:
+            try:
+                if self.contacts.model_max_contacts_host > 0:
+                    contact_capacities = np.asarray(self.contacts.world_max_contacts_host, dtype=np.int32)
+            except RuntimeError:
+                self.contacts = None
+        if len(limit_capacities) != self.num_worlds or len(contact_capacities) != self.num_worlds:
+            raise ValueError("Unilateral container world capacities must match the model world count.")
+
+        limit_offsets = _capacity_offsets(limit_capacities)
+        contact_offsets = _capacity_offsets(contact_capacities)
+        self.limit_capacity = int(limit_offsets[-1])
+        self.contact_capacity = int(contact_offsets[-1])
+        self._lagged_contact_block_count = 1
+        self.world_limit_capacity = self._device_array(limit_capacities, self.device)
+        self.world_limit_offset = self._device_array(limit_offsets[:-1], self.device)
+        self.world_limit_count = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.world_contact_capacity = self._device_array(contact_capacities, self.device)
+        self.world_contact_offset = self._device_array(contact_offsets[:-1], self.device)
+        self.world_contact_count = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.limit_world = self._device_array(
+            np.repeat(np.arange(self.num_worlds, dtype=np.int32), limit_capacities), self.device
+        )
+        self.limit_local = self._device_array(_segment_local_indices(limit_capacities, limit_offsets), self.device)
+        self.contact_world = self._device_array(
+            np.repeat(np.arange(self.num_worlds, dtype=np.int32), contact_capacities), self.device
+        )
+        self.contact_local = self._device_array(
+            _segment_local_indices(contact_capacities, contact_offsets), self.device
+        )
+
+        self.limit_body_first = wp.full(self.limit_capacity, -1, dtype=wp.int32, device=self.device)
+        self.limit_body_second = wp.full(self.limit_capacity, -1, dtype=wp.int32, device=self.device)
+        self.limit_jacobian_first = wp.zeros(self.limit_capacity, dtype=vec6f, device=self.device)
+        self.limit_jacobian_second = wp.zeros(self.limit_capacity, dtype=vec6f, device=self.device)
+        self.limit_bias = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_reaction = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_velocity = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_residual = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_physical_delassus = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_projection_delassus = wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+        self.limit_acceleration_trial = (
+            wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.limit_acceleration_previous = (
+            wp.zeros(self.limit_capacity, dtype=wp.float32, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.world_limit_residual_max = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+
+        self.contact_body_first = wp.full(self.contact_capacity, -1, dtype=wp.int32, device=self.device)
+        self.contact_body_second = wp.full(self.contact_capacity, -1, dtype=wp.int32, device=self.device)
+        self.contact_jacobian_first = wp.zeros(self.contact_capacity, dtype=mat36f, device=self.device)
+        self.contact_jacobian_second = wp.zeros(self.contact_capacity, dtype=mat36f, device=self.device)
+        self.contact_bias = wp.zeros(self.contact_capacity, dtype=wp.vec3f, device=self.device)
+        self.contact_friction = wp.zeros(self.contact_capacity, dtype=wp.float32, device=self.device)
+        self.contact_reaction = wp.zeros(self.contact_capacity, dtype=wp.vec3f, device=self.device)
+        self.contact_velocity = wp.zeros(self.contact_capacity, dtype=wp.vec3f, device=self.device)
+        self.contact_source_to_internal = wp.full(self.contact_capacity, -1, dtype=wp.int32, device=self.device)
+        self.contact_residual = wp.zeros(self.contact_capacity, dtype=wp.float32, device=self.device)
+        self.contact_physical_delassus = wp.zeros(self.contact_capacity, dtype=wp.mat33f, device=self.device)
+        self.contact_prepared_delassus = wp.zeros(self.contact_capacity, dtype=wp.mat33f, device=self.device)
+        self.contact_projection_delassus = wp.zeros(self.contact_capacity, dtype=wp.mat33f, device=self.device)
+        self.contact_acceleration_trial = (
+            wp.zeros(self.contact_capacity, dtype=wp.vec3f, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.contact_acceleration_previous = (
+            wp.zeros(self.contact_capacity, dtype=wp.vec3f, device=self.device)
+            if self._allocate_acceleration_storage
+            else None
+        )
+        self.world_physical_projection_status = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.world_jacobi_projection_status = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.projection_twist_delta = wp.zeros(self.model.size.sum_of_num_bodies, dtype=vec6f, device=self.device)
+        self.world_contact_residual_max = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.projection_status = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.world_has_unilateral = wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.body_has_unilateral = wp.zeros(self.model.size.sum_of_num_bodies, dtype=wp.int32, device=self.device)
+
+    def begin_time_step(
+        self,
+        time_step: wp.array[wp.float32],
+        inverse_time_step: wp.array[wp.float32],
+        *,
+        limit_stabilization_fraction: float,
+        contact_stabilization_fraction: float,
+        contact_dead_zone: float,
+        impact_velocity_threshold: float,
+        contact_recoverable_response: bool,
+    ) -> None:
+        """Freeze unilateral data and import begin-step velocities and reactions once."""
+        self._time_step = time_step
+        self._inverse_time_step = inverse_time_step
+        self._limit_stabilization_fraction = limit_stabilization_fraction
+        self._contact_stabilization_fraction = contact_stabilization_fraction
+        self._contact_dead_zone = contact_dead_zone
+        self._impact_velocity_threshold = impact_velocity_threshold
+        self._contact_recoverable_response = contact_recoverable_response
+        wp.copy(self.body_velocity_begin, self.data.bodies.u_i.view(dtype=vec6f))
+        if self.dynamic_row_count > 0:
+            wp.copy(self.joint_velocity_begin, self.data.joints.dq_j)
+        self._update_unilaterals(
+            time_step,
+            limit_stabilization_fraction,
+            contact_stabilization_fraction,
+            contact_dead_zone,
+            impact_velocity_threshold,
+            contact_recoverable_response,
+        )
+        self._freeze_constraint_multiplicities()
+
+    def _freeze_constraint_multiplicities(self) -> None:
+        """Build combined entity incidence without a device-to-host readback."""
+        wp.copy(self.body_constraint_count, self.static_body_constraint_count)
+        self.body_has_unilateral.zero_()
+        for entity_world, entity_local, world_count, body_first, body_second in (
+            (
+                self.friction_world,
+                self.friction_local,
+                self.world_friction_count,
+                self.friction_body_first,
+                self.friction_body_second,
+            ),
+            (
+                self.limit_world,
+                self.limit_local,
+                self.world_limit_count,
+                self.limit_body_first,
+                self.limit_body_second,
+            ),
+            (
+                self.contact_world,
+                self.contact_local,
+                self.world_contact_count,
+                self.contact_body_first,
+                self.contact_body_second,
+            ),
+        ):
+            if entity_world.shape[0] > 0:
+                wp.launch(
+                    _accumulate_constraint_incidence,
+                    dim=entity_world.shape[0],
+                    inputs=[entity_world, entity_local, world_count, body_first, body_second],
+                    outputs=[self.body_constraint_count, self.body_has_unilateral],
+                    device=self.device,
+                )
+
+    def update(
+        self,
+        time_step: wp.array[wp.float32],
+        joint_penalty_scale: float | wp.array[wp.float32] = 10.0,
+        linearization_twist: wp.array[vec6f] | None = None,
+        assemble_structural_penalty: bool = True,
+    ) -> None:
+        """Prepare one nonlinear evaluation and assemble the smooth primal system.
+
+        :meth:`begin_time_step` must be called before the first nonlinear
+        evaluation. It freezes the inertial and restitution velocities while
+        this method continues to use the current body velocity for gyroscopic
+        torque evaluation.
+
+        If ``linearization_twist`` is omitted, the current body velocity is
+        explicitly captured and used as the structural Newton linearization
+        twist. Pass a packed zero twist for the first linearly implicit
+        assembly about the begin-step pose.
+        """
+        if isinstance(joint_penalty_scale, wp.array):
+            if joint_penalty_scale.ndim != 1 or joint_penalty_scale.dtype != wp.float32:
+                raise ValueError("joint_penalty_scale must be a one-dimensional float32 array.")
+            if joint_penalty_scale.shape[0] != self.num_worlds:
+                raise ValueError("joint_penalty_scale must contain one entry per world.")
+            world_joint_penalty_scale = joint_penalty_scale
+        else:
+            if joint_penalty_scale <= 0.0:
+                raise ValueError("joint_penalty_scale must be positive.")
+            self._uniform_joint_penalty_scale.fill_(joint_penalty_scale)
+            world_joint_penalty_scale = self._uniform_joint_penalty_scale
+        data = self.data
+        if linearization_twist is None:
+            wp.copy(self.body_linearization_twist, data.bodies.u_i.view(dtype=vec6f))
+            linearization_twist = self.body_linearization_twist
+        elif linearization_twist.shape[0] != self.model.size.sum_of_num_bodies:
+            raise ValueError("linearization_twist must contain one entry per model body.")
+        self.system.assemble_bodies(
+            self.model.bodies.m_i,
+            data.bodies.I_i,
+            self.body_velocity_begin,
+            data.bodies.u_i.view(dtype=vec6f),
+            data.bodies.w_e_i.view(dtype=vec6f),
+            data.bodies.w_a_i.view(dtype=vec6f),
+            self.model.gravity.vector,
+            time_step,
+        )
+        if self.dynamic_row_count > 0:
+            wp.launch(
+                _prepare_dynamic_rows,
+                dim=self.dynamic_row_count,
+                inputs=[
+                    self.dynamic_row_world,
+                    self.dynamic_uses_dof_jacobian,
+                    self.dynamic_body_first_global,
+                    self.dynamic_body_second_global,
+                    self.dynamic_value_index,
+                    self.dynamic_dof_index,
+                    self.dynamic_sparse_first_index,
+                    self.dynamic_sparse_second_index,
+                    self._sparse_jacobian_data,
+                    self._sparse_dof_jacobian_data,
+                    data.joints.m_j,
+                    data.joints.dq_b_j,
+                    self.dynamic_effort_index,
+                    self.effort_value_index,
+                    data.joints.inv_m_a,
+                    data.joints.dq_b_a,
+                    self.model.joints.a_j,
+                    self.model.joints.k_p_j,
+                    self.model.joints.dof_act_types,
+                    data.joints.dq_j,
+                    self.joint_velocity_begin,
+                    data.joints.tau_j,
+                    self.model.joints.k_d_j,
+                    self.model.joints.tau_j_max,
+                    linearization_twist,
+                    time_step,
+                ],
+                outputs=[
+                    self.dynamic_jacobian_first,
+                    self.dynamic_jacobian_second,
+                    self.dynamic_effective_inertia,
+                    self.dynamic_free_velocity,
+                    self.effort_intercept,
+                    self.effort_slope,
+                    self.effort_impulse_bound,
+                ],
+                device=self.device,
+            )
+            self.system.add_dynamic_rows(
+                self.dynamic_row_world,
+                self.dynamic_body_first_global,
+                self.dynamic_body_second_global,
+                self.dynamic_jacobian_first,
+                self.dynamic_jacobian_second,
+                self.dynamic_effective_inertia,
+                self.dynamic_free_velocity,
+                prescribed_twist=self.body_velocity_begin,
+            )
+        if self.structural_row_count > 0:
+            self.structural_proximal_defect.zero_()
+            wp.launch(
+                _prepare_structural_rows,
+                dim=self.structural_row_count,
+                inputs=[
+                    self.structural_body_first_global,
+                    self.structural_body_second_global,
+                    self.structural_sparse_first_index,
+                    self.structural_sparse_second_index,
+                    self._sparse_jacobian_data,
+                    self.model.bodies.inv_m_i,
+                    data.bodies.inv_I_i,
+                ],
+                outputs=[
+                    self.structural_jacobian_first,
+                    self.structural_jacobian_second,
+                    self.structural_effective_mass,
+                ],
+                device=self.device,
+            )
+            if self.dynamic_row_count > 0:
+                wp.launch(
+                    _include_dynamic_compliance_in_structural_effective_mass,
+                    dim=self.model.size.sum_of_num_joints,
+                    inputs=[
+                        self.model.joints.bid_B,
+                        self.model.joints.bid_F,
+                        self.model.joints.kinematic_cts_offset,
+                        self.model.joints.num_kinematic_cts,
+                        self.joint_dynamic_row_offset,
+                        self.joint_dynamic_row_count,
+                        self.structural_jacobian_first,
+                        self.structural_jacobian_second,
+                        self.dynamic_jacobian_first,
+                        self.dynamic_jacobian_second,
+                        self.dynamic_effective_inertia,
+                        self.model.bodies.inv_m_i,
+                        data.bodies.inv_I_i,
+                    ],
+                    outputs=[self.structural_effective_mass],
+                    device=self.device,
+                )
+            if assemble_structural_penalty:
+                self.system.add_structural_rows(
+                    self.structural_row_world,
+                    self.structural_body_first_global,
+                    self.structural_body_second_global,
+                    self.structural_jacobian_first,
+                    self.structural_jacobian_second,
+                    self.structural_residual,
+                    self.structural_reaction,
+                    self.structural_effective_mass,
+                    linearization_twist,
+                    time_step,
+                    world_joint_penalty_scale,
+                    self.structural_penalty,
+                    prescribed_twist=self.body_velocity_begin,
+                )
+
+    def _update_unilaterals(
+        self,
+        time_step: wp.array[wp.float32],
+        limit_stabilization_fraction: float,
+        contact_stabilization_fraction: float,
+        contact_dead_zone: float,
+        impact_velocity_threshold: float,
+        contact_recoverable_response: bool,
+        import_reactions: bool = True,
+        update_counts: bool = True,
+    ) -> None:
+        if self.friction_capacity > 0:
+            wp.launch(
+                _prepare_joint_frictions,
+                dim=self.friction_capacity,
+                inputs=[
+                    self.friction_world,
+                    self.friction_body_first,
+                    self.friction_body_second,
+                    self.friction_dof_index,
+                    self.friction_multiplier_index,
+                    self.friction_sparse_first_index,
+                    self.friction_sparse_second_index,
+                    self._sparse_dof_jacobian_data,
+                    self._joint_friction_force,
+                    self.data.joints.lambda_f_j,
+                    self.body_velocity_begin,
+                    time_step,
+                    import_reactions,
+                ],
+                outputs=[
+                    self.friction_jacobian_first,
+                    self.friction_jacobian_second,
+                    self.friction_impulse_bound,
+                    self.friction_reaction,
+                    self.friction_velocity,
+                ],
+                device=self.device,
+            )
+
+        if self.limit_capacity > 0 and self.limits is not None:
+            if update_counts:
+                wp.launch(
+                    _copy_clamped_world_counts,
+                    dim=self.num_worlds,
+                    inputs=[self.limits.world_active_limits, self.world_limit_capacity],
+                    outputs=[self.world_limit_count],
+                    device=self.device,
+                )
+            wp.launch(
+                _prepare_limits,
+                dim=self.limits.model_max_limits_host,
+                inputs=[
+                    self.limits.model_active_limits,
+                    self.limits.model_max_limits_host,
+                    self.limits.wid,
+                    self.limits.lid,
+                    self.limits.bids,
+                    self.limits.r_q,
+                    self.limits.reaction,
+                    self.body_velocity_begin,
+                    self.world_limit_capacity,
+                    self.world_limit_offset,
+                    self.system.body_vector_index,
+                    self._sparse_limit_offsets,
+                    self._sparse_jacobian_data,
+                    time_step,
+                    limit_stabilization_fraction,
+                    import_reactions,
+                ],
+                outputs=[
+                    self.limit_body_first,
+                    self.limit_body_second,
+                    self.limit_jacobian_first,
+                    self.limit_jacobian_second,
+                    self.limit_bias,
+                    self.limit_reaction,
+                    self.limit_velocity,
+                ],
+                device=self.device,
+            )
+        elif update_counts:
+            self.world_limit_count.zero_()
+
+        if self.contact_capacity > 0 and self.contacts is not None:
+            if update_counts:
+                self.world_contact_count.zero_()
+            wp.launch(
+                _prepare_contacts,
+                dim=self.contacts.model_max_contacts_host,
+                inputs=[
+                    self.contacts.model_active_contacts,
+                    self.contacts.model_max_contacts_host,
+                    self.contacts.wid,
+                    self.contacts.cid,
+                    self.contacts.bid_AB,
+                    self.contacts.position_A,
+                    self.contacts.position_B,
+                    self.contacts.frame,
+                    self.contacts.gapfunc,
+                    self.contacts.material,
+                    self.contacts.reaction,
+                    self.data.bodies.q_i,
+                    self.body_velocity_begin,
+                    self.world_contact_capacity,
+                    self.world_contact_count,
+                    self.world_contact_offset,
+                    self.system.body_vector_index,
+                    time_step,
+                    contact_stabilization_fraction,
+                    contact_dead_zone,
+                    impact_velocity_threshold,
+                    contact_recoverable_response,
+                    import_reactions,
+                    update_counts,
+                    self.contact_source_to_internal,
+                ],
+                outputs=[
+                    self.contact_body_first,
+                    self.contact_body_second,
+                    self.contact_jacobian_first,
+                    self.contact_jacobian_second,
+                    self.contact_bias,
+                    self.contact_friction,
+                    self.contact_reaction,
+                    self.contact_velocity,
+                ],
+                device=self.device,
+            )
+        elif update_counts:
+            self.world_contact_count.zero_()
+
+        if self.limit_capacity > 0:
+            wp.launch(
+                _clear_inactive_limits,
+                dim=self.limit_capacity,
+                inputs=[self.limit_world, self.limit_local, self.world_limit_count],
+                outputs=[
+                    self.limit_body_first,
+                    self.limit_body_second,
+                    self.limit_reaction,
+                    self.limit_velocity,
+                ],
+                device=self.device,
+            )
+        if self.contact_capacity > 0:
+            wp.launch(
+                _clear_inactive_contacts,
+                dim=self.contact_capacity,
+                inputs=[self.contact_world, self.contact_local, self.world_contact_count],
+                outputs=[
+                    self.contact_body_first,
+                    self.contact_body_second,
+                    self.contact_reaction,
+                    self.contact_velocity,
+                ],
+                device=self.device,
+            )
+
+        if update_counts:
+            wp.launch(
+                _mark_worlds_with_unilaterals,
+                dim=self.num_worlds,
+                inputs=[self.world_contact_count, self.world_limit_count, self.world_friction_count],
+                outputs=[self.world_has_unilateral],
+                device=self.device,
+            )
+
+    def _evaluate_structural_candidate_pose_residual(
+        self,
+        time_step: wp.array[wp.float32],
+        candidate_twist: wp.array[vec6f],
+        linearization_twist: wp.array[vec6f],
+        world_active: wp.array[wp.bool],
+        candidate_residual: wp.array[wp.float32],
+    ) -> None:
+        """Evaluate exact structural residuals after integrating a candidate twist."""
+        wp.launch(
+            self._evaluate_candidate_structural_residual,
+            dim=self.model.size.sum_of_num_joints,
+            inputs=[
+                time_step,
+                self.model.joints.wid,
+                self.model.joints.dof_type,
+                self.model.joints.coords_offset,
+                self.model.joints.dofs_offset,
+                self.model.joints.kinematic_cts_offset,
+                self.model.joints.bid_B,
+                self.model.joints.bid_F,
+                self.model.joints.B_r_Bj,
+                self.model.joints.F_r_Fj,
+                self.model.joints.X_Bj,
+                self.model.joints.X_Fj,
+                self.data.bodies.q_i,
+                candidate_twist,
+                linearization_twist,
+                self.data.joints.q_j_p,
+                world_active,
+            ],
+            outputs=[
+                candidate_residual,
+                self.structural_residual_velocity_scratch,
+                self.joint_coordinate_scratch,
+                self.joint_velocity_scratch,
+            ],
+            device=self.device,
+        )
+
+    def update_structural_multipliers_from_twist(
+        self,
+        time_step: wp.array[wp.float32],
+        structural_tolerance: float,
+        linearization_twist: wp.array[vec6f],
+        global_twist: wp.array[vec6f],
+        projected_twist: wp.array[vec6f],
+        world_active: wp.array[wp.bool],
+        projected_fraction: float = 0.0,
+    ) -> None:
+        """Update structural multipliers from exact candidate-pose residuals."""
+        if not structural_tolerance > 0.0:
+            raise ValueError("Structural tolerance must be positive.")
+        if linearization_twist.shape[0] != self.model.size.sum_of_num_bodies:
+            raise ValueError("linearization_twist must contain one entry per body.")
+        if global_twist.shape[0] != self.model.size.sum_of_num_bodies:
+            raise ValueError("global_twist must contain one entry per body.")
+        if projected_twist.shape[0] != self.model.size.sum_of_num_bodies:
+            raise ValueError("projected_twist must contain one entry per body.")
+        if world_active.shape[0] != self.num_worlds:
+            raise ValueError("world_active must contain one entry per world.")
+        if not 0.0 <= projected_fraction <= 1.0:
+            raise ValueError("projected_fraction must be in [0, 1].")
+        self.world_structural_residual.zero_()
+        self.world_projected_structural_residual.zero_()
+        if self.structural_row_count == 0:
+            return
+        wp.launch(
+            _blend_structural_candidate_twist,
+            dim=self.model.size.sum_of_num_bodies,
+            inputs=[global_twist, projected_twist, projected_fraction],
+            outputs=[self.structural_candidate_twist],
+            device=self.device,
+        )
+        if self.joint_proximal_relaxation > 0.0:
+            self._evaluate_structural_candidate_pose_residual(
+                time_step,
+                self.structural_candidate_twist,
+                linearization_twist,
+                world_active,
+                self.structural_candidate_residual,
+            )
+        wp.launch(
+            _update_structural_multipliers_from_candidate_rows,
+            dim=self.structural_row_count,
+            inputs=[
+                time_step,
+                structural_tolerance,
+                self.structural_row_world,
+                world_active,
+                self.projection_status,
+                self.structural_body_first_global,
+                self.structural_body_second_global,
+                self.structural_jacobian_first,
+                self.structural_jacobian_second,
+                self.structural_candidate_residual,
+                self.structural_proximal_defect,
+                self.structural_residual,
+                self.structural_penalty,
+                linearization_twist,
+                self.structural_candidate_twist,
+                self.joint_proximal_relaxation,
+                self.system.body_vector_index,
+                self.structural_reaction,
+            ],
+            outputs=[
+                self.world_structural_residual,
+                self.system.right_hand_side,
+            ],
+            device=self.device,
+        )
+        wp.launch(
+            _reduce_structural_candidate_residual,
+            dim=self.structural_row_count,
+            inputs=[
+                structural_tolerance,
+                self.structural_row_world,
+                world_active,
+                self.projection_status,
+                self.structural_body_first_global,
+                self.structural_body_second_global,
+                self.structural_candidate_residual,
+                self.system.body_vector_index,
+            ],
+            outputs=[self.world_projected_structural_residual],
+            device=self.device,
+        )
+
+    def evaluate_lagged_velocity_consistency(
+        self,
+        velocity_tolerance: float,
+        global_twist: wp.array[vec6f],
+        projected_twist_previous: wp.array[vec6f],
+        world_active: wp.array[wp.bool],
+    ) -> None:
+        """Evaluate prior projected constraint velocities using the current global solve."""
+        if velocity_tolerance <= 0.0:
+            raise ValueError("Velocity tolerance must be positive.")
+        body_count = self.model.size.sum_of_num_bodies
+        if global_twist.shape[0] != body_count or projected_twist_previous.shape[0] != body_count:
+            raise ValueError("Twist arrays must contain one entry per packed body.")
+        if world_active.shape[0] != self.num_worlds:
+            raise ValueError("world_active must contain one entry per world.")
+
+        self.world_lagged_velocity_residual.zero_()
+        self.world_lagged_velocity_required.zero_()
+        inverse_tolerance = 1.0 / velocity_tolerance
+
+        scalar_rows = (
+            (
+                self.dynamic_row_count,
+                self.dynamic_row_world,
+                self.dynamic_body_first_global,
+                self.dynamic_body_second_global,
+                self.dynamic_jacobian_first,
+                self.dynamic_jacobian_second,
+            ),
+            (
+                self.structural_row_count,
+                self.structural_row_world,
+                self.structural_body_first_global,
+                self.structural_body_second_global,
+                self.structural_jacobian_first,
+                self.structural_jacobian_second,
+            ),
+            (
+                self.friction_capacity,
+                self.friction_world,
+                self.friction_body_first,
+                self.friction_body_second,
+                self.friction_jacobian_first,
+                self.friction_jacobian_second,
+            ),
+            (
+                self.limit_capacity,
+                self.limit_world,
+                self.limit_body_first,
+                self.limit_body_second,
+                self.limit_jacobian_first,
+                self.limit_jacobian_second,
+            ),
+        )
+        if self.contact_capacity == 0:
+            for row_count, row_world, body_first, body_second, jacobian_first, jacobian_second in scalar_rows:
+                if row_count <= 0:
+                    continue
+                wp.launch(
+                    _evaluate_lagged_scalar_velocity_consistency,
+                    dim=row_count,
+                    inputs=[
+                        row_world,
+                        body_first,
+                        body_second,
+                        jacobian_first,
+                        jacobian_second,
+                        world_active,
+                        global_twist,
+                        projected_twist_previous,
+                        inverse_tolerance,
+                    ],
+                    outputs=[self.world_lagged_velocity_required, self.world_lagged_velocity_residual],
+                    device=self.device,
+                )
+        if self.contact_capacity > 0:
+            wp.launch(
+                _evaluate_lagged_contact_velocity_consistency,
+                dim=(self.num_worlds, self._lagged_contact_block_count, _LAGGED_CONTACT_BLOCK_DIM),
+                block_dim=_LAGGED_CONTACT_BLOCK_DIM,
+                inputs=[
+                    self.world_dynamic_row_offset,
+                    self.world_dynamic_row_count,
+                    self.dynamic_body_first_global,
+                    self.dynamic_body_second_global,
+                    self.dynamic_jacobian_first,
+                    self.dynamic_jacobian_second,
+                    self.world_structural_row_offset,
+                    self.world_structural_row_count,
+                    self.structural_body_first_global,
+                    self.structural_body_second_global,
+                    self.structural_jacobian_first,
+                    self.structural_jacobian_second,
+                    self.world_friction_offset,
+                    self.world_friction_count,
+                    self.friction_body_first,
+                    self.friction_body_second,
+                    self.friction_jacobian_first,
+                    self.friction_jacobian_second,
+                    self.world_limit_offset,
+                    self.world_limit_count,
+                    self.limit_body_first,
+                    self.limit_body_second,
+                    self.limit_jacobian_first,
+                    self.limit_jacobian_second,
+                    self.world_contact_offset,
+                    self.world_contact_count,
+                    self.contact_body_first,
+                    self.contact_body_second,
+                    self.contact_jacobian_first,
+                    self.contact_jacobian_second,
+                    world_active,
+                    global_twist,
+                    projected_twist_previous,
+                    inverse_tolerance,
+                    self._lagged_contact_block_count,
+                ],
+                outputs=[self.world_lagged_velocity_required, self.world_lagged_velocity_residual],
+                device=self.device,
+            )
+
+    def reset_structural_multipliers(self, world_mask: wp.array[wp.bool] | None = None) -> None:
+        """Clear persistent structural multiplier warm starts."""
+        if self.structural_row_count == 0:
+            return
+        if world_mask is None:
+            self.structural_reaction.zero_()
+        else:
+            wp.launch(
+                _reset_structural_multipliers_masked,
+                dim=self.structural_row_count,
+                inputs=[self.structural_row_world, world_mask, self.structural_reaction],
+                device=self.device,
+            )
+
+    def reset_effort_counters(self, world_mask: wp.array[wp.bool] | None = None) -> None:
+        """Clear finite actuator correction warm starts and diagnostics."""
+        if not self.has_bounded_effort:
+            return
+        if world_mask is None:
+            self.effort_intercept.zero_()
+            self.effort_slope.zero_()
+            self.effort_impulse_bound.zero_()
+            self.effort_raw_impulse.zero_()
+            self.effort_counter_applied.zero_()
+            self.effort_counter_next.zero_()
+            self.effort_net_applied.zero_()
+            self.effort_net_target.zero_()
+            self.effort_velocity.zero_()
+            self.effort_residual.zero_()
+            self.world_effort_residual_max.zero_()
+            self.world_effort_defect_max.zero_()
+            return
+
+        wp.launch(
+            _reset_effort_rows_masked,
+            dim=self.effort_capacity,
+            inputs=[self.effort_world, world_mask],
+            outputs=[
+                self.effort_intercept,
+                self.effort_slope,
+                self.effort_impulse_bound,
+                self.effort_raw_impulse,
+                self.effort_counter_applied,
+                self.effort_counter_next,
+                self.effort_net_applied,
+                self.effort_net_target,
+                self.effort_velocity,
+                self.effort_residual,
+            ],
+            device=self.device,
+        )
+        wp.launch(
+            _reset_effort_worlds_masked,
+            dim=self.num_worlds,
+            inputs=[world_mask],
+            outputs=[self.world_effort_residual_max, self.world_effort_defect_max],
+            device=self.device,
+        )
+
+    def reset_friction_reactions(self, world_mask: wp.array[wp.bool] | None = None) -> None:
+        """Clear persistent joint-friction impulse warm starts."""
+        if self.friction_capacity == 0:
+            return
+        if world_mask is None:
+            self.friction_reaction.zero_()
+            return
+        wp.launch(
+            _reset_friction_reactions_masked,
+            dim=self.friction_capacity,
+            inputs=[self.friction_world, world_mask],
+            outputs=[self.friction_reaction],
+            device=self.device,
+        )
+
+    def promote_effort_counters(self, world_active: wp.array[wp.bool]) -> None:
+        """Promote the pending correction before solving its candidate system."""
+        if not self.has_bounded_effort:
+            return
+        wp.launch(
+            _promote_effort_counters,
+            dim=self.effort_capacity,
+            inputs=[self.effort_world, world_active, self.effort_counter_next],
+            outputs=[self.effort_counter_applied],
+            device=self.device,
+        )
+
+    def update_effort_counters(
+        self,
+        time_step: wp.array[wp.float32],
+        velocity_tolerance: float,
+        projected_twist: wp.array[vec6f],
+        world_active: wp.array[wp.bool],
+    ) -> None:
+        """Evaluate finite actuator defects without applying the next correction."""
+        if not self.has_bounded_effort:
+            return
+        if velocity_tolerance <= 0.0:
+            raise ValueError("Velocity tolerance must be positive.")
+        wp.launch(
+            _clear_active_effort_residuals,
+            dim=self.num_worlds,
+            inputs=[world_active],
+            outputs=[self.world_effort_residual_max, self.world_effort_defect_max],
+            device=self.device,
+        )
+        wp.launch(
+            _update_effort_counters,
+            dim=self.effort_capacity,
+            inputs=[
+                self.effort_world,
+                self.effort_dynamic_row_index,
+                world_active,
+                self.dynamic_body_first_global,
+                self.dynamic_body_second_global,
+                self.dynamic_jacobian_first,
+                self.dynamic_jacobian_second,
+                self.dynamic_effective_inertia,
+                projected_twist,
+                self.effort_intercept,
+                self.effort_slope,
+                self.effort_impulse_bound,
+                self.effort_counter_applied,
+                time_step,
+                velocity_tolerance,
+            ],
+            outputs=[
+                self.effort_counter_next,
+                self.effort_raw_impulse,
+                self.effort_net_applied,
+                self.effort_net_target,
+                self.effort_velocity,
+                self.effort_residual,
+                self.world_effort_residual_max,
+                self.world_effort_defect_max,
+            ],
+            device=self.device,
+        )
+
+    def scale_structural_multipliers(self, scale: float) -> None:
+        """Scale structural multipliers before using them as a warm start."""
+        if not 0.0 <= scale <= 1.0:
+            raise ValueError("scale must be in [0, 1].")
+        if self.structural_row_count == 0:
+            return
+        wp.launch(
+            _scale_structural_reactions,
+            dim=self.structural_row_count,
+            inputs=[scale, self.structural_reaction],
+            device=self.device,
+        )
+
+    def write_outputs(
+        self,
+        time_step: wp.array[wp.float32],
+        inverse_time_step: wp.array[wp.float32],
+        body_velocity: wp.array[vec6f] | None = None,
+        *,
+        write_body_velocity: bool = True,
+    ) -> None:
+        """Write force-valued reactions and optionally the solved body velocities."""
+        if body_velocity is None:
+            body_velocity = self.projected_twist
+        if body_velocity.shape[0] != self.model.size.sum_of_num_bodies:
+            raise ValueError("body_velocity must contain one entry per model body.")
+        if write_body_velocity:
+            wp.copy(self.data.bodies.u_i.view(dtype=vec6f), body_velocity)
+        body_data = self.data.bodies
+        joint_wrench = body_data.w_j_i.view(dtype=vec6f)
+        limit_wrench = body_data.w_l_i.view(dtype=vec6f)
+        contact_wrench = body_data.w_c_i.view(dtype=vec6f)
+        body_data.w_j_i.zero_()
+        body_data.w_l_i.zero_()
+        body_data.w_c_i.zero_()
+        if self.dynamic_row_count > 0:
+            if self.has_bounded_effort:
+                wp.launch(
+                    _write_dynamic_outputs_with_effort,
+                    dim=self.dynamic_row_count,
+                    inputs=[
+                        inverse_time_step,
+                        self.dynamic_row_world,
+                        self.dynamic_multiplier_index,
+                        self.dynamic_effort_index,
+                        self.dynamic_body_first_global,
+                        self.dynamic_body_second_global,
+                        self.dynamic_jacobian_first,
+                        self.dynamic_jacobian_second,
+                        self.dynamic_effective_inertia,
+                        self.dynamic_free_velocity,
+                        self.effort_counter_applied,
+                        self.effort_net_applied,
+                        self.effort_value_index,
+                        body_velocity,
+                    ],
+                    outputs=[self.data.joints.lambda_dyn_j, self.data.joints.lambda_tau_j, joint_wrench],
+                    device=self.device,
+                )
+            else:
+                wp.launch(
+                    _write_dynamic_outputs,
+                    dim=self.dynamic_row_count,
+                    inputs=[
+                        inverse_time_step,
+                        self.dynamic_row_world,
+                        self.dynamic_multiplier_index,
+                        self.dynamic_body_first_global,
+                        self.dynamic_body_second_global,
+                        self.dynamic_jacobian_first,
+                        self.dynamic_jacobian_second,
+                        self.dynamic_effective_inertia,
+                        self.dynamic_free_velocity,
+                        body_velocity,
+                    ],
+                    outputs=[self.data.joints.lambda_dyn_j, joint_wrench],
+                    device=self.device,
+                )
+        if self.friction_capacity > 0:
+            wp.launch(
+                _write_friction_outputs,
+                dim=self.friction_capacity,
+                inputs=[
+                    inverse_time_step,
+                    self.friction_world,
+                    self.friction_multiplier_index,
+                    self.friction_body_first,
+                    self.friction_body_second,
+                    self.friction_jacobian_first,
+                    self.friction_jacobian_second,
+                    self.friction_reaction,
+                ],
+                outputs=[self.data.joints.lambda_f_j, joint_wrench],
+                device=self.device,
+            )
+        if self.limit_capacity > 0 and self.limits is not None:
+            wp.launch(
+                _write_limit_outputs,
+                dim=self.limits.model_max_limits_host,
+                inputs=[
+                    self.limits.model_active_limits,
+                    self.limits.model_max_limits_host,
+                    self.limits.wid,
+                    self.limits.lid,
+                    self.world_limit_capacity,
+                    self.world_limit_offset,
+                    inverse_time_step,
+                    self.limit_body_first,
+                    self.limit_body_second,
+                    self.limit_jacobian_first,
+                    self.limit_jacobian_second,
+                    self.limit_reaction,
+                    self.limit_velocity,
+                ],
+                outputs=[self.limits.reaction, self.limits.velocity, limit_wrench],
+                device=self.device,
+            )
+        if self.contact_capacity > 0 and self.contacts is not None:
+            wp.launch(
+                _write_contact_outputs,
+                dim=self.contacts.model_max_contacts_host,
+                inputs=[
+                    self.contacts.model_active_contacts,
+                    self.contacts.model_max_contacts_host,
+                    self.contacts.wid,
+                    self.contact_source_to_internal,
+                    inverse_time_step,
+                    self.contact_body_first,
+                    self.contact_body_second,
+                    self.contact_jacobian_first,
+                    self.contact_jacobian_second,
+                    self.contact_reaction,
+                    self.contact_velocity,
+                ],
+                outputs=[self.contacts.reaction, self.contacts.velocity, self.contacts.mode, contact_wrench],
+                device=self.device,
+            )
+        if self.structural_row_count > 0:
+            wp.launch(
+                _accumulate_aligned_joint_wrenches,
+                dim=self.structural_row_count,
+                inputs=[
+                    self.structural_body_first_global,
+                    self.structural_body_second_global,
+                    self.structural_jacobian_first,
+                    self.structural_jacobian_second,
+                    self.structural_reaction,
+                ],
+                outputs=[joint_wrench],
+                device=self.device,
+            )
+
+    def validate_model_changed(self) -> None:
+        """Validate LOX constraint topology derived from aliased model values."""
+        source_model = self.model._model
+        if source_model is None:
+            return
+
+        if source_model.joint_friction is not None:
+            friction = source_model.joint_friction.numpy()
+            if np.any(~np.isfinite(friction) | (friction < 0.0)):
+                raise ValueError("Joint friction values must be finite and nonnegative.")
+        effort_limit = source_model.joint_effort_limit.numpy()
+        if np.any(np.isnan(effort_limit) | (effort_limit < 0.0)):
+            raise ValueError("Joint effort limits must be nonnegative or positive infinity.")

--- a/newton/_src/solvers/kamino/_src/solvers/lox/projection.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/projection.py
@@ -1,0 +1,1569 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared unilateral preparation, projection kernels, and residuals.
+
+Contact-facing functions use Kamino's normal-last order
+``(tangent_x, tangent_y, normal_z)``. Body twists and Jacobian columns use
+Kamino's linear-first 6D convention.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Any
+
+import warp as wp
+
+from ...core.types import mat36f, mat66f, vec6f
+from .contact import compute_contact_scaled_alart_curnier_residual, solve_contact_coulomb_newton
+
+__all__ = [
+    "PROJECTION_STATUS_INVALID",
+    "PROJECTION_STATUS_VALID",
+    "compute_contact_delassus",
+    "compute_limit_delassus",
+    "prepare_contact_coulomb_delassus",
+    "project_contact_coulomb_local",
+    "project_friction_local",
+    "project_limit_local",
+]
+
+PROJECTION_STATUS_INVALID = 0
+"""The local block or an input value was non-finite or non-positive."""
+
+PROJECTION_STATUS_VALID = 1
+"""The one-constraint update completed successfully."""
+
+wp.set_module_options({"enable_backward": False})
+
+_FUSED_RIGID_WORLD_MIN_BLOCKS_PER_SM = 4
+
+
+def _can_fuse_rigid_projection_by_world(
+    device: wp.Device,
+    world_count: int,
+    *,
+    required_world_arrays: tuple[wp.array[Any] | None, ...],
+    parallel_constraint_capacity: int | None = None,
+    world_block_dim: int | None = None,
+    minimum_blocks_per_sm: int = _FUSED_RIGID_WORLD_MIN_BLOCKS_PER_SM,
+) -> bool:
+    """Return whether launch fusion or world-level occupancy favors one block per world."""
+    enough_world_blocks = device.is_cuda and world_count >= device.sm_count * minimum_blocks_per_sm
+    small_world_work = (
+        parallel_constraint_capacity is not None
+        and world_block_dim is not None
+        and world_count > 0
+        and parallel_constraint_capacity <= world_count * world_block_dim
+    )
+    return (
+        device.is_cuda
+        and (enough_world_blocks or small_world_work)
+        and all(array is not None for array in required_world_arrays)
+    )
+
+
+@wp.struct
+class ContactProjectionData:
+    """Contact data that is invariant throughout a body-space solve."""
+
+    delassus: wp.mat33f
+    status: wp.int32
+
+
+@wp.struct
+class ScalarProjectionResult:
+    """Minimal result of a prepared scalar projection."""
+
+    reaction: wp.float32
+    reaction_delta: wp.float32
+    status: wp.int32
+
+
+@wp.struct
+class ContactProjectionResult:
+    """Minimal result of a prepared Coulomb projection."""
+
+    reaction: wp.vec3f
+    reaction_delta: wp.vec3f
+    status: wp.int32
+
+
+@wp.func
+def compute_contact_delassus(
+    jacobian_first: mat36f,
+    inverse_weight_first: mat66f,
+    jacobian_second: mat36f,
+    inverse_weight_second: mat66f,
+) -> wp.mat33f:
+    """Compute the full normal-last local contact Delassus block."""
+    return jacobian_first @ inverse_weight_first @ wp.transpose(
+        jacobian_first
+    ) + jacobian_second @ inverse_weight_second @ wp.transpose(jacobian_second)
+
+
+@wp.func
+def prepare_contact_coulomb_delassus(
+    delassus: wp.mat33f,
+    velocity_bias: wp.vec3f,
+    friction: wp.float32,
+) -> ContactProjectionData:
+    """Validate and, when numerically marginal, regularize a contact block."""
+    result = ContactProjectionData()
+    result.delassus = delassus
+    result.status = PROJECTION_STATUS_INVALID
+    if not wp.isfinite(velocity_bias) or not wp.isfinite(friction) or friction < 0.0:
+        return result
+    if not wp.isfinite(delassus):
+        return result
+
+    scale = wp.float32(0.0)
+    asymmetry = wp.float32(0.0)
+    symmetric = wp.mat33f(0.0)
+    for row in range(3):
+        for col in range(3):
+            scale = wp.max(scale, wp.abs(delassus[row, col]))
+            asymmetry = wp.max(asymmetry, wp.abs(delassus[row, col] - delassus[col, row]))
+            symmetric[row, col] = 0.5 * (delassus[row, col] + delassus[col, row])
+    if scale <= 0.0 or asymmetry > 1.0e-5 * scale:
+        return result
+
+    eigenvectors, eigenvalues = wp.eig3(symmetric)
+    if not wp.isfinite(eigenvalues):
+        return result
+    minimum_eigenvalue = wp.min(eigenvalues)
+    if minimum_eigenvalue < -1.0e-5 * scale:
+        return result
+
+    eigenvalue_floor = 1.0e-6 * scale
+    clamped_eigenvalues = wp.max(eigenvalues, wp.vec3f(eigenvalue_floor))
+    regularized = minimum_eigenvalue < eigenvalue_floor
+    if regularized:
+        symmetric = eigenvectors @ wp.diag(clamped_eigenvalues) @ wp.transpose(eigenvectors)
+    result.status = PROJECTION_STATUS_VALID
+    result.delassus = symmetric
+    return result
+
+
+@wp.func
+def _contact_projection_inputs_are_finite(
+    jacobian_first: mat36f,
+    inverse_weight_first: mat66f,
+    jacobian_second: mat36f,
+    inverse_weight_second: mat66f,
+) -> wp.bool:
+    return (
+        wp.isfinite(jacobian_first)
+        and wp.isfinite(inverse_weight_first)
+        and wp.isfinite(jacobian_second)
+        and wp.isfinite(inverse_weight_second)
+    )
+
+
+@wp.func
+def prepare_contact_coulomb(
+    jacobian_first: mat36f,
+    inverse_weight_first: mat66f,
+    jacobian_second: mat36f,
+    inverse_weight_second: mat66f,
+    velocity_bias: wp.vec3f,
+    friction: wp.float32,
+) -> ContactProjectionData:
+    """Validate fixed inputs and prepare the normal-last contact block."""
+    result = prepare_contact_coulomb_delassus(
+        compute_contact_delassus(
+            jacobian_first,
+            inverse_weight_first,
+            jacobian_second,
+            inverse_weight_second,
+        ),
+        velocity_bias,
+        friction,
+    )
+    if not _contact_projection_inputs_are_finite(
+        jacobian_first,
+        inverse_weight_first,
+        jacobian_second,
+        inverse_weight_second,
+    ):
+        result.status = PROJECTION_STATUS_INVALID
+    return result
+
+
+@wp.func
+def compute_limit_delassus(
+    jacobian_first: vec6f,
+    inverse_weight_first: mat66f,
+    jacobian_second: vec6f,
+    inverse_weight_second: mat66f,
+) -> wp.float32:
+    """Compute the scalar local joint-limit Delassus coefficient."""
+    return wp.dot(jacobian_first, inverse_weight_first @ jacobian_first) + wp.dot(
+        jacobian_second, inverse_weight_second @ jacobian_second
+    )
+
+
+@wp.func
+def project_limit_local(
+    current_velocity: wp.float32,
+    reaction_old: wp.float32,
+    delassus: wp.float32,
+) -> ScalarProjectionResult:
+    """Project one prepared scalar unilateral constraint."""
+    result = ScalarProjectionResult()
+    result.reaction = reaction_old
+    result.reaction_delta = 0.0
+    result.status = PROJECTION_STATUS_INVALID
+    if (
+        not wp.isfinite(current_velocity)
+        or not wp.isfinite(reaction_old)
+        or not wp.isfinite(delassus)
+        or delassus <= 0.0
+    ):
+        return result
+
+    free_velocity = current_velocity - delassus * reaction_old
+    reaction_new = wp.max(-free_velocity / delassus, 0.0)
+    reaction_delta = reaction_new - reaction_old
+    if not wp.isfinite(reaction_new) or not wp.isfinite(reaction_delta):
+        return result
+    result.reaction = reaction_new
+    result.reaction_delta = reaction_delta
+    result.status = PROJECTION_STATUS_VALID
+    return result
+
+
+@wp.func
+def project_friction_local(
+    current_velocity: wp.float32,
+    reaction_old: wp.float32,
+    delassus: wp.float32,
+    impulse_bound: wp.float32,
+) -> ScalarProjectionResult:
+    """Project one prepared bounded scalar friction constraint."""
+    result = ScalarProjectionResult()
+    result.reaction = reaction_old
+    result.reaction_delta = 0.0
+    result.status = PROJECTION_STATUS_INVALID
+    if (
+        not wp.isfinite(current_velocity)
+        or not wp.isfinite(reaction_old)
+        or not wp.isfinite(delassus)
+        or delassus <= 0.0
+        or not wp.isfinite(impulse_bound)
+        or impulse_bound < 0.0
+    ):
+        return result
+
+    free_velocity = current_velocity - delassus * reaction_old
+    reaction_new = wp.clamp(-free_velocity / delassus, -impulse_bound, impulse_bound)
+    reaction_delta = reaction_new - reaction_old
+    if not wp.isfinite(reaction_new) or not wp.isfinite(reaction_delta):
+        return result
+    result.reaction = reaction_new
+    result.reaction_delta = reaction_delta
+    result.status = PROJECTION_STATUS_VALID
+    return result
+
+
+@wp.func
+def project_contact_coulomb_local(
+    current_velocity: wp.vec3f,
+    reaction_old: wp.vec3f,
+    delassus: wp.mat33f,
+    friction: wp.float32,
+) -> ContactProjectionResult:
+    """Project one prepared normal-last Coulomb contact."""
+    result = ContactProjectionResult()
+    result.reaction = reaction_old
+    result.reaction_delta = wp.vec3f(0.0)
+    result.status = PROJECTION_STATUS_INVALID
+    free_velocity = current_velocity - delassus @ reaction_old
+    if not wp.isfinite(free_velocity):
+        return result
+
+    reaction_new = solve_contact_coulomb_newton(delassus, free_velocity, friction)
+    reaction_delta = reaction_new - reaction_old
+    if not wp.isfinite(reaction_new) or not wp.isfinite(reaction_delta):
+        return result
+    result.reaction = reaction_new
+    result.reaction_delta = reaction_delta
+    result.status = PROJECTION_STATUS_VALID
+    return result
+
+
+@wp.struct
+class _ProjectionIndexData:
+    constraint_world: wp.array[wp.int32]
+    constraint_local: wp.array[wp.int32]
+    world_constraint_count: wp.array[wp.int32]
+    color_counts: wp.array[wp.int32]
+    color_offsets: wp.array[wp.int32]
+    order: wp.array[wp.int32]
+
+
+@wp.struct
+class _RigidProjectionState:
+    """Array descriptors; body values remain in their original SoA buffers."""
+
+    world_active: wp.array[wp.bool]
+    occupancy: wp.array2d[wp.int32]
+    inverse_weight: wp.array[mat66f]
+    projected_twist: wp.array[vec6f]
+    twist_delta: wp.array[vec6f]
+    world_status: wp.array[wp.int32]
+
+
+@wp.struct
+class _RigidContactProjectionData:
+    """Array descriptors; constructing this view does not pack contact values."""
+
+    body_first: wp.array[wp.int32]
+    body_second: wp.array[wp.int32]
+    jacobian_first: wp.array[mat36f]
+    jacobian_second: wp.array[mat36f]
+    delassus: wp.array[wp.mat33f]
+    bias: wp.array[wp.vec3f]
+    friction: wp.array[wp.float32]
+    reaction: wp.array[wp.vec3f]
+
+
+def _make_direct_projection_index(
+    constraint_world: wp.array[wp.int32],
+    constraint_local: wp.array[wp.int32] | None = None,
+    world_constraint_count: wp.array[wp.int32] | None = None,
+) -> _ProjectionIndexData:
+    index = _ProjectionIndexData()
+    index.constraint_world = constraint_world
+    if constraint_local is not None:
+        index.constraint_local = constraint_local
+    if world_constraint_count is not None:
+        index.world_constraint_count = world_constraint_count
+    return index
+
+
+def _make_colored_projection_index(
+    constraint_world: wp.array[wp.int32],
+    color_counts: wp.array[wp.int32],
+    color_offsets: wp.array[wp.int32],
+    order: wp.array[wp.int32],
+) -> _ProjectionIndexData:
+    index = _ProjectionIndexData()
+    index.constraint_world = constraint_world
+    index.color_counts = color_counts
+    index.color_offsets = color_offsets
+    index.order = order
+    return index
+
+
+def _make_rigid_projection_state(
+    world_active: wp.array[wp.bool],
+    projected_twist: wp.array[vec6f],
+    twist_delta: wp.array[vec6f],
+    world_status: wp.array[wp.int32],
+    occupancy: wp.array2d[wp.int32] | None = None,
+    inverse_weight: wp.array[mat66f] | None = None,
+) -> _RigidProjectionState:
+    state = _RigidProjectionState()
+    state.world_active = world_active
+    state.projected_twist = projected_twist
+    state.twist_delta = twist_delta
+    state.world_status = world_status
+    if occupancy is not None:
+        state.occupancy = occupancy
+    if inverse_weight is not None:
+        state.inverse_weight = inverse_weight
+    return state
+
+
+@wp.func_native("""
+#if defined(__CUDA_ARCH__)
+__syncthreads();
+#endif
+""")
+def _sync_threads(): ...
+
+
+@wp.kernel
+def _prepare_contact_physical_projection_data(
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    inverse_weight: wp.array[mat66f],
+    physical_delassus: wp.array[wp.mat33f],
+    prepared_delassus: wp.array[wp.mat33f],
+    world_status: wp.array[wp.int32],
+):
+    contact = wp.tid()
+    world = contact_world[contact]
+    if contact_local[contact] >= world_contact_count[world]:
+        return
+
+    inverse_weight_first = mat66f(0.0)
+    inverse_weight_second = mat66f(0.0)
+    first = contact_body_first[contact]
+    second = contact_body_second[contact]
+    if first < 0 and second < 0:
+        physical_delassus[contact] = wp.mat33f(0.0)
+        prepared_delassus[contact] = wp.mat33f(0.0)
+        return
+    if first >= 0:
+        inverse_weight_first = inverse_weight[first]
+    if second >= 0:
+        inverse_weight_second = inverse_weight[second]
+    jacobian_first = contact_jacobian_first[contact]
+    jacobian_second = contact_jacobian_second[contact]
+    physical = compute_contact_delassus(
+        jacobian_first,
+        inverse_weight_first,
+        jacobian_second,
+        inverse_weight_second,
+    )
+    data = prepare_contact_coulomb_delassus(
+        physical,
+        contact_bias[contact],
+        contact_friction[contact],
+    )
+    if not _contact_projection_inputs_are_finite(
+        jacobian_first,
+        inverse_weight_first,
+        jacobian_second,
+        inverse_weight_second,
+    ):
+        data.status = PROJECTION_STATUS_INVALID
+    physical_delassus[contact] = physical
+    prepared_delassus[contact] = data.delassus
+    if data.status == PROJECTION_STATUS_INVALID:
+        world_status[world] = data.status
+
+
+@wp.kernel
+def _prepare_scalar_projection_data(
+    constraint_world: wp.array[wp.int32],
+    constraint_local: wp.array[wp.int32],
+    world_constraint_count: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    constraint = wp.tid()
+    world = constraint_world[constraint]
+    if constraint_local[constraint] >= world_constraint_count[world]:
+        return
+
+    first = body_first[constraint]
+    second = body_second[constraint]
+    if first < 0 and second < 0:
+        delassus[constraint] = 0.0
+        return
+    inverse_weight_first = mat66f(0.0)
+    inverse_weight_second = mat66f(0.0)
+    if first >= 0:
+        inverse_weight_first = inverse_weight[first]
+    if second >= 0:
+        inverse_weight_second = inverse_weight[second]
+    value = compute_limit_delassus(
+        jacobian_first[constraint],
+        inverse_weight_first,
+        jacobian_second[constraint],
+        inverse_weight_second,
+    )
+    delassus[constraint] = value
+    if not wp.isfinite(value) or value <= 0.0:
+        world_status[world] = PROJECTION_STATUS_INVALID
+
+
+@wp.func
+def _atomic_add_twist(values: wp.array[vec6f], body: wp.int32, increment: vec6f):
+    if body >= 0:
+        wp.atomic_add(values, body, increment)
+
+
+@wp.func
+def _accumulate_twist_by_occupancy(
+    values: wp.array[vec6f],
+    occupancy: wp.array2d[wp.int32],
+    body: wp.int32,
+    color: wp.int32,
+    increment: vec6f,
+):
+    if occupancy[body, color] == 1:
+        values[body] += increment
+    else:
+        wp.atomic_add(values, body, increment)
+
+
+@wp.func
+def _is_zero_vec3(value: wp.vec3f) -> wp.bool:
+    return value[0] == 0.0 and value[1] == 0.0 and value[2] == 0.0
+
+
+@wp.func
+def _compute_contact_velocity(
+    contact: wp.int32,
+    first: wp.int32,
+    second: wp.int32,
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    projected_twist: wp.array[vec6f],
+) -> wp.vec3f:
+    velocity = contact_bias[contact]
+    if first >= 0:
+        velocity += contact_jacobian_first[contact] @ projected_twist[first]
+    if second >= 0:
+        velocity += contact_jacobian_second[contact] @ projected_twist[second]
+    return velocity
+
+
+@cache
+def _make_accumulate_projection_delta(colored: bool):
+    """Apply weights per color, or defer them until Jacobi body accumulation."""
+
+    @wp.func
+    def accumulate(
+        first: wp.int32,
+        second: wp.int32,
+        target_color: wp.int32,
+        correction_first: vec6f,
+        correction_second: vec6f,
+        state: _RigidProjectionState,
+    ):
+        if wp.static(colored):
+            if first >= 0:
+                correction_first = state.inverse_weight[first] @ correction_first
+            if second >= 0:
+                correction_second = state.inverse_weight[second] @ correction_second
+            if first >= 0:
+                if first == second:
+                    _accumulate_twist_by_occupancy(
+                        state.twist_delta,
+                        state.occupancy,
+                        first,
+                        target_color,
+                        correction_first + correction_second,
+                    )
+                else:
+                    _accumulate_twist_by_occupancy(
+                        state.twist_delta,
+                        state.occupancy,
+                        first,
+                        target_color,
+                        correction_first,
+                    )
+            if second >= 0 and second != first:
+                _accumulate_twist_by_occupancy(
+                    state.twist_delta,
+                    state.occupancy,
+                    second,
+                    target_color,
+                    correction_second,
+                )
+        else:
+            _atomic_add_twist(state.twist_delta, first, correction_first)
+            _atomic_add_twist(state.twist_delta, second, correction_second)
+
+    return accumulate
+
+
+@cache
+def _make_project_rigid_contact(colored: bool):
+    """Share local projection and specialize only accumulation."""
+    accumulate = _make_accumulate_projection_delta(colored)
+
+    @wp.func
+    def project_contact(
+        contact: wp.int32,
+        world: wp.int32,
+        target_color: wp.int32,
+        data: _RigidContactProjectionData,
+        delassus: wp.array[wp.mat33f],
+        state: _RigidProjectionState,
+    ):
+        first = data.body_first[contact]
+        second = data.body_second[contact]
+        if first < 0 and second < 0:
+            data.reaction[contact] = wp.vec3f(0.0)
+            return
+        velocity = _compute_contact_velocity(
+            contact,
+            first,
+            second,
+            data.jacobian_first,
+            data.jacobian_second,
+            data.bias,
+            state.projected_twist,
+        )
+        reaction_old = data.reaction[contact]
+        if _is_zero_vec3(reaction_old) and velocity[2] >= 0.0 and wp.isfinite(velocity):
+            return
+        projection = project_contact_coulomb_local(
+            velocity,
+            reaction_old,
+            delassus[contact],
+            data.friction[contact],
+        )
+        if projection.status == PROJECTION_STATUS_INVALID:
+            state.world_status[world] = PROJECTION_STATUS_INVALID
+            return
+        data.reaction[contact] = projection.reaction
+        if _is_zero_vec3(projection.reaction_delta):
+            return
+        correction_first = vec6f(0.0)
+        correction_second = vec6f(0.0)
+        if first >= 0:
+            correction_first = wp.transpose(data.jacobian_first[contact]) @ projection.reaction_delta
+        if second >= 0:
+            correction_second = wp.transpose(data.jacobian_second[contact]) @ projection.reaction_delta
+        accumulate(first, second, target_color, correction_first, correction_second, state)
+
+    return project_contact
+
+
+@cache
+def _make_project_rigid_scalar(colored: bool, limit: bool):
+    """Share local projection and specialize only accumulation."""
+    accumulate = _make_accumulate_projection_delta(colored)
+
+    @wp.func
+    def project_scalar(
+        constraint: wp.int32,
+        world: wp.int32,
+        target_color: wp.int32,
+        body_first: wp.array[wp.int32],
+        body_second: wp.array[wp.int32],
+        jacobian_first: wp.array[vec6f],
+        jacobian_second: wp.array[vec6f],
+        bias: wp.array[wp.float32],
+        bound: wp.array[wp.float32],
+        delassus: wp.array[wp.float32],
+        reaction: wp.array[wp.float32],
+        state: _RigidProjectionState,
+    ):
+        first = body_first[constraint]
+        second = body_second[constraint]
+        if first < 0 and second < 0:
+            reaction[constraint] = 0.0
+            return
+        velocity = wp.float32(0.0)
+        if wp.static(limit):
+            velocity = bias[constraint]
+        if first >= 0:
+            velocity += wp.dot(jacobian_first[constraint], state.projected_twist[first])
+        if second >= 0:
+            velocity += wp.dot(jacobian_second[constraint], state.projected_twist[second])
+        if wp.static(limit):
+            projection = project_limit_local(velocity, reaction[constraint], delassus[constraint])
+        else:
+            projection = project_friction_local(
+                velocity,
+                reaction[constraint],
+                delassus[constraint],
+                bound[constraint],
+            )
+        if projection.status == PROJECTION_STATUS_INVALID:
+            state.world_status[world] = PROJECTION_STATUS_INVALID
+            return
+        correction_first = vec6f(0.0)
+        correction_second = vec6f(0.0)
+        if first >= 0:
+            correction_first = jacobian_first[constraint] * projection.reaction_delta
+        if second >= 0:
+            correction_second = jacobian_second[constraint] * projection.reaction_delta
+        accumulate(first, second, target_color, correction_first, correction_second, state)
+        reaction[constraint] = projection.reaction
+
+    return project_scalar
+
+
+_project_rigid_contact_colored = _make_project_rigid_contact(True)
+_project_rigid_contact_jacobi = _make_project_rigid_contact(False)
+_project_rigid_friction_colored = _make_project_rigid_scalar(True, False)
+_project_rigid_limit_colored = _make_project_rigid_scalar(True, True)
+_project_rigid_friction_jacobi = _make_project_rigid_scalar(False, False)
+_project_rigid_limit_jacobi = _make_project_rigid_scalar(False, True)
+
+
+@wp.kernel
+def _prepare_contacts_jacobi(
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    body_constraint_count: wp.array[wp.int32],
+    static_body_constraint_count: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.mat33f],
+    world_status: wp.array[wp.int32],
+):
+    contact = wp.tid()
+    world = contact_world[contact]
+    if contact_local[contact] >= world_contact_count[world]:
+        return
+
+    inverse_weight_first = mat66f(0.0)
+    inverse_weight_second = mat66f(0.0)
+    first = contact_body_first[contact]
+    second = contact_body_second[contact]
+    if first < 0 and second < 0:
+        delassus[contact] = wp.mat33f(0.0)
+        return
+    if first >= 0:
+        multiplicity = wp.max(1, body_constraint_count[first] - static_body_constraint_count[first])
+        inverse_weight_first = wp.float32(multiplicity) * inverse_weight[first]
+    if second >= 0:
+        multiplicity = wp.max(1, body_constraint_count[second] - static_body_constraint_count[second])
+        inverse_weight_second = wp.float32(multiplicity) * inverse_weight[second]
+    data = prepare_contact_coulomb(
+        contact_jacobian_first[contact],
+        inverse_weight_first,
+        contact_jacobian_second[contact],
+        inverse_weight_second,
+        contact_bias[contact],
+        contact_friction[contact],
+    )
+    delassus[contact] = data.delassus
+    if data.status == PROJECTION_STATUS_INVALID:
+        world_status[world] = data.status
+
+
+@wp.kernel
+def _prepare_limits_jacobi(
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    body_constraint_count: wp.array[wp.int32],
+    static_body_constraint_count: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    limit = wp.tid()
+    world = limit_world[limit]
+    if limit_local[limit] >= world_limit_count[world]:
+        return
+
+    inverse_weight_first = mat66f(0.0)
+    inverse_weight_second = mat66f(0.0)
+    first = limit_body_first[limit]
+    second = limit_body_second[limit]
+    if first < 0 and second < 0:
+        delassus[limit] = 0.0
+        return
+    if first >= 0:
+        multiplicity = wp.max(1, body_constraint_count[first] - static_body_constraint_count[first])
+        inverse_weight_first = wp.float32(multiplicity) * inverse_weight[first]
+    if second >= 0:
+        multiplicity = wp.max(1, body_constraint_count[second] - static_body_constraint_count[second])
+        inverse_weight_second = wp.float32(multiplicity) * inverse_weight[second]
+    value = compute_limit_delassus(
+        limit_jacobian_first[limit],
+        inverse_weight_first,
+        limit_jacobian_second[limit],
+        inverse_weight_second,
+    )
+    delassus[limit] = value
+    if not wp.isfinite(value) or value <= 0.0:
+        world_status[world] = PROJECTION_STATUS_INVALID
+
+
+@wp.kernel
+def _prepare_frictions_jacobi(
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    body_constraint_count: wp.array[wp.int32],
+    static_body_constraint_count: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+):
+    friction = wp.tid()
+    world = friction_world[friction]
+    if friction_local[friction] >= world_friction_count[world]:
+        return
+    inverse_weight_first = mat66f(0.0)
+    inverse_weight_second = mat66f(0.0)
+    first = friction_body_first[friction]
+    second = friction_body_second[friction]
+    if first >= 0:
+        multiplicity = wp.max(1, body_constraint_count[first] - static_body_constraint_count[first])
+        inverse_weight_first = wp.float32(multiplicity) * inverse_weight[first]
+    if second >= 0:
+        multiplicity = wp.max(1, body_constraint_count[second] - static_body_constraint_count[second])
+        inverse_weight_second = wp.float32(multiplicity) * inverse_weight[second]
+    value = compute_limit_delassus(
+        friction_jacobian_first[friction],
+        inverse_weight_first,
+        friction_jacobian_second[friction],
+        inverse_weight_second,
+    )
+    delassus[friction] = value
+    if not wp.isfinite(value) or value <= 0.0:
+        world_status[world] = PROJECTION_STATUS_INVALID
+
+
+@wp.kernel
+def _initialize_jacobi_projection_status(
+    world_active: wp.array[wp.bool],
+    prepared_status: wp.array[wp.int32],
+    world_status: wp.array[wp.int32],
+):
+    world = wp.tid()
+    if world_active[world]:
+        world_status[world] = prepared_status[world]
+
+
+@wp.kernel
+def _warmstart_contacts_jacobi(
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    prepared_status: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    inverse_weight: wp.array[mat66f],
+    apply_inverse_weight: wp.bool,
+    reaction: wp.array[wp.vec3f],
+    twist_delta: wp.array[vec6f],
+):
+    contact = wp.tid()
+    world = contact_world[contact]
+    if (
+        contact_local[contact] >= world_contact_count[world]
+        or not world_active[world]
+        or prepared_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+    first = contact_body_first[contact]
+    second = contact_body_second[contact]
+    impulse = reaction[contact]
+    if not _is_zero_vec3(impulse):
+        if first >= 0:
+            wrench = wp.transpose(contact_jacobian_first[contact]) @ impulse
+            if apply_inverse_weight:
+                wrench = inverse_weight[first] @ wrench
+            _atomic_add_twist(twist_delta, first, wrench)
+        if second >= 0:
+            wrench = wp.transpose(contact_jacobian_second[contact]) @ impulse
+            if apply_inverse_weight:
+                wrench = inverse_weight[second] @ wrench
+            _atomic_add_twist(twist_delta, second, wrench)
+
+
+@wp.kernel
+def _warmstart_limits_jacobi(
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    prepared_status: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    inverse_weight: wp.array[mat66f],
+    apply_inverse_weight: wp.bool,
+    reaction: wp.array[wp.float32],
+    twist_delta: wp.array[vec6f],
+):
+    limit = wp.tid()
+    world = limit_world[limit]
+    if (
+        limit_local[limit] >= world_limit_count[world]
+        or not world_active[world]
+        or prepared_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+    first = limit_body_first[limit]
+    second = limit_body_second[limit]
+    impulse = reaction[limit]
+    if first >= 0:
+        wrench = limit_jacobian_first[limit] * impulse
+        if apply_inverse_weight:
+            wrench = inverse_weight[first] @ wrench
+        _atomic_add_twist(twist_delta, first, wrench)
+    if second >= 0:
+        wrench = limit_jacobian_second[limit] * impulse
+        if apply_inverse_weight:
+            wrench = inverse_weight[second] @ wrench
+        _atomic_add_twist(twist_delta, second, wrench)
+
+
+@wp.kernel
+def _warmstart_frictions_jacobi(
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    prepared_status: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    inverse_weight: wp.array[mat66f],
+    apply_inverse_weight: wp.bool,
+    reaction: wp.array[wp.float32],
+    twist_delta: wp.array[vec6f],
+):
+    friction = wp.tid()
+    world = friction_world[friction]
+    if (
+        friction_local[friction] >= world_friction_count[world]
+        or not world_active[world]
+        or prepared_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+    first = friction_body_first[friction]
+    second = friction_body_second[friction]
+    impulse = reaction[friction]
+    if first >= 0:
+        wrench = friction_jacobian_first[friction] * impulse
+        if apply_inverse_weight:
+            wrench = inverse_weight[first] @ wrench
+        _atomic_add_twist(twist_delta, first, wrench)
+    if second >= 0:
+        wrench = friction_jacobian_second[friction] * impulse
+        if apply_inverse_weight:
+            wrench = inverse_weight[second] @ wrench
+        _atomic_add_twist(twist_delta, second, wrench)
+
+
+@cache
+def _make_project_contacts_kernel(colored: bool):
+    """Specialize local-frame Coulomb projection by indexing."""
+    project_contact = _make_project_rigid_contact(colored)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def project_contacts_kernel(
+        launch_dim: wp.int32,
+        target_color: wp.int32,
+        index: _ProjectionIndexData,
+        contact_data: _RigidContactProjectionData,
+        state: _RigidProjectionState,
+    ):
+        lane = wp.tid()
+        begin = lane
+        end = lane + 1
+        stride = 1
+        if wp.static(colored):
+            begin = index.color_offsets[target_color] + lane
+            end = index.color_offsets[target_color] + index.color_counts[target_color]
+            stride = launch_dim
+        for ordered in range(begin, end, stride):
+            contact = ordered
+            if wp.static(colored):
+                contact = index.order[ordered]
+            world = index.constraint_world[contact]
+            if wp.static(not colored):
+                if index.constraint_local[contact] >= index.world_constraint_count[world]:
+                    continue
+            if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+                continue
+            project_contact(contact, world, target_color, contact_data, contact_data.delassus, state)
+
+    return project_contacts_kernel
+
+
+@cache
+def _make_project_scalar_kernel(colored: bool, limit: bool):
+    """Specialize scalar unilateral projection by indexing and projection law."""
+    project_scalar = _make_project_rigid_scalar(colored, limit)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def project_scalar_kernel(
+        launch_dim: wp.int32,
+        target_color: wp.int32,
+        index: _ProjectionIndexData,
+        body_first: wp.array[wp.int32],
+        body_second: wp.array[wp.int32],
+        jacobian_first: wp.array[vec6f],
+        jacobian_second: wp.array[vec6f],
+        bias: wp.array[wp.float32],
+        impulse_bound: wp.array[wp.float32],
+        delassus: wp.array[wp.float32],
+        reaction: wp.array[wp.float32],
+        state: _RigidProjectionState,
+    ):
+        lane = wp.tid()
+        begin = lane
+        end = lane + 1
+        stride = 1
+        if wp.static(colored):
+            begin = index.color_offsets[target_color] + lane
+            end = index.color_offsets[target_color] + index.color_counts[target_color]
+            stride = launch_dim
+
+        for ordered in range(begin, end, stride):
+            constraint = ordered
+            if wp.static(colored):
+                constraint = index.order[ordered]
+            world = index.constraint_world[constraint]
+            if wp.static(not colored):
+                if index.constraint_local[constraint] >= index.world_constraint_count[world]:
+                    continue
+            if not state.world_active[world] or state.world_status[world] != PROJECTION_STATUS_VALID:
+                continue
+            project_scalar(
+                constraint,
+                world,
+                target_color,
+                body_first,
+                body_second,
+                jacobian_first,
+                jacobian_second,
+                bias,
+                impulse_bound,
+                delassus,
+                reaction,
+                state,
+            )
+
+    return project_scalar_kernel
+
+
+@wp.kernel
+def _initialize_projection_residuals(
+    world_contact_residual_max: wp.array[wp.float32],
+    world_limit_residual_max: wp.array[wp.float32],
+    world_friction_residual_max: wp.array[wp.float32],
+):
+    world = wp.tid()
+    world_contact_residual_max[world] = 0.0
+    world_limit_residual_max[world] = 0.0
+    world_friction_residual_max[world] = 0.0
+
+
+@wp.kernel
+def _compute_friction_projection_residuals(
+    world_mask: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    friction_impulse_bound: wp.array[wp.float32],
+    friction_reaction: wp.array[wp.float32],
+    friction_delassus: wp.array[wp.float32],
+    projected_twist: wp.array[vec6f],
+    friction_velocity: wp.array[wp.float32],
+    friction_residual: wp.array[wp.float32],
+    world_friction_residual_max: wp.array[wp.float32],
+):
+    friction = wp.tid()
+    world = friction_world[friction]
+    if (
+        friction_local[friction] >= world_friction_count[world]
+        or not world_mask[world]
+        or projection_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+
+    first = friction_body_first[friction]
+    second = friction_body_second[friction]
+    value = wp.float32(0.0)
+    if first >= 0:
+        value += wp.dot(friction_jacobian_first[friction], projected_twist[first])
+    if second >= 0:
+        value += wp.dot(friction_jacobian_second[friction], projected_twist[second])
+    friction_velocity[friction] = value
+    delassus = friction_delassus[friction]
+    scale = wp.sqrt(delassus)
+    scaled_reaction = scale * friction_reaction[friction]
+    scaled_velocity = value / scale
+    scaled_bound = scale * friction_impulse_bound[friction]
+    residual = wp.abs(scaled_reaction - wp.clamp(scaled_reaction - scaled_velocity, -scaled_bound, scaled_bound))
+    friction_residual[friction] = residual
+    wp.atomic_max(world_friction_residual_max, world, residual)
+
+
+@wp.kernel
+def _compute_contact_projection_residuals(
+    world_mask: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_delassus: wp.array[wp.mat33f],
+    projected_twist: wp.array[vec6f],
+    contact_velocity: wp.array[wp.vec3f],
+    contact_residual: wp.array[wp.float32],
+    world_contact_residual_max: wp.array[wp.float32],
+):
+    contact = wp.tid()
+    world = contact_world[contact]
+    if (
+        contact_local[contact] >= world_contact_count[world]
+        or not world_mask[world]
+        or projection_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+
+    first = contact_body_first[contact]
+    second = contact_body_second[contact]
+    if first < 0 and second < 0:
+        contact_velocity[contact] = wp.vec3f(0.0)
+        contact_residual[contact] = 0.0
+        return
+    contact_velocity_final = wp.vec3f(0.0)
+    if first >= 0:
+        contact_velocity_final += contact_jacobian_first[contact] @ projected_twist[first]
+    if second >= 0:
+        contact_velocity_final += contact_jacobian_second[contact] @ projected_twist[second]
+    contact_velocity[contact] = contact_velocity_final
+    contact_residual_vector = compute_contact_scaled_alart_curnier_residual(
+        contact_delassus[contact],
+        contact_reaction[contact],
+        contact_velocity_final + contact_bias[contact],
+        contact_friction[contact],
+    )
+    residual_max = wp.max(wp.abs(contact_residual_vector))
+    contact_residual[contact] = residual_max
+    wp.atomic_max(world_contact_residual_max, world, residual_max)
+
+
+@wp.kernel
+def _compute_limit_projection_residuals(
+    world_mask: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    limit_bias: wp.array[wp.float32],
+    limit_reaction: wp.array[wp.float32],
+    limit_delassus: wp.array[wp.float32],
+    projected_twist: wp.array[vec6f],
+    limit_velocity: wp.array[wp.float32],
+    limit_residual: wp.array[wp.float32],
+    world_limit_residual_max: wp.array[wp.float32],
+):
+    limit = wp.tid()
+    world = limit_world[limit]
+    if (
+        limit_local[limit] >= world_limit_count[world]
+        or not world_mask[world]
+        or projection_status[world] != PROJECTION_STATUS_VALID
+    ):
+        return
+
+    first = limit_body_first[limit]
+    second = limit_body_second[limit]
+    if first < 0 and second < 0:
+        limit_velocity[limit] = 0.0
+        limit_residual[limit] = 0.0
+        return
+    limit_velocity_final = wp.float32(0.0)
+    if first >= 0:
+        limit_velocity_final += wp.dot(limit_jacobian_first[limit], projected_twist[first])
+    if second >= 0:
+        limit_velocity_final += wp.dot(limit_jacobian_second[limit], projected_twist[second])
+    limit_velocity[limit] = limit_velocity_final
+    scale = wp.sqrt(limit_delassus[limit])
+    scaled_reaction = scale * limit_reaction[limit]
+    scaled_velocity = (limit_velocity_final + limit_bias[limit]) / scale
+    limit_residual_value = wp.abs(scaled_reaction - wp.max(scaled_reaction - scaled_velocity, 0.0))
+    limit_residual[limit] = limit_residual_value
+    wp.atomic_max(world_limit_residual_max, world, limit_residual_value)
+
+
+def compute_projection_residuals(
+    world_mask: wp.array[wp.bool],
+    projection_status: wp.array[wp.int32],
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    friction_impulse_bound: wp.array[wp.float32],
+    friction_reaction: wp.array[wp.float32],
+    friction_delassus: wp.array[wp.float32],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_delassus: wp.array[wp.mat33f],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    limit_bias: wp.array[wp.float32],
+    limit_reaction: wp.array[wp.float32],
+    limit_delassus: wp.array[wp.float32],
+    projected_twist: wp.array[vec6f],
+    friction_velocity: wp.array[wp.float32],
+    contact_velocity: wp.array[wp.vec3f],
+    limit_velocity: wp.array[wp.float32],
+    contact_residual: wp.array[wp.float32],
+    limit_residual: wp.array[wp.float32],
+    friction_residual: wp.array[wp.float32],
+    world_contact_residual_max: wp.array[wp.float32],
+    world_limit_residual_max: wp.array[wp.float32],
+    world_friction_residual_max: wp.array[wp.float32],
+) -> None:
+    """Recompute final unilateral velocities and per-world natural-map residual maxima."""
+    world_count = world_mask.shape[0]
+    if (
+        projection_status.shape[0] != world_count
+        or world_friction_count.shape[0] != world_count
+        or world_contact_count.shape[0] != world_count
+        or world_limit_count.shape[0] != world_count
+        or world_contact_residual_max.shape[0] != world_count
+        or world_limit_residual_max.shape[0] != world_count
+        or world_friction_residual_max.shape[0] != world_count
+    ):
+        raise ValueError("Projection diagnostic world arrays must have identical lengths.")
+    if (
+        friction_world.shape[0] != friction_local.shape[0]
+        or contact_world.shape[0] != contact_local.shape[0]
+        or limit_world.shape[0] != limit_local.shape[0]
+    ):
+        raise ValueError("Projection diagnostic world and local arrays must have identical lengths.")
+    wp.launch(
+        _initialize_projection_residuals,
+        dim=world_count,
+        inputs=[],
+        outputs=[
+            world_contact_residual_max,
+            world_limit_residual_max,
+            world_friction_residual_max,
+        ],
+        device=projected_twist.device,
+    )
+    if friction_world.shape[0] > 0:
+        wp.launch(
+            _compute_friction_projection_residuals,
+            dim=friction_world.shape[0],
+            inputs=[
+                world_mask,
+                projection_status,
+                friction_world,
+                friction_local,
+                world_friction_count,
+                friction_body_first,
+                friction_body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                friction_impulse_bound,
+                friction_reaction,
+                friction_delassus,
+                projected_twist,
+            ],
+            outputs=[friction_velocity, friction_residual, world_friction_residual_max],
+            device=projected_twist.device,
+        )
+    if contact_world.shape[0] > 0:
+        wp.launch(
+            _compute_contact_projection_residuals,
+            dim=contact_world.shape[0],
+            inputs=[
+                world_mask,
+                projection_status,
+                contact_world,
+                contact_local,
+                world_contact_count,
+                contact_body_first,
+                contact_body_second,
+                contact_jacobian_first,
+                contact_jacobian_second,
+                contact_bias,
+                contact_friction,
+                contact_reaction,
+                contact_delassus,
+                projected_twist,
+            ],
+            outputs=[contact_velocity, contact_residual, world_contact_residual_max],
+            device=projected_twist.device,
+        )
+    if limit_world.shape[0] > 0:
+        wp.launch(
+            _compute_limit_projection_residuals,
+            dim=limit_world.shape[0],
+            inputs=[
+                world_mask,
+                projection_status,
+                limit_world,
+                limit_local,
+                world_limit_count,
+                limit_body_first,
+                limit_body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                limit_bias,
+                limit_reaction,
+                limit_delassus,
+                projected_twist,
+            ],
+            outputs=[limit_velocity, limit_residual, world_limit_residual_max],
+            device=projected_twist.device,
+        )
+
+
+def prepare_physical_projection_data(
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    inverse_weight: wp.array[mat66f],
+    friction_delassus: wp.array[wp.float32],
+    contact_physical_delassus: wp.array[wp.mat33f],
+    contact_prepared_delassus: wp.array[wp.mat33f],
+    limit_delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+) -> None:
+    """Cache physical local Delassus blocks once for fixed body-space data."""
+    world_count = world_status.shape[0]
+    if (
+        world_friction_count.shape[0] != world_count
+        or world_contact_count.shape[0] != world_count
+        or world_limit_count.shape[0] != world_count
+    ):
+        raise ValueError("Friction, contact, limit, and status world arrays must have identical lengths.")
+    world_status.fill_(PROJECTION_STATUS_VALID)
+    for world, local, count, first, second, jacobian_first, jacobian_second, output in (
+        (
+            friction_world,
+            friction_local,
+            world_friction_count,
+            friction_body_first,
+            friction_body_second,
+            friction_jacobian_first,
+            friction_jacobian_second,
+            friction_delassus,
+        ),
+        (
+            limit_world,
+            limit_local,
+            world_limit_count,
+            limit_body_first,
+            limit_body_second,
+            limit_jacobian_first,
+            limit_jacobian_second,
+            limit_delassus,
+        ),
+    ):
+        if world.shape[0] > 0:
+            wp.launch(
+                _prepare_scalar_projection_data,
+                dim=world.shape[0],
+                inputs=[world, local, count, first, second, jacobian_first, jacobian_second, inverse_weight],
+                outputs=[output, world_status],
+                device=inverse_weight.device,
+            )
+    if contact_world.shape[0] > 0:
+        wp.launch(
+            _prepare_contact_physical_projection_data,
+            dim=contact_world.shape[0],
+            inputs=[
+                contact_world,
+                contact_local,
+                world_contact_count,
+                contact_body_first,
+                contact_body_second,
+                contact_jacobian_first,
+                contact_jacobian_second,
+                contact_bias,
+                contact_friction,
+                inverse_weight,
+            ],
+            outputs=[contact_physical_delassus, contact_prepared_delassus, world_status],
+            device=inverse_weight.device,
+        )
+
+
+def prepare_jacobi_projection_data(
+    friction_world: wp.array[wp.int32],
+    friction_local: wp.array[wp.int32],
+    world_friction_count: wp.array[wp.int32],
+    friction_body_first: wp.array[wp.int32],
+    friction_body_second: wp.array[wp.int32],
+    friction_jacobian_first: wp.array[vec6f],
+    friction_jacobian_second: wp.array[vec6f],
+    contact_world: wp.array[wp.int32],
+    contact_local: wp.array[wp.int32],
+    world_contact_count: wp.array[wp.int32],
+    contact_body_first: wp.array[wp.int32],
+    contact_body_second: wp.array[wp.int32],
+    contact_jacobian_first: wp.array[mat36f],
+    contact_jacobian_second: wp.array[mat36f],
+    contact_bias: wp.array[wp.vec3f],
+    contact_friction: wp.array[wp.float32],
+    limit_world: wp.array[wp.int32],
+    limit_local: wp.array[wp.int32],
+    world_limit_count: wp.array[wp.int32],
+    limit_body_first: wp.array[wp.int32],
+    limit_body_second: wp.array[wp.int32],
+    limit_jacobian_first: wp.array[vec6f],
+    limit_jacobian_second: wp.array[vec6f],
+    body_constraint_count: wp.array[wp.int32],
+    static_body_constraint_count: wp.array[wp.int32],
+    inverse_weight: wp.array[mat66f],
+    friction_delassus: wp.array[wp.float32],
+    contact_delassus: wp.array[wp.mat33f],
+    limit_delassus: wp.array[wp.float32],
+    world_status: wp.array[wp.int32],
+) -> None:
+    """Prepare mass-split body-space blocks for true Jacobi projection."""
+    world_count = world_status.shape[0]
+    if (
+        world_friction_count.shape[0] != world_count
+        or world_contact_count.shape[0] != world_count
+        or world_limit_count.shape[0] != world_count
+    ):
+        raise ValueError("Friction, contact, limit, and status world arrays must have identical lengths.")
+    if body_constraint_count.shape[0] != static_body_constraint_count.shape[0]:
+        raise ValueError("Body incidence arrays must have identical lengths.")
+    world_status.fill_(PROJECTION_STATUS_VALID)
+    if friction_world.shape[0] > 0:
+        wp.launch(
+            _prepare_frictions_jacobi,
+            dim=friction_world.shape[0],
+            inputs=[
+                friction_world,
+                friction_local,
+                world_friction_count,
+                friction_body_first,
+                friction_body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                body_constraint_count,
+                static_body_constraint_count,
+                inverse_weight,
+            ],
+            outputs=[friction_delassus, world_status],
+            device=inverse_weight.device,
+        )
+    if contact_world.shape[0] > 0:
+        wp.launch(
+            _prepare_contacts_jacobi,
+            dim=contact_world.shape[0],
+            inputs=[
+                contact_world,
+                contact_local,
+                world_contact_count,
+                contact_body_first,
+                contact_body_second,
+                contact_jacobian_first,
+                contact_jacobian_second,
+                contact_bias,
+                contact_friction,
+                body_constraint_count,
+                static_body_constraint_count,
+                inverse_weight,
+            ],
+            outputs=[contact_delassus, world_status],
+            device=inverse_weight.device,
+        )
+    if limit_world.shape[0] > 0:
+        wp.launch(
+            _prepare_limits_jacobi,
+            dim=limit_world.shape[0],
+            inputs=[
+                limit_world,
+                limit_local,
+                world_limit_count,
+                limit_body_first,
+                limit_body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                body_constraint_count,
+                static_body_constraint_count,
+                inverse_weight,
+            ],
+            outputs=[limit_delassus, world_status],
+            device=inverse_weight.device,
+        )
+
+
+@wp.func
+def _check_projected_twist(
+    body: wp.int32,
+    world: wp.int32,
+    projected_twist: wp.array[vec6f],
+    world_status: wp.array[wp.int32],
+):
+    if not wp.isfinite(projected_twist[body]):
+        wp.atomic_min(world_status, world, PROJECTION_STATUS_INVALID)
+
+
+@wp.kernel
+def _validate_projected_twists(
+    body_world: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    projected_twist: wp.array[vec6f],
+    world_status: wp.array[wp.int32],
+):
+    body = wp.tid()
+    world = body_world[body]
+    if world_active[world]:
+        _check_projected_twist(body, world, projected_twist, world_status)

--- a/newton/_src/solvers/kamino/_src/solvers/lox/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/solver.py
@@ -1,0 +1,1111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen-contact orchestration for the LOX rigid-body solve."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import warp as wp
+
+from ......sim import ModelFlags
+from ...core.bodies import update_body_wrenches
+from ...core.state import StateKamino
+from ...core.types import vec6f
+from .adapter import _write_integrator_body_inputs
+from .colored_gauss_seidel import ColoredGaussSeidelProjection
+from .jacobi import project_constraints_jacobi
+from .joint_delassus import BatchedStructuralDelassus
+from .problem import LOXProblem
+from .projection import (
+    PROJECTION_STATUS_VALID,
+    compute_projection_residuals,
+    prepare_jacobi_projection_data,
+    prepare_physical_projection_data,
+)
+
+if TYPE_CHECKING:
+    from ....config import ConstraintStabilizationConfig, LOXSolverConfig
+    from ...core.data import DataKamino
+    from ...core.joints import JointCorrectionMode
+    from ...core.model import ModelKamino
+    from ...dynamics.dual import DualProblem
+    from ...geometry.contacts import ContactsKamino
+    from ...kinematics.jacobians import SparseSystemJacobians
+    from ...kinematics.limits import LimitsKamino
+    from ..metrics import SolutionMetricsData
+
+__all__ = [
+    "LOX_STATUS_ACTIVE",
+    "LOX_STATUS_CONVERGED",
+    "LOX_STATUS_FAILED",
+    "LOX_STATUS_ITERATION_LIMIT",
+    "LOXSolver",
+    "LOXStatus",
+]
+
+LOX_STATUS_ACTIVE = 0
+"""The world is active in the current splitting solve."""
+
+LOX_STATUS_CONVERGED = 1
+"""The world met the configured splitting tolerances."""
+
+LOX_STATUS_FAILED = 2
+"""A unilateral projection failed for the world."""
+
+LOX_STATUS_ITERATION_LIMIT = 3
+"""The world reached the configured splitting iteration limit."""
+
+wp.set_module_options({"enable_backward": False})
+
+_JOINT_PENALTY_SEED_PERCENTILE = 0.02
+
+
+@wp.struct
+class LOXStatus:
+    """Per-world LOX terminal status."""
+
+    converged: wp.int32
+    """Whether the world met every configured LOX stopping tolerance."""
+    iterations: wp.int32
+    """Number of splitting iterations performed for the world."""
+    r_p: wp.float32
+    """NCP primal feasibility residual, or NaN when solution metrics are disabled."""
+    r_d: wp.float32
+    """NCP dual feasibility residual, or NaN when solution metrics are disabled."""
+    r_c: wp.float32
+    """NCP complementarity residual, or NaN when solution metrics are disabled."""
+    accepted: wp.int32
+    """Whether LOX accepted the world's final projected iterate."""
+    failed: wp.int32
+    """Whether a projection failed for the world."""
+    iteration_limit: wp.int32
+    """Whether the world stopped at the configured iteration limit."""
+
+
+def _low_mode_eigenvalue(eigenvalues: np.ndarray) -> float:
+    """Select the discrete low-mode percentile used for ALM scale seeding."""
+    index = int(_JOINT_PENALTY_SEED_PERCENTILE * eigenvalues.size)
+    return float(eigenvalues[index])
+
+
+@wp.kernel
+def _finalize_world_status(
+    world_converged: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    world_iteration_limit: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+    world_accepted: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    solver_status: wp.array[LOXStatus],
+):
+    world = wp.tid()
+    converged = world_converged[world] and not world_failed[world]
+    accepted = not world_failed[world]
+    world_accepted[world] = accepted
+    if world_failed[world]:
+        world_status[world] = LOX_STATUS_FAILED
+    elif converged:
+        world_status[world] = LOX_STATUS_CONVERGED
+    elif world_iteration_limit[world]:
+        world_status[world] = LOX_STATUS_ITERATION_LIMIT
+    else:
+        world_status[world] = LOX_STATUS_ACTIVE
+
+    status = LOXStatus()
+    status.converged = wp.int32(converged)
+    status.iterations = iteration_count[world]
+    status.r_p = wp.nan
+    status.r_d = wp.nan
+    status.r_c = wp.nan
+    status.accepted = wp.int32(accepted)
+    status.failed = wp.int32(world_failed[world])
+    status.iteration_limit = wp.int32(world_iteration_limit[world])
+    solver_status[world] = status
+
+
+@wp.kernel
+def _reset_solver_status(solver_status: wp.array[LOXStatus]):
+    world = wp.tid()
+    status = LOXStatus()
+    status.converged = wp.int32(0)
+    status.iterations = wp.int32(0)
+    status.r_p = wp.nan
+    status.r_d = wp.nan
+    status.r_c = wp.nan
+    status.accepted = wp.int32(0)
+    status.failed = wp.int32(0)
+    status.iteration_limit = wp.int32(0)
+    solver_status[world] = status
+
+
+@wp.kernel
+def _update_solver_status_metrics(
+    r_p: wp.array[wp.float32],
+    r_d: wp.array[wp.float32],
+    r_c: wp.array[wp.float32],
+    solver_status: wp.array[LOXStatus],
+):
+    world = wp.tid()
+    status = solver_status[world]
+    status.r_p = r_p[world]
+    status.r_d = r_d[world]
+    status.r_c = r_c[world]
+    solver_status[world] = status
+
+
+@wp.kernel
+def _reset_solver_worlds_masked(
+    world_mask: wp.array[wp.bool],
+    world_active: wp.array[wp.bool],
+    world_converged: wp.array[wp.bool],
+    world_failed: wp.array[wp.bool],
+    world_iteration_limit: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+    world_accepted: wp.array[wp.bool],
+    world_status: wp.array[wp.int32],
+    solver_status: wp.array[LOXStatus],
+    contact_residual_max: wp.array[wp.float32],
+    limit_residual_max: wp.array[wp.float32],
+    friction_residual_max: wp.array[wp.float32],
+):
+    world = wp.tid()
+    if world_mask[world]:
+        world_active[world] = True
+        world_converged[world] = False
+        world_failed[world] = False
+        world_iteration_limit[world] = False
+        iteration_count[world] = 0
+        world_accepted[world] = False
+        world_status[world] = LOX_STATUS_ACTIVE
+        status = LOXStatus()
+        status.converged = wp.int32(0)
+        status.iterations = wp.int32(0)
+        status.r_p = wp.nan
+        status.r_d = wp.nan
+        status.r_c = wp.nan
+        status.accepted = wp.int32(0)
+        status.failed = wp.int32(0)
+        status.iteration_limit = wp.int32(0)
+        solver_status[world] = status
+        contact_residual_max[world] = 0.0
+        limit_residual_max[world] = 0.0
+        friction_residual_max[world] = 0.0
+
+
+@wp.kernel
+def _update_iteration_condition(
+    max_iterations: wp.int32,
+    world_active: wp.array[wp.bool],
+    iteration_count: wp.array[wp.int32],
+    condition: wp.array[wp.int32],
+):
+    world = wp.tid()
+    if world_active[world] and iteration_count[world] < max_iterations:
+        wp.atomic_max(condition, 0, 1)
+
+
+@wp.kernel
+def _mark_iteration_limit(
+    world_active: wp.array[wp.bool],
+    world_iteration_limit: wp.array[wp.bool],
+):
+    world = wp.tid()
+    if world_active[world]:
+        world_active[world] = False
+        world_iteration_limit[world] = True
+
+
+@wp.kernel
+def _initialize_body_velocity_guess(
+    body_block: wp.array[wp.int32],
+    body_world: wp.array[wp.int32],
+    inverse_mass: wp.array[wp.float32],
+    inverse_inertia_world: wp.array[wp.mat33f],
+    velocity_start: wp.array[vec6f],
+    external_wrench: wp.array[wp.spatial_vectorf],
+    gravity: wp.array[wp.vec3f],
+    time_step: wp.array[wp.float32],
+    fraction: float,
+    velocity_guess: wp.array[vec6f],
+):
+    body = wp.tid()
+    dt = time_step[body_world[body]]
+    guess = velocity_start[body]
+    if body_block[body] >= 0 and fraction > 0.0:
+        wrench = external_wrench[body]
+        inv_mass = inverse_mass[body]
+        linear_acceleration = inv_mass * wp.vec3f(wrench[0], wrench[1], wrench[2])
+        if inv_mass > 0.0:
+            linear_acceleration += gravity[body_world[body]]
+        angular_acceleration = inverse_inertia_world[body] @ wp.vec3f(wrench[3], wrench[4], wrench[5])
+        for axis in range(3):
+            guess[axis] += fraction * dt * linear_acceleration[axis]
+            guess[axis + 3] += fraction * dt * angular_acceleration[axis]
+    velocity_guess[body] = guess
+
+
+class LOXSolver:
+    """Run a fixed LOX splitting solve on one frozen linearization.
+
+    The caller owns collision detection, Jacobian construction, pose
+    integration, and nonlinear relinearization. This class owns the smooth
+    system update, weight construction, blocked dense LLT solve, unilateral
+    projections, convergence freezing, and output conversion for one such
+    linearization. A nonfailed world that reaches the iteration limit is
+    accepted using its last projected iterate.
+    """
+
+    def __init__(
+        self,
+        model: ModelKamino,
+        data: DataKamino,
+        jacobians: SparseSystemJacobians,
+        limits: LimitsKamino | None,
+        contacts: ContactsKamino | None,
+        config: LOXSolverConfig,
+        constraints: ConstraintStabilizationConfig,
+        rotation_correction: JointCorrectionMode,
+    ):
+        problem = None
+        if model.size.sum_of_num_bodies > 0:
+            problem = LOXProblem(
+                model=model,
+                data=data,
+                jacobians=jacobians,
+                limits=limits,
+                contacts=contacts,
+                eliminate_fixed_world_islands=config.eliminate_fixed_world_islands,
+                projection_method=config.projection_method,
+                rotation_correction=rotation_correction,
+                joint_proximal_relaxation=config.joint_proximal_relaxation,
+            )
+        if problem is None:
+            raise ValueError("LOX requires at least one rigid body.")
+        self._config = config
+        self.model = model
+        self._constraints = constraints
+        self.problem = problem
+        self.device = model.device
+        self.num_worlds = model.info.num_worlds
+        self.max_iterations = config.max_iterations
+        self.use_graph_conditionals = config.use_graph_conditionals
+        self.fixed_iterations = config.fixed_iterations
+        self.projection_iterations = config.projection_iterations
+        self.projection_method = config.projection_method
+        self.gauss_seidel_max_colors = config.gauss_seidel_max_colors
+        self._colored_gauss_seidel = None
+        self.inertial_warmstart_fraction = config.inertial_warmstart_fraction
+        self.position_tolerance = config.position_tolerance
+        self.rotation_tolerance = config.rotation_tolerance
+        self.velocity_tolerance = config.velocity_tolerance
+        self.weight_sigma = config.weight_sigma
+        self.weight_beta = config.weight_beta
+        self.joint_penalty_scale = wp.full(
+            self.num_worlds, config.joint_penalty_scale, dtype=wp.float32, device=self.device
+        )
+        self.joint_multiplier_projected_fraction = config.joint_multiplier_projected_fraction
+        self.joint_warmstart_factor = config.joint_warmstart_factor
+        self._bind_rigid_topology()
+        self.world_accepted = wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.world_status = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.status = wp.empty(self.num_worlds, dtype=LOXStatus, device=self.device)
+        wp.launch(_reset_solver_status, dim=self.num_worlds, outputs=[self.status], device=self.device)
+        self._iteration_condition = wp.zeros(1, dtype=wp.int32, device=self.device)
+        self._projection_theta = (
+            wp.ones(self.num_worlds, dtype=wp.float32, device=self.device)
+            if config.projection_method == "apgd"
+            else None
+        )
+        self._projection_beta = (
+            wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+            if config.projection_method == "apgd"
+            else None
+        )
+        self._projection_restart_dot = (
+            wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+            if config.projection_method == "apgd"
+            else None
+        )
+        self.has_bounded_effort = problem is not None and problem.has_bounded_effort
+        self._time_step: wp.array[wp.float32] | None = None
+        self._inverse_time_step: wp.array[wp.float32] | None = None
+        self._time_step_prepared = False
+
+    def _bind_rigid_topology(self) -> None:
+        """Bind solver views and scratch arrays to the current rigid topology."""
+        problem = self.problem
+        self.system = problem.system if problem is not None else None
+        self._has_dynamic_rigid_bodies = self.system is not None and bool(self.system.dynamic_bodies)
+        if self.system is not None:
+            self.system.selective_body_weights = self._config.selective_weights
+        self.splitting = problem.splitting if problem is not None else None
+        self.projected_twist = (
+            self.splitting.projected_twist
+            if self.splitting is not None
+            else wp.empty(0, dtype=vec6f, device=self.device)
+        )
+        self.world_active = (
+            self.splitting.world_active
+            if self.splitting is not None
+            else wp.ones(self.num_worlds, dtype=wp.bool, device=self.device)
+        )
+        self.world_converged = (
+            self.splitting.world_converged
+            if self.splitting is not None
+            else wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        )
+        self.world_failed = (
+            self.splitting.world_failed
+            if self.splitting is not None
+            else wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        )
+        self.world_iteration_limit = (
+            self.splitting.world_iteration_limit
+            if self.splitting is not None
+            else wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        )
+        self.iteration_count = (
+            self.splitting.iteration_count
+            if self.splitting is not None
+            else wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        )
+        self.contact_residual_max = (
+            problem.world_contact_residual_max
+            if problem is not None
+            else wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        )
+        self.limit_residual_max = (
+            problem.world_limit_residual_max
+            if problem is not None
+            else wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        )
+        self.friction_residual_max = (
+            problem.world_friction_residual_max
+            if problem is not None
+            else wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        )
+        rigid_body_count = problem.model.size.sum_of_num_bodies if problem is not None else 0
+        self._initial_twist = wp.zeros(rigid_body_count, dtype=vec6f, device=self.device)
+
+    def _make_structural_delassus(self) -> BatchedStructuralDelassus:
+        problem = self.problem
+        return BatchedStructuralDelassus(
+            body_system=self.system,
+            body_first_global=problem.structural_body_first_global,
+            body_second_global=problem.structural_body_second_global,
+            jacobian_first=problem.structural_jacobian_first,
+            jacobian_second=problem.structural_jacobian_second,
+        )
+
+    def rebuild_rigid_topology(self) -> None:
+        """Rebuild rigid allocations after dynamic-body classification changes."""
+        problem = self.problem
+        if problem is None:
+            return
+        problem.rebuild_dynamic_body_topology()
+        self._colored_gauss_seidel = None
+        self._bind_rigid_topology()
+        self.has_bounded_effort = problem.has_bounded_effort
+        self.reset()
+
+    def joint_penalty_scale_seed(
+        self,
+        time_step: float,
+    ) -> list[float]:
+        """Estimate and apply a timestep-aware structural ALM scale.
+
+        The estimate is the reciprocal of the discrete second-percentile
+        positive eigenvalue of the effective-mass-normalized structural
+        Delassus. Both the percentile and the resulting scale are evaluated
+        independently for each world. Systems with fewer than 50 positive
+        modes therefore retain the minimum-eigenvalue estimate. The smooth
+        operator excludes the body contact-consensus metric, which is a
+        separate splitting concern.
+
+        This operation prepares the LOX problem from the initial rigid state and
+        performs a one-time dense structural assembly and host eigensolve, so
+        it is intended for initialization rather than the captured simulation
+        loop.
+
+        Args:
+            time_step: Uniform simulation time step [s].
+
+        Returns:
+            The estimated dimensionless structural ALM penalty scale for each
+            world.
+        """
+        problem = self.problem
+        if problem is None:
+            raise ValueError("joint penalty scale seeding requires a LOX rigid-body system.")
+        problem.prepare_joint_penalty_scale_seed(time_step)
+        time_step_array = problem.model.time.dt
+        inverse_time_step = problem.model.time.inv_dt
+        if problem.structural_row_count == 0:
+            return self.joint_penalty_scale.numpy().tolist()
+
+        self.reset()
+        problem.begin_time_step(
+            time_step_array,
+            inverse_time_step,
+            limit_stabilization_fraction=self._constraints.beta,
+            contact_stabilization_fraction=self._constraints.gamma,
+            contact_dead_zone=self._constraints.delta,
+            impact_velocity_threshold=self._config.impact_velocity_threshold,
+            contact_recoverable_response=self._config.contact_recoverable_response,
+        )
+        try:
+            problem.body_linearization_twist.zero_()
+            problem.update(
+                time_step_array,
+                joint_penalty_scale=1.0,
+                linearization_twist=problem.body_linearization_twist,
+                assemble_structural_penalty=False,
+            )
+            wp.copy(self.system.weighted_matrix, self.system.smooth_matrix)
+            self.system.factorize()
+
+            structural_delassus = self._make_structural_delassus()
+            structural_delassus.assemble()
+            matrix_values = structural_delassus.matrix.numpy()
+            matrix_offsets = structural_delassus.info.mio.numpy()
+            vector_offsets = structural_delassus.info.vio.numpy()
+            vector_rows = structural_delassus.vector_row.numpy()
+            effective_mass = problem.structural_effective_mass.numpy()
+            matrix_epsilon = np.finfo(matrix_values.dtype).eps
+
+            seeds = self.joint_penalty_scale.numpy().astype(np.float64)
+            positive_by_world: list[list[np.ndarray]] = [[] for _ in range(problem.num_worlds)]
+            for component, row_count in enumerate(structural_delassus.component_row_counts):
+                if row_count == 0:
+                    continue
+                matrix_offset = int(matrix_offsets[component])
+                vector_offset = int(vector_offsets[component])
+                rows = vector_rows[vector_offset : vector_offset + row_count]
+                row_metric = effective_mass[rows].astype(np.float64)
+                metric_sqrt = np.sqrt(row_metric)
+                matrix = (
+                    matrix_values[matrix_offset : matrix_offset + row_count * row_count]
+                    .reshape(row_count, row_count)
+                    .astype(np.float64)
+                )
+                normalized = metric_sqrt[:, None] * matrix * metric_sqrt[None, :]
+                eigenvalues = np.linalg.eigvalsh(normalized)
+                positive_threshold = matrix_epsilon * row_count * float(eigenvalues[-1])
+                positive = eigenvalues[eigenvalues > positive_threshold]
+                if positive.size == 0:
+                    world = structural_delassus.component_world_host[component]
+                    raise RuntimeError(
+                        f"World {world} component {component} structural Delassus has no resolvable positive eigenvalue."
+                    )
+                positive_by_world[structural_delassus.component_world_host[component]].append(positive)
+
+            for world, component_eigenvalues in enumerate(positive_by_world):
+                if not component_eigenvalues:
+                    continue
+                positive = np.sort(np.concatenate(component_eigenvalues))
+                seed = 1.0 / _low_mode_eigenvalue(positive)
+                if not math.isfinite(seed) or seed > np.finfo(np.float32).max:
+                    raise RuntimeError(f"World {world} structural ALM penalty seed is not representable in float32.")
+                seeds[world] = seed
+
+            applied_seeds = seeds.astype(np.float32)
+            self.joint_penalty_scale.assign(applied_seeds)
+            return applied_seeds.tolist()
+        finally:
+            self.reset()
+
+    def solve_forward_dynamics(
+        self,
+        state_in: StateKamino,
+        state_out: StateKamino,
+        _contacts: object | None = None,
+    ) -> None:
+        """Solve one LOX forward-dynamics step from prepared Kamino data."""
+        if self.splitting is not None:
+            wp.copy(self.splitting.splitting_dual_impulse, state_in.lambda_w_i.view(dtype=vec6f))
+        constraints = self._constraints
+        time_step = self.model.time.dt
+        inverse_time_step = self.model.time.inv_dt
+        problem = self.problem
+        self.begin_time_step(
+            time_step,
+            inverse_time_step,
+            limit_stabilization_fraction=constraints.beta,
+            contact_stabilization_fraction=constraints.gamma,
+            contact_dead_zone=constraints.delta,
+            impact_velocity_threshold=self._config.impact_velocity_threshold,
+            contact_recoverable_response=self._config.contact_recoverable_response,
+        )
+
+        linearization_twist = None
+        if problem is not None:
+            problem.body_linearization_twist.zero_()
+            linearization_twist = problem.body_linearization_twist
+        self.solve(linearization_twist=linearization_twist, write_output=False)
+        if self.splitting is not None:
+            wp.copy(state_out.lambda_w_i.view(dtype=vec6f), self.splitting.splitting_dual_impulse)
+
+        if problem is not None:
+            problem.write_outputs(time_step, inverse_time_step, write_body_velocity=False)
+            model = problem.model
+            data = problem.data
+            update_body_wrenches(model.bodies, data.bodies)
+            # Expose the accepted LOX velocity as equivalent inputs to the
+            # selected Kamino integrator.
+            wp.launch(
+                _write_integrator_body_inputs,
+                dim=model.size.sum_of_num_bodies,
+                inputs=[
+                    problem.system.body_vector_index,
+                    model.bodies.wid,
+                    self.world_accepted,
+                    time_step,
+                    model.bodies.m_i,
+                    data.bodies.I_i,
+                    model.bodies.inv_m_i,
+                    model.bodies.inv_i_I_i,
+                    model.gravity.vector,
+                    problem.body_velocity_begin,
+                    self.projected_twist,
+                ],
+                outputs=[data.bodies.w_i, data.bodies.u_i],
+                device=model.device,
+            )
+
+    def notify_model_changed(self, flags: ModelFlags | int) -> None:
+        """Refresh or rebuild the LOX problem after model changes."""
+        problem = self.problem
+        if problem is None:
+            return
+        if flags & ModelFlags.BODY_PROPERTIES and problem.dynamic_body_topology_changed():
+            self.rebuild_rigid_topology()
+
+    def validate_model_changed(self) -> None:
+        """Validate LOX-specific values derived from the Newton model."""
+        # Host-side validation cannot synchronize aliased Newton arrays while a
+        # CUDA graph is being captured. The same topology was validated when the
+        # solver was built; captured property updates retain that topology.
+        if self.device.is_cuda and self.device.is_capturing:
+            return
+        if self.problem is not None:
+            self.problem.validate_model_changed()
+
+    def reset(
+        self,
+        problem: DualProblem | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
+    ) -> None:
+        """Clear structural/splitting warm starts and per-world diagnostics."""
+        del problem
+        if world_mask is not None:
+            if world_mask.shape != (self.num_worlds,) or world_mask.dtype != wp.bool:
+                raise ValueError(f"world_mask must have shape ({self.num_worlds},) and dtype bool.")
+            if world_mask.device != self.device:
+                raise ValueError(f"world_mask must be allocated on {self.device}, found {world_mask.device}.")
+        if self.splitting is not None:
+            self.splitting.reset(world_mask=world_mask)
+            self.problem.reset_structural_multipliers(world_mask=world_mask)
+            if self.has_bounded_effort:
+                self.problem.reset_effort_counters(world_mask=world_mask)
+            self.problem.projection_status.zero_()
+            self.problem.contact_residual.zero_()
+            self.problem.limit_residual.zero_()
+            self.problem.friction_residual.zero_()
+            self.problem.reset_friction_reactions(world_mask=world_mask)
+        elif world_mask is None:
+            self.world_active.fill_(True)
+            self.world_converged.zero_()
+            self.world_failed.zero_()
+            self.world_iteration_limit.zero_()
+            self.iteration_count.zero_()
+        if world_mask is None:
+            self.world_accepted.zero_()
+            self.world_status.fill_(LOX_STATUS_ACTIVE)
+            wp.launch(_reset_solver_status, dim=self.num_worlds, outputs=[self.status], device=self.device)
+            self.contact_residual_max.zero_()
+            self.limit_residual_max.zero_()
+            self.friction_residual_max.zero_()
+        else:
+            wp.launch(
+                _reset_solver_worlds_masked,
+                dim=self.num_worlds,
+                inputs=[world_mask],
+                outputs=[
+                    self.world_active,
+                    self.world_converged,
+                    self.world_failed,
+                    self.world_iteration_limit,
+                    self.iteration_count,
+                    self.world_accepted,
+                    self.world_status,
+                    self.status,
+                    self.contact_residual_max,
+                    self.limit_residual_max,
+                    self.friction_residual_max,
+                ],
+                device=self.device,
+            )
+        self._initial_twist.zero_()
+        self._time_step_prepared = False
+
+    def update_status_metrics(self, metrics: SolutionMetricsData) -> None:
+        """Populate terminal NCP residuals from the optional metrics evaluation."""
+        wp.launch(
+            _update_solver_status_metrics,
+            dim=self.num_worlds,
+            inputs=[metrics.r_ncp_primal, metrics.r_ncp_dual, metrics.r_ncp_compl],
+            outputs=[self.status],
+            device=self.device,
+        )
+
+    def begin_time_step(
+        self,
+        time_step: wp.array[wp.float32],
+        inverse_time_step: wp.array[wp.float32],
+        *,
+        limit_stabilization_fraction: float,
+        contact_stabilization_fraction: float,
+        contact_dead_zone: float,
+        impact_velocity_threshold: float,
+        contact_recoverable_response: bool,
+        reset_dual: bool = False,
+    ) -> None:
+        """Freeze inertial velocities and import damped constraint warm starts.
+
+        The body consensus warm start is loaded from the Newton input state as
+        the generalized impulse ``W u`` and converted back to the scaled dual
+        after the solve builds its current body weight.
+        """
+        self._time_step = time_step
+        self._inverse_time_step = inverse_time_step
+        if self.problem is not None:
+            self.problem.scale_structural_multipliers(self.joint_warmstart_factor)
+            self.problem.begin_time_step(
+                time_step,
+                inverse_time_step,
+                limit_stabilization_fraction=limit_stabilization_fraction,
+                contact_stabilization_fraction=contact_stabilization_fraction,
+                contact_dead_zone=contact_dead_zone,
+                impact_velocity_threshold=impact_velocity_threshold,
+                contact_recoverable_response=contact_recoverable_response,
+            )
+            wp.launch(
+                _initialize_body_velocity_guess,
+                dim=self.problem.model.size.sum_of_num_bodies,
+                inputs=[
+                    self.system.body_block,
+                    self.problem.model.bodies.wid,
+                    self.problem.model.bodies.inv_m_i,
+                    self.problem.data.bodies.inv_I_i,
+                    self.problem.body_velocity_begin,
+                    self.problem.data.bodies.w_e_i,
+                    self.problem.model.gravity.vector,
+                    time_step,
+                    self.inertial_warmstart_fraction,
+                ],
+                outputs=[self._initial_twist],
+                device=self.device,
+            )
+            if reset_dual:
+                self.splitting.splitting_dual.zero_()
+                self.splitting.splitting_dual_impulse.zero_()
+        self._time_step_prepared = True
+
+    def _prepare_colored_gauss_seidel_projection(self) -> None:
+        projection_problem = self.problem
+        if self._colored_gauss_seidel is None or self._colored_gauss_seidel.problem is not projection_problem:
+            self._colored_gauss_seidel = ColoredGaussSeidelProjection(
+                projection_problem,
+                self.gauss_seidel_max_colors,
+            )
+        prepared_status = self.problem.world_jacobi_projection_status
+        inverse_weight = self.system.inverse_weight
+        self._colored_gauss_seidel.prepare(inverse_weight, prepared_status)
+
+    def _prepare_body_space_projection(self) -> None:
+        problem = self.problem
+        if not self._has_dynamic_rigid_bodies:
+            problem.projection_status.fill_(PROJECTION_STATUS_VALID)
+            return
+        prepare_physical_projection_data(
+            problem.friction_world,
+            problem.friction_local,
+            problem.world_friction_count,
+            problem.friction_body_first,
+            problem.friction_body_second,
+            problem.friction_jacobian_first,
+            problem.friction_jacobian_second,
+            problem.contact_world,
+            problem.contact_local,
+            problem.world_contact_count,
+            problem.contact_body_first,
+            problem.contact_body_second,
+            problem.contact_jacobian_first,
+            problem.contact_jacobian_second,
+            problem.contact_bias,
+            problem.contact_friction,
+            problem.limit_world,
+            problem.limit_local,
+            problem.world_limit_count,
+            problem.limit_body_first,
+            problem.limit_body_second,
+            problem.limit_jacobian_first,
+            problem.limit_jacobian_second,
+            self.system.inverse_weight,
+            problem.friction_physical_delassus,
+            problem.contact_physical_delassus,
+            problem.contact_prepared_delassus,
+            problem.limit_physical_delassus,
+            problem.world_physical_projection_status,
+        )
+        if self.projection_method in ("jacobi", "apgd") or (
+            self.projection_method == "gauss_seidel" and self.gauss_seidel_max_colors == 1
+        ):
+            prepare_jacobi_projection_data(
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                problem.friction_jacobian_first,
+                problem.friction_jacobian_second,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                problem.contact_jacobian_first,
+                problem.contact_jacobian_second,
+                problem.contact_bias,
+                problem.contact_friction,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                problem.limit_jacobian_first,
+                problem.limit_jacobian_second,
+                problem.body_constraint_count,
+                problem.static_body_constraint_count,
+                self.system.inverse_weight,
+                problem.friction_projection_delassus,
+                problem.contact_projection_delassus,
+                problem.limit_projection_delassus,
+                problem.world_jacobi_projection_status,
+            )
+        elif self.projection_method == "gauss_seidel" and self.gauss_seidel_max_colors > 1:
+            self._prepare_colored_gauss_seidel_projection()
+
+    def _project_body_space_constraints(self) -> None:
+        if not self._has_dynamic_rigid_bodies:
+            return
+        problem = self.problem
+        splitting = self.splitting
+        if self.projection_method in ("jacobi", "apgd") or (
+            self.projection_method == "gauss_seidel" and self.gauss_seidel_max_colors == 1
+        ):
+            project_constraints_jacobi(
+                self.projection_iterations,
+                splitting.world_active,
+                splitting.body_world,
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                problem.friction_jacobian_first,
+                problem.friction_jacobian_second,
+                problem.friction_impulse_bound,
+                problem.friction_projection_delassus,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                problem.contact_jacobian_first,
+                problem.contact_jacobian_second,
+                problem.contact_bias,
+                problem.contact_friction,
+                problem.contact_projection_delassus,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                problem.limit_jacobian_first,
+                problem.limit_jacobian_second,
+                problem.limit_bias,
+                problem.limit_projection_delassus,
+                self.system.inverse_weight,
+                splitting.projected_twist,
+                problem.projection_twist_delta,
+                problem.contact_reaction,
+                problem.limit_reaction,
+                problem.friction_reaction,
+                problem.world_jacobi_projection_status,
+                problem.projection_status,
+                world_body_offset=problem.model.info.bodies_offset,
+                world_body_count=problem.model.info.num_bodies,
+                world_friction_offset=problem.world_friction_offset,
+                world_contact_offset=problem.world_contact_offset,
+                world_limit_offset=problem.world_limit_offset,
+                accelerated=self.projection_method == "apgd",
+                theta=self._projection_theta,
+                beta=self._projection_beta,
+                restart_dot=self._projection_restart_dot,
+                friction_trial=problem.friction_acceleration_trial,
+                friction_previous=problem.friction_acceleration_previous,
+                contact_trial=problem.contact_acceleration_trial,
+                contact_previous=problem.contact_acceleration_previous,
+                limit_trial=problem.limit_acceleration_trial,
+                limit_previous=problem.limit_acceleration_previous,
+            )
+        elif self.projection_method == "gauss_seidel" and self.gauss_seidel_max_colors > 1:
+            self._colored_gauss_seidel.project(
+                self.projection_iterations,
+                splitting.world_active,
+                splitting.body_world,
+                self.system.inverse_weight,
+                splitting.projected_twist,
+                problem.projection_twist_delta,
+                problem.world_jacobi_projection_status,
+                problem.projection_status,
+            )
+
+    def _update_conditional_iteration(self) -> None:
+        self._iteration_condition.zero_()
+        wp.launch(
+            _update_iteration_condition,
+            dim=self.num_worlds,
+            inputs=[
+                self.max_iterations,
+                self.world_active,
+                self.iteration_count,
+            ],
+            outputs=[self._iteration_condition],
+            device=self.device,
+        )
+
+    def _prepare_body_space_candidate(self) -> None:
+        """Solve and prepare the rigid candidate without unilateral projection."""
+        problem = self.problem
+        system = self.system
+        splitting = self.splitting
+        if self.has_bounded_effort:
+            problem.promote_effort_counters(splitting.world_active)
+            system.build_candidate_right_hand_side_with_effort(
+                splitting.projected_twist,
+                splitting.splitting_dual,
+                problem.body_effort_offset,
+                problem.body_effort_index,
+                problem.body_effort_side,
+                problem.effort_dynamic_row_index,
+                problem.dynamic_jacobian_first,
+                problem.dynamic_jacobian_second,
+                problem.effort_counter_applied,
+            )
+        else:
+            system.build_candidate_right_hand_side(splitting.projected_twist, splitting.splitting_dual)
+        system.solve_candidate(problem.body_velocity_begin)
+        splitting.prepare_projection(system.body_solution)
+
+    def _finish_body_space_iteration(
+        self, time_step: wp.array[wp.float32], linearization_twist: wp.array[vec6f]
+    ) -> None:
+        """Update structural state and finish the rigid splitting iteration."""
+        problem = self.problem
+        splitting = self.splitting
+        problem.update_structural_multipliers_from_twist(
+            time_step,
+            min(self.position_tolerance, self.rotation_tolerance),
+            linearization_twist,
+            splitting.global_twist,
+            splitting.projected_twist,
+            splitting.world_active,
+            projected_fraction=self.joint_multiplier_projected_fraction,
+        )
+        if self.has_bounded_effort:
+            problem.update_effort_counters(
+                time_step,
+                self.velocity_tolerance,
+                splitting.projected_twist,
+                splitting.world_active,
+            )
+        if not self.fixed_iterations:
+            problem.evaluate_lagged_velocity_consistency(
+                self.velocity_tolerance,
+                splitting.global_twist,
+                splitting.projected_twist_previous,
+                splitting.world_active,
+            )
+            splitting.finish_iteration(
+                problem.projection_status,
+                time_step,
+                self.position_tolerance,
+                self.rotation_tolerance,
+                self.velocity_tolerance,
+                effort_residual=(problem.world_effort_residual_max if self.has_bounded_effort else None),
+                structural_residual=problem.world_structural_residual,
+                projected_structural_residual=problem.world_projected_structural_residual,
+                lagged_velocity_residual=problem.world_lagged_velocity_residual,
+                lagged_velocity_required=problem.world_lagged_velocity_required,
+            )
+        else:
+            splitting.finish_fixed_iteration(
+                problem.projection_status,
+            )
+
+    def _body_space_iteration(
+        self,
+        time_step: wp.array[wp.float32],
+        linearization_twist: wp.array[vec6f],
+        conditional: bool,
+    ) -> None:
+        self._prepare_body_space_candidate()
+        self._project_body_space_constraints()
+        self._finish_body_space_iteration(time_step, linearization_twist)
+        if conditional:
+            self._update_conditional_iteration()
+
+    def solve(
+        self,
+        *,
+        initial_twist: wp.array[vec6f] | None = None,
+        linearization_twist: wp.array[vec6f] | None = None,
+        write_output: bool = True,
+    ) -> None:
+        """Assemble and solve one frozen-contact smooth linearization.
+
+        Args:
+            initial_twist: Optional initial projected body twist.
+            linearization_twist: Optional body twist used to linearize joint constraints.
+            write_output: Whether to write the solution to the Kamino containers.
+        """
+        if not self._time_step_prepared:
+            raise RuntimeError("begin_time_step() must be called before solving LOX.")
+        time_step = self._time_step
+        inverse_time_step = self._inverse_time_step
+        if time_step is None or inverse_time_step is None:
+            raise RuntimeError("LOX per-world timestep arrays are not prepared.")
+        if self.splitting is not None:
+            if initial_twist is None:
+                initial_twist = self._initial_twist
+            self.splitting.begin(initial_twist, reset_dual=False)
+        self.world_accepted.zero_()
+        self.world_status.fill_(LOX_STATUS_ACTIVE)
+        if self.problem is not None:
+            self.problem.contact_residual.zero_()
+            self.problem.limit_residual.zero_()
+            self.problem.friction_residual.zero_()
+        self.contact_residual_max.zero_()
+        self.limit_residual_max.zero_()
+        self.friction_residual_max.zero_()
+        problem = self.problem
+        system = self.system
+        splitting = self.splitting
+        if problem is not None:
+            problem.update(
+                time_step,
+                joint_penalty_scale=self.joint_penalty_scale,
+                linearization_twist=linearization_twist,
+                assemble_structural_penalty=True,
+            )
+            if linearization_twist is None:
+                linearization_twist = problem.body_linearization_twist
+            system.build_weighted_matrix(
+                body_has_unilateral=problem.body_has_unilateral,
+                sigma=self.weight_sigma,
+                beta=self.weight_beta,
+            )
+            splitting.restore_dual_from_impulse(system.inverse_weight, problem.body_has_unilateral)
+            system.factorize()
+            self._prepare_body_space_projection()
+
+        use_conditional_loop = (
+            not self.fixed_iterations
+            and self.use_graph_conditionals
+            and (not self.device.is_cuda or not self.device.is_capturing or wp.is_conditional_graph_supported())
+        )
+        if use_conditional_loop:
+            self._iteration_condition.fill_(1)
+            wp.capture_while(
+                self._iteration_condition,
+                self._body_space_iteration,
+                time_step=time_step,
+                linearization_twist=linearization_twist,
+                conditional=True,
+            )
+        else:
+            for _iteration in range(self.max_iterations):
+                self._body_space_iteration(time_step, linearization_twist, conditional=False)
+
+        if splitting is not None:
+            splitting.store_dual_impulse(system.weight, problem.body_has_unilateral)
+            splitting.mark_iteration_limit()
+        else:
+            wp.launch(
+                _mark_iteration_limit,
+                dim=self.num_worlds,
+                inputs=[],
+                outputs=[self.world_active, self.world_iteration_limit],
+                device=self.device,
+            )
+        wp.launch(
+            _finalize_world_status,
+            dim=self.num_worlds,
+            inputs=[self.world_converged, self.world_failed, self.world_iteration_limit, self.iteration_count],
+            outputs=[self.world_accepted, self.world_status, self.status],
+            device=self.device,
+        )
+        if problem is not None:
+            compute_projection_residuals(
+                self.world_accepted,
+                problem.projection_status,
+                problem.friction_world,
+                problem.friction_local,
+                problem.world_friction_count,
+                problem.friction_body_first,
+                problem.friction_body_second,
+                problem.friction_jacobian_first,
+                problem.friction_jacobian_second,
+                problem.friction_impulse_bound,
+                problem.friction_reaction,
+                problem.friction_physical_delassus,
+                problem.contact_world,
+                problem.contact_local,
+                problem.world_contact_count,
+                problem.contact_body_first,
+                problem.contact_body_second,
+                problem.contact_jacobian_first,
+                problem.contact_jacobian_second,
+                problem.contact_bias,
+                problem.contact_friction,
+                problem.contact_reaction,
+                problem.contact_physical_delassus,
+                problem.limit_world,
+                problem.limit_local,
+                problem.world_limit_count,
+                problem.limit_body_first,
+                problem.limit_body_second,
+                problem.limit_jacobian_first,
+                problem.limit_jacobian_second,
+                problem.limit_bias,
+                problem.limit_reaction,
+                problem.limit_physical_delassus,
+                splitting.projected_twist,
+                problem.friction_velocity,
+                problem.contact_velocity,
+                problem.limit_velocity,
+                problem.contact_residual,
+                problem.limit_residual,
+                problem.friction_residual,
+                problem.world_contact_residual_max,
+                problem.world_limit_residual_max,
+                problem.world_friction_residual_max,
+            )
+            if write_output:
+                problem.write_outputs(time_step, inverse_time_step, body_velocity=splitting.projected_twist)

--- a/newton/_src/solvers/kamino/_src/solvers/lox/system.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/system.py
@@ -1,0 +1,1157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Block-diagonal primal body systems for the LOX backend.
+
+This module owns only solver-internal, contact-free body-space assembly. Each
+factor block is one connected dynamic-body component and each dynamic body
+contributes six linear-first velocity unknowns. Prescribed bodies retain their
+global packed body indices but map to ``-1`` in the matrix layout.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import lru_cache
+
+import numpy as np
+import warp as wp
+
+from ...core.types import mat66f, vec6f
+from ...linalg import DenseLinearOperatorData, DenseSquareMultiLinearInfo, HybridLLTBlockedSolver
+from .weight import (
+    BODY_WEIGHT_STATUS_VALID,
+    compute_body_weight_mass_proportional,
+)
+
+__all__ = ["BatchedPrimalBodySystem"]
+
+wp.set_module_options({"enable_backward": False})
+
+_RCM_MIN_DIMENSION = 256
+
+
+@wp.struct
+class PrimalRowContribution:
+    """Matrix and right-hand-side contribution of one body-space term."""
+
+    matrix: mat66f
+    """Symmetric contribution to the body-space operator."""
+    right_hand_side: vec6f
+    """Contribution to the body-space right-hand side."""
+
+
+@wp.func
+def make_spatial_mass_matrix(mass: wp.float32, inertia_world: wp.mat33f) -> mat66f:
+    """Construct a linear-first spatial mass matrix about the center of mass.
+
+    Args:
+        mass: Body mass [kg].
+        inertia_world: World-space inertia about the center of mass [kg m^2].
+
+    Returns:
+        ``diag(mass I_3, inertia_world)``.
+    """
+    matrix = mat66f(0.0)
+    for index in range(3):
+        matrix[index, index] = mass
+    for row in range(3):
+        for col in range(3):
+            matrix[row + 3, col + 3] = inertia_world[row, col]
+    return matrix
+
+
+@wp.func
+def compute_body_explicit_wrench(
+    mass: wp.float32,
+    inertia_world: wp.mat33f,
+    velocity_previous: vec6f,
+    external_wrench: vec6f,
+    actuation_wrench: vec6f,
+    gravity: wp.vec3f,
+) -> vec6f:
+    """Combine explicit body forces in world coordinates.
+
+    Args:
+        mass: Body mass [kg].
+        inertia_world: World-space inertia about the center of mass [kg m^2].
+        velocity_previous: Begin-of-step linear-first body twist [m/s, rad/s].
+        external_wrench: External body wrench excluding gravity [N, N m].
+        actuation_wrench: Joint-actuation body wrench [N, N m].
+        gravity: World-space gravitational acceleration [m/s^2].
+
+    Returns:
+        Explicit force and torque, including gravity and the gyroscopic torque [N, N m].
+    """
+    result = external_wrench + actuation_wrench
+    for index in range(3):
+        result[index] += mass * gravity[index]
+
+    angular_velocity = wp.vec3f(velocity_previous[3], velocity_previous[4], velocity_previous[5])
+    gyroscopic_torque = -wp.cross(angular_velocity, inertia_world @ angular_velocity)
+    for index in range(3):
+        result[index + 3] += gyroscopic_torque[index]
+    return result
+
+
+@wp.func
+def compute_body_inertial_system(
+    mass: wp.float32,
+    inertia_world: wp.mat33f,
+    velocity_previous: vec6f,
+    force_explicit: vec6f,
+    time_step: wp.float32,
+) -> PrimalRowContribution:
+    """Compute the inertial operator and explicit-force right-hand side.
+
+    Args:
+        mass: Body mass [kg].
+        inertia_world: World-space inertia about the center of mass [kg m^2].
+        velocity_previous: Begin-of-step linear-first body twist [m/s, rad/s].
+        force_explicit: Explicit body wrench [N, N m].
+        time_step: Time step [s].
+
+    Returns:
+        The mass matrix and ``M v_previous + h force_explicit``.
+    """
+    result = PrimalRowContribution()
+    result.matrix = make_spatial_mass_matrix(mass, inertia_world)
+    result.right_hand_side = result.matrix @ velocity_previous + time_step * force_explicit
+    return result
+
+
+@wp.func
+def compute_dynamic_joint_row(
+    jacobian: vec6f,
+    effective_inertia: wp.float32,
+    free_velocity: wp.float32,
+) -> PrimalRowContribution:
+    """Eliminate one implicit joint-dynamics coordinate into body space.
+
+    The joint equation is ``effective_inertia * dq = h_joint`` with
+    ``free_velocity = h_joint / effective_inertia`` and ``dq = J v``.
+
+    Args:
+        jacobian: Linear-first joint velocity Jacobian row.
+        effective_inertia: Positive implicit joint inertia.
+        free_velocity: Implicit joint free velocity.
+
+    Returns:
+        ``effective_inertia J^T J`` and
+        ``effective_inertia free_velocity J^T``.
+    """
+    result = PrimalRowContribution()
+    result.matrix = effective_inertia * wp.outer(jacobian, jacobian)
+    result.right_hand_side = effective_inertia * free_velocity * jacobian
+    return result
+
+
+@wp.func
+def compute_augmented_joint_row(
+    jacobian: vec6f,
+    residual: wp.float32,
+    multiplier: wp.float32,
+    penalty: wp.float32,
+    time_step: wp.float32,
+    linearization_velocity: wp.float32,
+) -> PrimalRowContribution:
+    """Linearize one structural joint row with augmented Lagrangian forces.
+
+    For ``C(q(v)) ~= residual + h J (v - v_k)``, this returns the terms in
+
+    ``(M + h^2 penalty J^T J) v``
+    ``= f - h J^T (multiplier + penalty residual)``
+    ``+ h^2 penalty J^T J v_k``.
+
+    Args:
+        jacobian: Linear-first structural joint Jacobian row.
+        residual: Current joint position residual [m or rad].
+        multiplier: Persistent structural multiplier [N or N m].
+        penalty: Positive augmented penalty [N/m or N m/rad].
+        time_step: Time step [s].
+        linearization_velocity: Row velocity ``J v_k`` at the linearization
+            twist [m/s or rad/s]. Pass zero for the first linearly implicit
+            assembly about the begin-step pose.
+
+    Returns:
+        The structural matrix and right-hand-side contributions.
+    """
+    result = PrimalRowContribution()
+    result.matrix = time_step * time_step * penalty * wp.outer(jacobian, jacobian)
+    result.right_hand_side = (
+        -time_step * (multiplier + penalty * residual) + time_step * time_step * penalty * linearization_velocity
+    ) * jacobian
+    return result
+
+
+@lru_cache(maxsize=32)
+def _expand_body_symbolic_adjacency(
+    body_count: int,
+    body_edges: tuple[tuple[int, int], ...],
+) -> tuple[tuple[int, ...], ...]:
+    """Expand a reusable body graph into its six-DoF scalar adjacency."""
+    body_adjacency = np.eye(body_count, dtype=bool)
+    if body_edges:
+        edges = np.asarray(body_edges, dtype=np.int32)
+        body_adjacency[edges[:, 0], edges[:, 1]] = True
+        body_adjacency[edges[:, 1], edges[:, 0]] = True
+    scalar_adjacency = np.kron(body_adjacency, np.ones((6, 6), dtype=bool))
+    np.fill_diagonal(scalar_adjacency, False)
+    return tuple(tuple(np.flatnonzero(row).tolist()) for row in scalar_adjacency)
+
+
+@wp.kernel
+def _mark_blocks_with_unilaterals(
+    body_component: wp.array[wp.int32],
+    body_has_unilateral: wp.array[wp.int32],
+    block_has_unilateral: wp.array[wp.int32],
+):
+    body = wp.tid()
+    component = body_component[body]
+    if component >= 0 and body_has_unilateral[body] != 0:
+        wp.atomic_max(block_has_unilateral, component, 1)
+
+
+@wp.kernel
+def _enable_bodies_in_weighted_blocks(
+    body_component: wp.array[wp.int32],
+    block_has_unilateral: wp.array[wp.int32],
+    body_weight_enabled: wp.array[wp.int32],
+):
+    body = wp.tid()
+    component = body_component[body]
+    body_weight_enabled[body] = wp.where(component >= 0 and block_has_unilateral[component] != 0, 1, 0)
+
+
+@wp.func
+def _matrix_index(
+    matrix_offset: wp.int32,
+    dimension: wp.int32,
+    row: wp.int32,
+    col: wp.int32,
+) -> wp.int32:
+    return matrix_offset + dimension * row + col
+
+
+@wp.func
+def _atomic_add_body_vector(
+    vector: wp.array[wp.float32],
+    vector_offset: wp.int32,
+    body: wp.int32,
+    value: vec6f,
+):
+    body_offset = vector_offset + 6 * body
+    for row in range(6):
+        wp.atomic_add(vector, body_offset + row, value[row])
+
+
+@wp.func
+def _atomic_add_body_block(
+    matrix: wp.array[wp.float32],
+    matrix_offset: wp.int32,
+    dimension: wp.int32,
+    row_body: wp.int32,
+    col_body: wp.int32,
+    value: mat66f,
+):
+    row_offset = 6 * row_body
+    col_offset = 6 * col_body
+    for row in range(6):
+        for col in range(6):
+            index = _matrix_index(matrix_offset, dimension, row_offset + row, col_offset + col)
+            wp.atomic_add(matrix, index, value[row, col])
+
+
+@wp.kernel
+def _unpack_body_solution(
+    body_vector_index: wp.array[wp.int32],
+    packed_solution: wp.array[wp.float32],
+    prescribed_twist: wp.array[vec6f],
+    body_solution: wp.array[vec6f],
+):
+    body = wp.tid()
+    source_offset = body_vector_index[body]
+    value = vec6f(0.0)
+    if prescribed_twist:
+        value = prescribed_twist[body]
+    if source_offset >= 0:
+        for index in range(6):
+            value[index] = packed_solution[source_offset + index]
+    body_solution[body] = value
+
+
+@wp.kernel
+def _assemble_body_inertial_systems(
+    body_world: wp.array[wp.int32],
+    body_block: wp.array[wp.int32],
+    body_local: wp.array[wp.int32],
+    dimensions: wp.array[wp.int32],
+    matrix_offsets: wp.array[wp.int32],
+    vector_offsets: wp.array[wp.int32],
+    mass: wp.array[wp.float32],
+    inertia_world: wp.array[wp.mat33f],
+    velocity_previous: wp.array[vec6f],
+    evaluation_velocity: wp.array[vec6f],
+    external_wrench: wp.array[vec6f],
+    actuation_wrench: wp.array[vec6f],
+    gravity: wp.array[wp.vec3f],
+    time_step: wp.array[wp.float32],
+    matrix: wp.array[wp.float32],
+    right_hand_side: wp.array[wp.float32],
+):
+    body = wp.tid()
+    dt = time_step[body_world[body]]
+    block = body_block[body]
+    if block < 0:
+        return
+    local_body = body_local[body]
+    dimension = dimensions[block]
+    matrix_offset = matrix_offsets[block]
+    vector_offset = vector_offsets[block]
+    force_explicit = compute_body_explicit_wrench(
+        mass[body],
+        inertia_world[body],
+        evaluation_velocity[body],
+        external_wrench[body],
+        actuation_wrench[body],
+        gravity[body_world[body]],
+    )
+    contribution = compute_body_inertial_system(
+        mass[body], inertia_world[body], velocity_previous[body], force_explicit, dt
+    )
+
+    body_offset = 6 * local_body
+    for row in range(6):
+        right_hand_side[vector_offset + body_offset + row] = contribution.right_hand_side[row]
+        for col in range(6):
+            matrix[_matrix_index(matrix_offset, dimension, body_offset + row, body_offset + col)] = contribution.matrix[
+                row, col
+            ]
+
+
+@wp.kernel
+def _assemble_dynamic_joint_rows(
+    dimensions: wp.array[wp.int32],
+    matrix_offsets: wp.array[wp.int32],
+    vector_offsets: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    body_block: wp.array[wp.int32],
+    body_local: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    effective_inertia: wp.array[wp.float32],
+    free_velocity: wp.array[wp.float32],
+    prescribed_twist: wp.array[vec6f],
+    matrix: wp.array[wp.float32],
+    right_hand_side: wp.array[wp.float32],
+):
+    joint_row = wp.tid()
+    first = body_first[joint_row]
+    second = body_second[joint_row]
+    body_count = body_block.shape[0]
+    if effective_inertia[joint_row] <= 0.0 or (first < 0 and second < 0) or first >= body_count or second >= body_count:
+        return
+
+    first_local = body_local[first] if first >= 0 else -1
+    second_local = body_local[second] if second >= 0 else -1
+    if first_local < 0 and second_local < 0:
+        return
+    block = body_block[first] if first_local >= 0 else body_block[second]
+    if block < 0 or block >= dimensions.shape[0] or (second_local >= 0 and body_block[second] != block):
+        return
+    dimension = dimensions[block]
+
+    matrix_offset = matrix_offsets[block]
+    vector_offset = vector_offsets[block]
+    inertia = effective_inertia[joint_row]
+    velocity = free_velocity[joint_row]
+    first_jacobian = jacobian_first[joint_row]
+    second_jacobian = jacobian_second[joint_row]
+    if prescribed_twist and first >= 0 and first_local < 0:
+        velocity -= wp.dot(first_jacobian, prescribed_twist[first])
+    if prescribed_twist and second >= 0 and second_local < 0:
+        velocity -= wp.dot(second_jacobian, prescribed_twist[second])
+
+    if first_local >= 0:
+        first_contribution = compute_dynamic_joint_row(first_jacobian, inertia, velocity)
+        _atomic_add_body_block(matrix, matrix_offset, dimension, first_local, first_local, first_contribution.matrix)
+        _atomic_add_body_vector(right_hand_side, vector_offset, first_local, first_contribution.right_hand_side)
+    if second_local >= 0:
+        second_contribution = compute_dynamic_joint_row(second_jacobian, inertia, velocity)
+        _atomic_add_body_block(matrix, matrix_offset, dimension, second_local, second_local, second_contribution.matrix)
+        _atomic_add_body_vector(right_hand_side, vector_offset, second_local, second_contribution.right_hand_side)
+    if first_local >= 0 and second_local >= 0:
+        _atomic_add_body_block(
+            matrix,
+            matrix_offset,
+            dimension,
+            first_local,
+            second_local,
+            wp.outer(inertia * first_jacobian, second_jacobian),
+        )
+        _atomic_add_body_block(
+            matrix,
+            matrix_offset,
+            dimension,
+            second_local,
+            first_local,
+            wp.outer(inertia * second_jacobian, first_jacobian),
+        )
+
+
+@wp.kernel
+def _assemble_structural_joint_rows(
+    dimensions: wp.array[wp.int32],
+    matrix_offsets: wp.array[wp.int32],
+    vector_offsets: wp.array[wp.int32],
+    row_world: wp.array[wp.int32],
+    body_first: wp.array[wp.int32],
+    body_second: wp.array[wp.int32],
+    body_block: wp.array[wp.int32],
+    body_local: wp.array[wp.int32],
+    jacobian_first: wp.array[vec6f],
+    jacobian_second: wp.array[vec6f],
+    residual: wp.array[wp.float32],
+    reaction: wp.array[wp.float32],
+    effective_mass: wp.array[wp.float32],
+    linearization_twist: wp.array[vec6f],
+    prescribed_twist: wp.array[vec6f],
+    time_step: wp.array[wp.float32],
+    joint_penalty_scale: wp.array[wp.float32],
+    penalty: wp.array[wp.float32],
+    matrix: wp.array[wp.float32],
+    right_hand_side: wp.array[wp.float32],
+):
+    joint_row = wp.tid()
+    world = row_world[joint_row]
+    if world < 0 or world >= joint_penalty_scale.shape[0]:
+        penalty[joint_row] = 0.0
+        return
+    dt = time_step[world]
+    first = body_first[joint_row]
+    second = body_second[joint_row]
+    body_count = body_block.shape[0]
+    world_penalty_scale = joint_penalty_scale[world]
+    if (
+        dt <= 0.0
+        or world_penalty_scale <= 0.0
+        or effective_mass[joint_row] <= 0.0
+        or (first < 0 and second < 0)
+        or first >= body_count
+        or second >= body_count
+    ):
+        penalty[joint_row] = 0.0
+        return
+
+    first_local = body_local[first] if first >= 0 else -1
+    second_local = body_local[second] if second >= 0 else -1
+    if first_local < 0 and second_local < 0:
+        penalty[joint_row] = 0.0
+        return
+    block = body_block[first] if first_local >= 0 else body_block[second]
+    if block < 0 or block >= dimensions.shape[0] or (second_local >= 0 and body_block[second] != block):
+        penalty[joint_row] = 0.0
+        return
+    dimension = dimensions[block]
+
+    row_penalty = world_penalty_scale * effective_mass[joint_row] / (dt * dt)
+    penalty[joint_row] = row_penalty
+    matrix_offset = matrix_offsets[block]
+    vector_offset = vector_offsets[block]
+    first_jacobian = jacobian_first[joint_row]
+    second_jacobian = jacobian_second[joint_row]
+    row_residual = residual[joint_row]
+    # Kamino stores the reaction applied as +J^T lambda. The augmented
+    # Lagrangian dual used by the primal row has the opposite sign.
+    row_multiplier = -reaction[joint_row]
+    linearization_velocity = wp.float32(0.0)
+    if first >= 0:
+        linearization_velocity += wp.dot(first_jacobian, linearization_twist[first])
+    if second >= 0:
+        linearization_velocity += wp.dot(second_jacobian, linearization_twist[second])
+    if prescribed_twist and first >= 0 and first_local < 0:
+        linearization_velocity -= wp.dot(first_jacobian, prescribed_twist[first])
+    if prescribed_twist and second >= 0 and second_local < 0:
+        linearization_velocity -= wp.dot(second_jacobian, prescribed_twist[second])
+
+    if first_local >= 0:
+        first_contribution = compute_augmented_joint_row(
+            first_jacobian, row_residual, row_multiplier, row_penalty, dt, linearization_velocity
+        )
+        _atomic_add_body_block(matrix, matrix_offset, dimension, first_local, first_local, first_contribution.matrix)
+        _atomic_add_body_vector(right_hand_side, vector_offset, first_local, first_contribution.right_hand_side)
+    if second_local >= 0:
+        second_contribution = compute_augmented_joint_row(
+            second_jacobian, row_residual, row_multiplier, row_penalty, dt, linearization_velocity
+        )
+        _atomic_add_body_block(matrix, matrix_offset, dimension, second_local, second_local, second_contribution.matrix)
+        _atomic_add_body_vector(right_hand_side, vector_offset, second_local, second_contribution.right_hand_side)
+    if first_local >= 0 and second_local >= 0:
+        cross_scale = dt * dt * row_penalty
+        _atomic_add_body_block(
+            matrix,
+            matrix_offset,
+            dimension,
+            first_local,
+            second_local,
+            wp.outer(cross_scale * first_jacobian, second_jacobian),
+        )
+        _atomic_add_body_block(
+            matrix,
+            matrix_offset,
+            dimension,
+            second_local,
+            first_local,
+            wp.outer(cross_scale * second_jacobian, first_jacobian),
+        )
+
+
+@wp.kernel
+def _compute_body_weights_and_add(
+    body_component: wp.array[wp.int32],
+    body_local: wp.array[wp.int32],
+    body_has_unilateral: wp.array[wp.int32],
+    dimensions: wp.array[wp.int32],
+    matrix_offsets: wp.array[wp.int32],
+    smooth_matrix: wp.array[wp.float32],
+    mass: wp.array[wp.float32],
+    inertia_world: wp.array[wp.mat33f],
+    sigma: wp.float32,
+    beta: wp.float32,
+    weight: wp.array[mat66f],
+    inverse_weight: wp.array[mat66f],
+    eta: wp.array[wp.float32],
+    alpha: wp.array[wp.float32],
+    status: wp.array[wp.int32],
+    weighted_matrix: wp.array[wp.float32],
+):
+    body = wp.tid()
+    component = body_component[body]
+    if component < 0 or body_has_unilateral[body] == 0:
+        weight[body] = mat66f(0.0)
+        inverse_weight[body] = mat66f(0.0)
+        eta[body] = 0.0
+        alpha[body] = 0.0
+        status[body] = BODY_WEIGHT_STATUS_VALID
+        return
+    local_body = body_local[body]
+    dimension = dimensions[component]
+    matrix_offset = matrix_offsets[component]
+    body_offset = 6 * local_body
+    smooth_diagonal = mat66f(0.0)
+    for row in range(6):
+        for col in range(6):
+            index = _matrix_index(matrix_offset, dimension, body_offset + row, body_offset + col)
+            smooth_diagonal[row, col] = smooth_matrix[index]
+
+    result = compute_body_weight_mass_proportional(
+        smooth_diagonal,
+        mass[body],
+        inertia_world[body],
+        sigma,
+        beta,
+    )
+    weight[body] = result.weight
+    inverse_weight[body] = result.inverse_weight
+    eta[body] = result.eta
+    alpha[body] = result.alpha
+    status[body] = result.status
+    for row in range(6):
+        for col in range(6):
+            index = _matrix_index(matrix_offset, dimension, body_offset + row, body_offset + col)
+            weighted_matrix[index] += result.weight[row, col]
+
+
+@wp.kernel
+def _build_candidate_right_hand_side(
+    body_vector_index: wp.array[wp.int32],
+    smooth_right_hand_side: wp.array[wp.float32],
+    weight: wp.array[mat66f],
+    projected_twist: wp.array[vec6f],
+    splitting_dual: wp.array[vec6f],
+    candidate_right_hand_side: wp.array[wp.float32],
+):
+    body = wp.tid()
+    body_offset = body_vector_index[body]
+    if body_offset < 0:
+        return
+    weighted_target = weight[body] @ (projected_twist[body] + splitting_dual[body])
+    for row in range(6):
+        candidate_right_hand_side[body_offset + row] = smooth_right_hand_side[body_offset + row] + weighted_target[row]
+
+
+@wp.kernel
+def _build_candidate_right_hand_side_with_effort(
+    body_vector_index: wp.array[wp.int32],
+    smooth_right_hand_side: wp.array[wp.float32],
+    weight: wp.array[mat66f],
+    projected_twist: wp.array[vec6f],
+    splitting_dual: wp.array[vec6f],
+    body_effort_offset: wp.array[wp.int32],
+    body_effort_index: wp.array[wp.int32],
+    body_effort_side: wp.array[wp.int32],
+    effort_dynamic_row: wp.array[wp.int32],
+    dynamic_jacobian_first: wp.array[vec6f],
+    dynamic_jacobian_second: wp.array[vec6f],
+    effort_counter_applied: wp.array[wp.float32],
+    candidate_right_hand_side: wp.array[wp.float32],
+):
+    body = wp.tid()
+    body_offset = body_vector_index[body]
+    if body_offset < 0:
+        return
+    target = weight[body] @ (projected_twist[body] + splitting_dual[body])
+    effort_start = body_effort_offset[body]
+    effort_end = body_effort_offset[body + 1]
+    for incidence in range(effort_start, effort_end):
+        effort = body_effort_index[incidence]
+        dynamic_row = effort_dynamic_row[effort]
+        jacobian = dynamic_jacobian_first[dynamic_row]
+        if body_effort_side[incidence] != 0:
+            jacobian = dynamic_jacobian_second[dynamic_row]
+        target += effort_counter_applied[effort] * jacobian
+    for row in range(6):
+        candidate_right_hand_side[body_offset + row] = smooth_right_hand_side[body_offset + row] + target[row]
+
+
+class BatchedPrimalBodySystem:
+    """Allocated dense contact-free systems over independent body components.
+
+    World-level bookkeeping remains in model body order. The dense matrices and
+    vectors are instead packed by ``body_components`` so disconnected
+    articulations can be factorized independently. If no components are
+    supplied, each world is retained as one factor block.
+    """
+
+    def __init__(
+        self,
+        body_counts: Sequence[int],
+        device: wp.DeviceLike = None,
+        *,
+        body_components: Sequence[Sequence[int]] | None = None,
+        dynamic_bodies: Sequence[int] | None = None,
+        body_edges: Sequence[tuple[int, int]] | None = None,
+    ):
+        if len(body_counts) == 0:
+            raise ValueError("At least one world is required.")
+        if any(not isinstance(count, int) or count < 0 for count in body_counts) or sum(body_counts) == 0:
+            raise ValueError("Body counts must be non-negative and include at least one active body.")
+
+        self.device = wp.get_device(device)
+        self.body_counts = tuple(body_counts)
+        self.num_worlds = len(body_counts)
+        self.num_bodies = sum(body_counts)
+        body_counts_np = np.asarray(body_counts, dtype=np.int32)
+        world_body_offsets = np.empty(self.num_worlds + 1, dtype=np.int32)
+        world_body_offsets[0] = 0
+        np.cumsum(body_counts_np, out=world_body_offsets[1:])
+        body_world_np = np.repeat(np.arange(self.num_worlds, dtype=np.int32), body_counts_np)
+
+        if dynamic_bodies is None:
+            dynamic_body_np = np.arange(self.num_bodies, dtype=np.int32)
+        else:
+            dynamic_body_np = np.asarray(dynamic_bodies, dtype=np.int32)
+            if np.unique(dynamic_body_np).size != dynamic_body_np.size:
+                raise ValueError("dynamic_bodies must not contain duplicates.")
+            if np.any((dynamic_body_np < 0) | (dynamic_body_np >= self.num_bodies)):
+                raise ValueError("dynamic_bodies must reference packed bodies.")
+        dynamic_body_indices = tuple(dynamic_body_np.tolist())
+
+        if body_components is None:
+            dynamic_mask = np.zeros(self.num_bodies, dtype=bool)
+            dynamic_mask[dynamic_body_np] = True
+            component_bodies = np.flatnonzero(dynamic_mask).astype(np.int32)
+            dynamic_world = body_world_np[component_bodies]
+            boundaries = np.flatnonzero(dynamic_world[1:] != dynamic_world[:-1]) + 1
+            component_arrays = np.split(component_bodies, boundaries) if component_bodies.size else []
+        else:
+            component_arrays = [np.asarray(component, dtype=np.int32) for component in body_components]
+            if (not component_arrays and dynamic_body_np.size) or any(
+                component.size == 0 for component in component_arrays
+            ):
+                raise ValueError("Each body component must contain at least one body.")
+            flattened = np.concatenate(component_arrays) if component_arrays else np.empty(0, dtype=np.int32)
+            if not np.array_equal(np.sort(flattened), np.sort(dynamic_body_np)):
+                raise ValueError("body_components must contain every dynamic body exactly once.")
+            component_counts = np.asarray([component.size for component in component_arrays], dtype=np.int32)
+            component_world = body_world_np[flattened[np.cumsum(component_counts) - component_counts]]
+            if np.any(body_world_np[flattened] != np.repeat(component_world, component_counts)):
+                raise ValueError("A body component cannot span multiple worlds.")
+        self.dynamic_bodies = dynamic_body_indices
+        if component_arrays:
+            block_body_counts_np = np.asarray([component.size for component in component_arrays], dtype=np.int32)
+            component_offsets = np.empty(block_body_counts_np.size + 1, dtype=np.int32)
+            component_offsets[0] = 0
+            np.cumsum(block_body_counts_np, out=component_offsets[1:])
+            flattened_components = np.concatenate(component_arrays)
+            block_world_np = body_world_np[flattened_components[component_offsets[:-1]]]
+            self.block_body_counts = tuple(block_body_counts_np.tolist())
+            self.block_world_host = tuple(block_world_np.tolist())
+            storage_dimensions_np = 6 * block_body_counts_np
+            storage_dimensions = storage_dimensions_np.tolist()
+            active_dimensions = storage_dimensions
+        else:
+            # Dense multi-linear storage requires one positive allocation size,
+            # while the active dimension remains zero.
+            self.block_body_counts = (0,)
+            self.block_world_host = (0,)
+            storage_dimensions = [1]
+            active_dimensions = [0]
+        self.num_blocks = len(self.block_body_counts)
+
+        self.info = DenseSquareMultiLinearInfo()
+        self.info.finalize(dimensions=storage_dimensions, dtype=wp.float32, itype=wp.int32, device=self.device)
+        if active_dimensions != storage_dimensions:
+            self.info.dim = wp.array(active_dimensions, dtype=wp.int32, device=self.device)
+        self.smooth_matrix = wp.zeros(self.info.total_mat_size, dtype=wp.float32, device=self.device)
+        self.weighted_matrix = wp.zeros(self.info.total_mat_size, dtype=wp.float32, device=self.device)
+        self.right_hand_side = wp.zeros(self.info.total_vec_size, dtype=wp.float32, device=self.device)
+        self.candidate_right_hand_side = wp.zeros(self.info.total_vec_size, dtype=wp.float32, device=self.device)
+        self._packed_solution = wp.zeros(self.info.total_vec_size, dtype=wp.float32, device=self.device)
+        self.body_solution = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.weight = wp.zeros(self.num_bodies, dtype=mat66f, device=self.device)
+        self.inverse_weight = wp.zeros(self.num_bodies, dtype=mat66f, device=self.device)
+        self.weight_eta = wp.zeros(self.num_bodies, dtype=wp.float32, device=self.device)
+        self.weight_alpha = wp.zeros(self.num_bodies, dtype=wp.float32, device=self.device)
+        self.weight_status = wp.zeros(self.num_bodies, dtype=wp.int32, device=self.device)
+        body_block_np = np.full(self.num_bodies, -1, dtype=np.int32)
+        body_local_np = np.full(self.num_bodies, -1, dtype=np.int32)
+        body_vector_index_np = np.full(self.num_bodies, -1, dtype=np.int32)
+        if component_arrays:
+            block_indices = np.repeat(np.arange(self.num_blocks, dtype=np.int32), block_body_counts_np)
+            local_indices = np.arange(flattened_components.size, dtype=np.int32) - np.repeat(
+                component_offsets[:-1], block_body_counts_np
+            )
+            block_vector_offsets = 6 * component_offsets[:-1]
+            body_block_np[flattened_components] = block_indices
+            body_local_np[flattened_components] = local_indices
+            body_vector_index_np[flattened_components] = (
+                np.repeat(block_vector_offsets, block_body_counts_np) + 6 * local_indices
+            )
+
+        self.body_world_host = tuple(body_world_np.tolist())
+        self.body_block_host = tuple(body_block_np.tolist())
+        self.body_local_host = tuple(body_local_np.tolist())
+        self.body_vector_index_host = tuple(body_vector_index_np.tolist())
+        body_edges_np = np.asarray(body_edges if body_edges is not None else (), dtype=np.int32).reshape((-1, 2))
+        body_edges_np = body_edges_np[np.all(body_edges_np >= 0, axis=1)]
+        body_edges_np.sort(axis=1)
+        body_edges_np = np.unique(body_edges_np, axis=0)
+        self.body_edges_host = frozenset(map(tuple, body_edges_np.tolist()))
+        self._body_edge_keys_host = body_edges_np[:, 0].astype(np.int64) * self.num_bodies + body_edges_np[:, 1]
+        self.body_world = wp.array(body_world_np, dtype=wp.int32, device=self.device)
+        self.body_block = wp.array(body_block_np, dtype=wp.int32, device=self.device)
+        self.body_local = wp.array(body_local_np, dtype=wp.int32, device=self.device)
+        self.body_vector_index = wp.array(body_vector_index_np, dtype=wp.int32, device=self.device)
+        self.body_weight_enabled = wp.ones(self.num_bodies, dtype=wp.int32, device=self.device)
+        self.block_has_unilateral = wp.ones(self.num_blocks, dtype=wp.int32, device=self.device)
+        self.selective_body_weights = False
+        self.operator = DenseLinearOperatorData(info=self.info, mat=self.weighted_matrix)
+        symbolic_adjacency = self._build_symbolic_adjacency(body_edges) if body_edges is not None else None
+        # Factorization benefits from fewer wide dense panels, while repeated
+        # single-RHS solves retain the smaller tile for better occupancy.
+        self.linear_solver = HybridLLTBlockedSolver(
+            operator=self.operator,
+            factorize_block_size=64,
+            solve_block_dim=256,
+            rcm_min_dimension=_RCM_MIN_DIMENSION,
+            symbolic_adjacency=symbolic_adjacency,
+            dtype=wp.float32,
+            device=self.device,
+        )
+        self._mass: wp.array[wp.float32] | None = None
+        self._inertia_world: wp.array[wp.mat33f] | None = None
+
+    def _build_symbolic_adjacency(
+        self, body_edges: Sequence[tuple[int, int]]
+    ) -> tuple[tuple[tuple[int, ...], ...], ...]:
+        """Expand fixed body topology into scalar adjacency per factor block."""
+        edges = np.asarray(body_edges, dtype=np.int32).reshape((-1, 2))
+        if np.any((edges < 0) | (edges >= self.num_bodies)):
+            raise ValueError("body_edges must reference packed bodies.")
+        body_block = np.asarray(self.body_block_host, dtype=np.int32)
+        body_local = np.asarray(self.body_local_host, dtype=np.int32)
+        if edges.size:
+            edge_blocks = body_block[edges]
+            dynamic_edge = np.all(edge_blocks >= 0, axis=1)
+            if np.any(edge_blocks[dynamic_edge, 0] != edge_blocks[dynamic_edge, 1]):
+                raise ValueError("A body edge cannot span factor blocks.")
+            edges = edges[dynamic_edge]
+            edge_block = edge_blocks[dynamic_edge, 0]
+            local_edges = body_local[edges]
+            local_edges.sort(axis=1)
+            order = np.lexsort((local_edges[:, 1], local_edges[:, 0], edge_block))
+            edge_block = edge_block[order]
+            local_edges = local_edges[order]
+            edge_counts = np.bincount(edge_block, minlength=self.num_blocks).astype(np.int32, copy=False)
+            edge_offsets = np.empty(self.num_blocks + 1, dtype=np.int32)
+            edge_offsets[0] = 0
+            np.cumsum(edge_counts, out=edge_offsets[1:])
+        else:
+            local_edges = edges
+            edge_offsets = np.zeros(self.num_blocks + 1, dtype=np.int32)
+
+        adjacency_blocks = []
+        for block, body_count in enumerate(self.block_body_counts):
+            if 6 * body_count < _RCM_MIN_DIMENSION:
+                adjacency_blocks.append(())
+                continue
+            begin = edge_offsets[block]
+            end = edge_offsets[block + 1]
+            block_edges = tuple(map(tuple, local_edges[begin:end].tolist()))
+            adjacency_blocks.append(_expand_body_symbolic_adjacency(body_count, block_edges))
+        return tuple(adjacency_blocks)
+
+    def validate_body_pairs(
+        self,
+        name: str,
+        body_first: wp.array[wp.int32],
+        body_second: wp.array[wp.int32],
+    ) -> None:
+        """Verify fixed topology covers every dynamic off-diagonal assembly pair."""
+        first_values = body_first.numpy().astype(np.int32, copy=False)
+        second_values = body_second.numpy().astype(np.int32, copy=False)
+        if first_values.size != second_values.size:
+            raise ValueError(f"{name} endpoint arrays must have identical lengths.")
+        body_block = np.asarray(self.body_block_host, dtype=np.int32)
+        valid = (first_values >= 0) & (second_values >= 0)
+        valid &= body_block[first_values.clip(min=0)] >= 0
+        valid &= body_block[second_values.clip(min=0)] >= 0
+        pairs = np.column_stack((first_values[valid], second_values[valid]))
+        pairs.sort(axis=1)
+        pair_keys = pairs[:, 0].astype(np.int64) * self.num_bodies + pairs[:, 1]
+        missing = np.unique(pairs[~np.isin(pair_keys, self._body_edge_keys_host)], axis=0)
+        if missing.size:
+            raise ValueError(f"Fixed body topology does not cover {name} pairs: {list(map(tuple, missing.tolist()))}.")
+
+    def reset(self) -> None:
+        """Clear assembled matrices, vectors, weights, and factorization state."""
+        self.smooth_matrix.zero_()
+        self.weighted_matrix.zero_()
+        self.right_hand_side.zero_()
+        self.candidate_right_hand_side.zero_()
+        self._packed_solution.zero_()
+        self.body_solution.zero_()
+        self.weight.zero_()
+        self.inverse_weight.zero_()
+        self.weight_eta.zero_()
+        self.weight_alpha.zero_()
+        self.weight_status.zero_()
+        self.body_weight_enabled.zero_()
+        self.block_has_unilateral.zero_()
+        self.linear_solver.reset()
+
+    def assemble_bodies(
+        self,
+        mass: wp.array[wp.float32],
+        inertia_world: wp.array[wp.mat33f],
+        velocity_previous: wp.array[vec6f],
+        evaluation_velocity: wp.array[vec6f],
+        external_wrench: wp.array[vec6f],
+        actuation_wrench: wp.array[vec6f],
+        gravity: wp.array[wp.vec3f],
+        time_step: wp.array[wp.float32],
+    ) -> None:
+        """Reset and assemble body inertia and explicit-force terms."""
+        if any(
+            array.shape[0] != self.num_bodies
+            for array in (
+                mass,
+                inertia_world,
+                velocity_previous,
+                evaluation_velocity,
+                external_wrench,
+                actuation_wrench,
+            )
+        ):
+            raise ValueError("Body input arrays must contain one entry per packed active body.")
+        self.reset()
+        self._mass = mass
+        self._inertia_world = inertia_world
+        wp.launch(
+            _assemble_body_inertial_systems,
+            dim=self.num_bodies,
+            inputs=[
+                self.body_world,
+                self.body_block,
+                self.body_local,
+                self.info.dim,
+                self.info.mio,
+                self.info.vio,
+                mass,
+                inertia_world,
+                velocity_previous,
+                evaluation_velocity,
+                external_wrench,
+                actuation_wrench,
+                gravity,
+                time_step,
+            ],
+            outputs=[self.smooth_matrix, self.right_hand_side],
+            device=self.device,
+        )
+
+    def add_dynamic_rows(
+        self,
+        row_world: wp.array[wp.int32],
+        body_first: wp.array[wp.int32],
+        body_second: wp.array[wp.int32],
+        jacobian_first: wp.array[vec6f],
+        jacobian_second: wp.array[vec6f],
+        effective_inertia: wp.array[wp.float32],
+        free_velocity: wp.array[wp.float32],
+        prescribed_twist: wp.array[vec6f] | None = None,
+    ) -> None:
+        """Add implicit joint-dynamics rows to the smooth system."""
+        row_count = row_world.shape[0]
+        if row_count == 0:
+            return
+        if any(
+            array.shape[0] != row_count
+            for array in (
+                body_first,
+                body_second,
+                jacobian_first,
+                jacobian_second,
+                effective_inertia,
+                free_velocity,
+            )
+        ):
+            raise ValueError("Dynamic-row arrays must have identical lengths.")
+        if prescribed_twist is not None and prescribed_twist.shape[0] != self.num_bodies:
+            raise ValueError("prescribed_twist must contain one entry per packed body.")
+        wp.launch(
+            _assemble_dynamic_joint_rows,
+            dim=row_count,
+            inputs=[
+                self.info.dim,
+                self.info.mio,
+                self.info.vio,
+                body_first,
+                body_second,
+                self.body_block,
+                self.body_local,
+                jacobian_first,
+                jacobian_second,
+                effective_inertia,
+                free_velocity,
+                prescribed_twist,
+            ],
+            outputs=[self.smooth_matrix, self.right_hand_side],
+            device=self.device,
+        )
+
+    def add_structural_rows(
+        self,
+        row_world: wp.array[wp.int32],
+        body_first: wp.array[wp.int32],
+        body_second: wp.array[wp.int32],
+        jacobian_first: wp.array[vec6f],
+        jacobian_second: wp.array[vec6f],
+        residual: wp.array[wp.float32],
+        reaction: wp.array[wp.float32],
+        effective_mass: wp.array[wp.float32],
+        linearization_twist: wp.array[vec6f],
+        time_step: wp.array[wp.float32],
+        joint_penalty_scale: wp.array[wp.float32],
+        penalty: wp.array[wp.float32],
+        prescribed_twist: wp.array[vec6f] | None = None,
+    ) -> None:
+        """Add augmented structural rows and write their derived penalties."""
+        row_count = row_world.shape[0]
+        if row_count == 0:
+            return
+        if joint_penalty_scale.shape[0] != self.num_worlds:
+            raise ValueError("joint_penalty_scale must contain one entry per world.")
+        if linearization_twist.shape[0] != self.num_bodies:
+            raise ValueError("linearization_twist must contain one entry per packed body.")
+        if prescribed_twist is not None and prescribed_twist.shape[0] != self.num_bodies:
+            raise ValueError("prescribed_twist must contain one entry per packed body.")
+        if any(
+            array.shape[0] != row_count
+            for array in (
+                body_first,
+                body_second,
+                jacobian_first,
+                jacobian_second,
+                residual,
+                reaction,
+                effective_mass,
+                penalty,
+            )
+        ):
+            raise ValueError("Structural-row arrays must have identical lengths.")
+        wp.launch(
+            _assemble_structural_joint_rows,
+            dim=row_count,
+            inputs=[
+                self.info.dim,
+                self.info.mio,
+                self.info.vio,
+                row_world,
+                body_first,
+                body_second,
+                self.body_block,
+                self.body_local,
+                jacobian_first,
+                jacobian_second,
+                residual,
+                reaction,
+                effective_mass,
+                linearization_twist,
+                prescribed_twist,
+                time_step,
+                joint_penalty_scale,
+            ],
+            outputs=[penalty, self.smooth_matrix, self.right_hand_side],
+            device=self.device,
+        )
+
+    def _mark_weighted_bodies(self, body_has_unilateral: wp.array[wp.int32] | None) -> None:
+        if body_has_unilateral is None:
+            self.body_weight_enabled.fill_(1)
+            return
+        if body_has_unilateral.shape[0] != self.num_bodies:
+            raise ValueError("body_has_unilateral must contain one entry per body.")
+        if self.selective_body_weights:
+            wp.copy(self.body_weight_enabled, body_has_unilateral)
+            return
+        self.block_has_unilateral.zero_()
+        wp.launch(
+            _mark_blocks_with_unilaterals,
+            dim=self.num_bodies,
+            inputs=[self.body_block, body_has_unilateral],
+            outputs=[self.block_has_unilateral],
+            device=self.device,
+        )
+        wp.launch(
+            _enable_bodies_in_weighted_blocks,
+            dim=self.num_bodies,
+            inputs=[self.body_block, self.block_has_unilateral],
+            outputs=[self.body_weight_enabled],
+            device=self.device,
+        )
+
+    def build_weighted_matrix(
+        self,
+        *,
+        sigma: float,
+        beta: float,
+        metric_matrix: wp.array[wp.float32] | None = None,
+        body_has_unilateral: wp.array[wp.int32] | None = None,
+    ) -> None:
+        """Compute body weights and assemble ``A + W``."""
+        if self._mass is None or self._inertia_world is None:
+            raise ValueError("assemble_bodies() must be called before build_weighted_matrix().")
+        if metric_matrix is None:
+            metric_matrix = self.smooth_matrix
+        elif metric_matrix.shape[0] != self.info.total_mat_size:
+            raise ValueError("metric_matrix must match the packed body matrix storage.")
+        self._mark_weighted_bodies(body_has_unilateral)
+        wp.copy(self.weighted_matrix, self.smooth_matrix)
+        wp.launch(
+            _compute_body_weights_and_add,
+            dim=self.num_bodies,
+            inputs=[
+                self.body_block,
+                self.body_local,
+                self.body_weight_enabled,
+                self.info.dim,
+                self.info.mio,
+                metric_matrix,
+                self._mass,
+                self._inertia_world,
+                sigma,
+                beta,
+            ],
+            outputs=[
+                self.weight,
+                self.inverse_weight,
+                self.weight_eta,
+                self.weight_alpha,
+                self.weight_status,
+                self.weighted_matrix,
+            ],
+            device=self.device,
+        )
+
+    def factorize(self) -> None:
+        """Factorize the current weighted matrices with batched dense LLT."""
+        self.linear_solver.compute(self.weighted_matrix)
+
+    def build_candidate_right_hand_side(
+        self,
+        projected_twist: wp.array[vec6f],
+        splitting_dual: wp.array[vec6f],
+    ) -> None:
+        """Build ``f + W (p + lambda)`` for one splitting iteration."""
+        if projected_twist.shape[0] != self.num_bodies or splitting_dual.shape[0] != self.num_bodies:
+            raise ValueError("Splitting vectors must contain one entry per packed active body.")
+        wp.launch(
+            _build_candidate_right_hand_side,
+            dim=self.num_bodies,
+            inputs=[
+                self.body_vector_index,
+                self.right_hand_side,
+                self.weight,
+                projected_twist,
+                splitting_dual,
+            ],
+            outputs=[self.candidate_right_hand_side],
+            device=self.device,
+        )
+
+    def build_candidate_right_hand_side_with_effort(
+        self,
+        projected_twist: wp.array[vec6f],
+        splitting_dual: wp.array[vec6f],
+        body_effort_offset: wp.array[wp.int32],
+        body_effort_index: wp.array[wp.int32],
+        body_effort_side: wp.array[wp.int32],
+        effort_dynamic_row: wp.array[wp.int32],
+        dynamic_jacobian_first: wp.array[vec6f],
+        dynamic_jacobian_second: wp.array[vec6f],
+        effort_counter_applied: wp.array[wp.float32],
+    ) -> None:
+        """Build a candidate right-hand side with finite-drive counter-impulses."""
+        if projected_twist.shape[0] != self.num_bodies or splitting_dual.shape[0] != self.num_bodies:
+            raise ValueError("Splitting vectors must contain one entry per packed active body.")
+        if body_effort_offset.shape[0] != self.num_bodies + 1:
+            raise ValueError("Effort offsets must contain one interval per packed active body.")
+        wp.launch(
+            _build_candidate_right_hand_side_with_effort,
+            dim=self.num_bodies,
+            inputs=[
+                self.body_vector_index,
+                self.right_hand_side,
+                self.weight,
+                projected_twist,
+                splitting_dual,
+                body_effort_offset,
+                body_effort_index,
+                body_effort_side,
+                effort_dynamic_row,
+                dynamic_jacobian_first,
+                dynamic_jacobian_second,
+                effort_counter_applied,
+            ],
+            outputs=[self.candidate_right_hand_side],
+            device=self.device,
+        )
+
+    def solve_candidate(
+        self,
+        prescribed_twist: wp.array[vec6f],
+    ) -> None:
+        """Solve the prepared candidate right-hand side and unpack body velocities."""
+        if prescribed_twist.shape[0] != self.num_bodies:
+            raise ValueError("prescribed_twist must contain one entry per packed body.")
+        self.linear_solver.solve(self.candidate_right_hand_side, self._packed_solution)
+        wp.launch(
+            _unpack_body_solution,
+            dim=self.num_bodies,
+            inputs=[self.body_vector_index, self._packed_solution, prescribed_twist],
+            outputs=[self.body_solution],
+            device=self.device,
+        )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/types.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent state for LOX splitting iterations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import warp as wp
+
+from ...core.types import mat66f, vec6f
+from .kernels import (
+    _finalize_residual_iteration,
+    _initialize_bodies,
+    _initialize_fixed_iteration,
+    _initialize_iteration_residuals,
+    _initialize_worlds,
+    _mark_iteration_limit,
+    _prepare_projection,
+    _restore_dual_from_impulse,
+    _store_dual_impulse,
+    _update_bodies_and_reduce_residuals,
+    _update_fixed_iteration_bodies,
+)
+
+__all__ = ["SplittingState"]
+
+
+class SplittingState:
+    """Persistent body/world state for a batched LOX solve."""
+
+    def __init__(self, body_counts: Sequence[int], device: wp.DeviceLike = None):
+        if len(body_counts) == 0:
+            raise ValueError("At least one world is required.")
+        if any(not isinstance(count, int) or count < 0 for count in body_counts) or sum(body_counts) == 0:
+            raise ValueError("Body counts must be non-negative and include at least one active body.")
+
+        self.device = wp.get_device(device)
+        self.body_counts = tuple(body_counts)
+        self.num_worlds = len(body_counts)
+        self.num_bodies = sum(body_counts)
+        body_world = np.repeat(
+            np.arange(self.num_worlds, dtype=np.int32),
+            np.asarray(body_counts, dtype=np.int32),
+        )
+
+        self.body_world = wp.array(body_world, dtype=wp.int32, device=self.device)
+        self.projected_twist = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.projected_twist_previous = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.global_twist = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.global_twist_previous = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.splitting_dual = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.splitting_dual_impulse = wp.zeros(self.num_bodies, dtype=vec6f, device=self.device)
+        self.world_active = wp.ones(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.world_converged = wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.world_failed = wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.world_iteration_limit = wp.zeros(self.num_worlds, dtype=wp.bool, device=self.device)
+        self.iteration_count = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+        self.residual_change = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_split = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_structural = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_structural_projected = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_cross_iterate = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_lagged_velocity = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self.residual_total = wp.zeros(self.num_worlds, dtype=wp.float32, device=self.device)
+        self._iteration_failed = wp.zeros(self.num_worlds, dtype=wp.int32, device=self.device)
+
+    def _initialize(
+        self,
+        world_mask: wp.array[wp.bool] | None,
+        initial_twist: wp.array[vec6f] | None,
+        reset_dual: bool,
+    ) -> None:
+        wp.launch(
+            _initialize_bodies,
+            dim=self.num_bodies,
+            inputs=[self.body_world, world_mask, initial_twist, reset_dual],
+            outputs=[
+                self.projected_twist,
+                self.projected_twist_previous,
+                self.global_twist,
+                self.global_twist_previous,
+                self.splitting_dual,
+                self.splitting_dual_impulse,
+            ],
+            device=self.device,
+        )
+        wp.launch(
+            _initialize_worlds,
+            dim=self.num_worlds,
+            inputs=[world_mask],
+            outputs=[
+                self.world_active,
+                self.world_converged,
+                self.world_failed,
+                self.world_iteration_limit,
+                self.iteration_count,
+                self.residual_change,
+                self.residual_split,
+                self.residual_structural,
+                self.residual_structural_projected,
+                self.residual_cross_iterate,
+                self.residual_lagged_velocity,
+                self.residual_total,
+                self._iteration_failed,
+            ],
+            device=self.device,
+        )
+
+    def reset(self, world_mask: wp.array[wp.bool] | None = None) -> None:
+        """Reset body-space warm starts and world diagnostics."""
+        if world_mask is not None and world_mask.shape[0] != self.num_worlds:
+            raise ValueError("world_mask must contain one entry per world.")
+        self._initialize(world_mask, initial_twist=None, reset_dual=True)
+
+    def begin(self, initial_twist: wp.array[vec6f], reset_dual: bool = False) -> None:
+        """Initialize one nonlinear solve while optionally retaining its impulse warm start."""
+        if initial_twist.shape[0] != self.num_bodies:
+            raise ValueError("initial_twist must contain one entry per packed active body.")
+        self._initialize(world_mask=None, initial_twist=initial_twist, reset_dual=reset_dual)
+
+    def store_dual_impulse(
+        self,
+        weight: wp.array[mat66f],
+        body_has_unilateral: wp.array[wp.int32],
+    ) -> None:
+        """Store the physical body impulse ``W u`` for later warm starting."""
+        if weight.shape[0] != self.num_bodies or body_has_unilateral.shape[0] != self.num_bodies:
+            raise ValueError("Weight and unilateral mask arrays must contain one entry per body.")
+        wp.launch(
+            _store_dual_impulse,
+            dim=self.num_bodies,
+            inputs=[body_has_unilateral, weight],
+            outputs=[self.splitting_dual, self.splitting_dual_impulse],
+            device=self.device,
+        )
+
+    def restore_dual_from_impulse(
+        self,
+        inverse_weight: wp.array[mat66f],
+        body_has_unilateral: wp.array[wp.int32],
+    ) -> None:
+        """Recover the scaled dual ``u = W^-1 (W u)`` for the current weight."""
+        if inverse_weight.shape[0] != self.num_bodies or body_has_unilateral.shape[0] != self.num_bodies:
+            raise ValueError("Inverse weight and unilateral mask arrays must contain one entry per body.")
+        wp.launch(
+            _restore_dual_from_impulse,
+            dim=self.num_bodies,
+            inputs=[body_has_unilateral, inverse_weight],
+            outputs=[self.splitting_dual_impulse, self.splitting_dual],
+            device=self.device,
+        )
+
+    def prepare_projection(
+        self,
+        global_solution: wp.array[vec6f],
+        body_split_enabled: wp.array[wp.int32] | None = None,
+    ) -> None:
+        """Store the global solution and initialize ``p = v - u``."""
+        if global_solution.shape[0] != self.num_bodies:
+            raise ValueError("global_solution must contain one entry per packed active body.")
+        if body_split_enabled is not None and body_split_enabled.shape[0] != self.num_bodies:
+            raise ValueError("body_split_enabled must contain one entry per packed active body.")
+        wp.launch(
+            _prepare_projection,
+            dim=self.num_bodies,
+            inputs=[self.body_world, self.world_active, body_split_enabled, global_solution],
+            outputs=[
+                self.splitting_dual,
+                self.global_twist_previous,
+                self.global_twist,
+                self.projected_twist_previous,
+                self.projected_twist,
+            ],
+            device=self.device,
+        )
+
+    def finish_iteration(
+        self,
+        projection_status: wp.array[wp.int32],
+        time_step: wp.array[wp.float32],
+        position_tolerance: float,
+        rotation_tolerance: float,
+        velocity_tolerance: float,
+        effort_residual: wp.array[wp.float32] | None = None,
+        structural_residual: wp.array[wp.float32] | None = None,
+        projected_structural_residual: wp.array[wp.float32] | None = None,
+        lagged_velocity_residual: wp.array[wp.float32] | None = None,
+        lagged_velocity_required: wp.array[wp.int32] | None = None,
+    ) -> None:
+        """Update duals and residuals, then test per-world convergence."""
+        if any(
+            not np.isfinite(tolerance) or tolerance <= 0.0
+            for tolerance in (position_tolerance, rotation_tolerance, velocity_tolerance)
+        ):
+            raise ValueError("Convergence tolerances must be finite and positive.")
+        wp.launch(
+            _initialize_iteration_residuals,
+            dim=self.num_worlds,
+            inputs=[
+                projection_status,
+            ],
+            outputs=[
+                self.world_active,
+                self.world_failed,
+                self.iteration_count,
+                self._iteration_failed,
+                self.residual_change,
+                self.residual_split,
+                self.residual_cross_iterate,
+            ],
+            device=self.device,
+        )
+        wp.launch(
+            _update_bodies_and_reduce_residuals,
+            dim=self.num_bodies,
+            inputs=[
+                time_step,
+                position_tolerance,
+                rotation_tolerance,
+                velocity_tolerance,
+                self.body_world,
+                self.global_twist_previous,
+                self.global_twist,
+                self.projected_twist_previous,
+                self.projected_twist,
+                self.world_active,
+            ],
+            outputs=[
+                self.splitting_dual,
+                self._iteration_failed,
+                self.residual_change,
+                self.residual_split,
+                self.residual_cross_iterate,
+            ],
+            device=self.device,
+        )
+        wp.launch(
+            _finalize_residual_iteration,
+            dim=self.num_worlds,
+            inputs=[
+                structural_residual,
+                projected_structural_residual,
+                lagged_velocity_residual,
+                lagged_velocity_required,
+                effort_residual,
+                self.iteration_count,
+                self._iteration_failed,
+            ],
+            outputs=[
+                self.world_active,
+                self.world_converged,
+                self.world_failed,
+                self.residual_change,
+                self.residual_split,
+                self.residual_structural,
+                self.residual_structural_projected,
+                self.residual_cross_iterate,
+                self.residual_lagged_velocity,
+                self.residual_total,
+            ],
+            device=self.device,
+        )
+
+    def finish_fixed_iteration(
+        self,
+        projection_status: wp.array[wp.int32],
+    ) -> None:
+        """Update the dual state and failures for a fixed-count iteration."""
+        wp.launch(
+            _initialize_fixed_iteration,
+            dim=self.num_worlds,
+            inputs=[projection_status],
+            outputs=[self.world_active, self.world_failed, self.iteration_count],
+            device=self.device,
+        )
+        wp.launch(
+            _update_fixed_iteration_bodies,
+            dim=self.num_bodies,
+            inputs=[self.body_world, self.global_twist, self.projected_twist],
+            outputs=[self.world_active, self.world_failed, self.splitting_dual],
+            device=self.device,
+        )
+
+    def mark_iteration_limit(self) -> None:
+        """Deactivate worlds that remain unconverged at the iteration limit."""
+        wp.launch(
+            _mark_iteration_limit,
+            dim=self.num_worlds,
+            inputs=[],
+            outputs=[self.world_active, self.world_iteration_limit],
+            device=self.device,
+        )

--- a/newton/_src/solvers/kamino/_src/solvers/lox/weight.py
+++ b/newton/_src/solvers/kamino/_src/solvers/lox/weight.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rigid-body consensus weights for the LOX split.
+
+The primitive uses Kamino's linear-first twist order
+``(linear_x, linear_y, linear_z, angular_x, angular_y, angular_z)`` but is
+otherwise independent of Kamino containers. The body mass matrix is
+``M = diag(m I_3, I_world)`` and is referenced at the body's center of mass.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from ...core.types import mat66f
+
+__all__ = [
+    "BODY_WEIGHT_STATUS_INVALID",
+    "BODY_WEIGHT_STATUS_VALID",
+    "BodyWeightResult",
+    "compute_body_weight_mass_proportional",
+]
+
+BODY_WEIGHT_STATUS_INVALID = 0
+"""The input contained a non-finite value or an invalid policy parameter."""
+
+BODY_WEIGHT_STATUS_VALID = 1
+"""The input yielded a usable weight, including any numerical regularization."""
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.struct
+class BodyWeightResult:
+    """Result of one mass-proportional rigid-body weight computation."""
+
+    weight: mat66f
+    """Mass-proportional body weight ``W = alpha M``."""
+    inverse_weight: mat66f
+    """Inverse mass-proportional body weight ``W^-1``."""
+    eta: wp.float32
+    """Minimum eigenvalue of the regularized mass-normalized smooth block."""
+    alpha: wp.float32
+    """Scalar weight selected by the paper's clamping policy."""
+    status: wp.int32
+    """One of the ``BODY_WEIGHT_STATUS_*`` values."""
+
+
+@wp.func
+def _make_invalid_body_weight_result() -> BodyWeightResult:
+    result = BodyWeightResult()
+    result.weight = mat66f(0.0)
+    result.inverse_weight = mat66f(0.0)
+    result.eta = 0.0
+    result.alpha = 0.0
+    result.status = BODY_WEIGHT_STATUS_INVALID
+    return result
+
+
+@wp.func
+def _symmetrize_mat33(value: wp.mat33f) -> wp.mat33f:
+    return 0.5 * (value + wp.transpose(value))
+
+
+@wp.func
+def _symmetrize_mat66(value: mat66f) -> mat66f:
+    return 0.5 * (value + wp.transpose(value))
+
+
+@wp.func
+def _compute_symmetric_eigenvalue_min_fixed(matrix: mat66f) -> wp.float32:
+    """Approximate the minimum eigenvalue with twelve cyclic Jacobi sweeps."""
+    diagonalized = matrix
+    sweep = int(0)
+    while sweep < 12:
+        first = int(0)
+        while first < 5:
+            second = first + 1
+            while second < 6:
+                off_diagonal = diagonalized[first, second]
+                if off_diagonal != 0.0:
+                    tau = (diagonalized[second, second] - diagonalized[first, first]) / (2.0 * off_diagonal)
+                    tangent = wp.float32(1.0)
+                    if tau != 0.0:
+                        tangent = wp.sign(tau) / (wp.abs(tau) + wp.sqrt(1.0 + tau * tau))
+                    cosine = 1.0 / wp.sqrt(1.0 + tangent * tangent)
+                    sine = tangent * cosine
+
+                    first_diagonal = diagonalized[first, first]
+                    second_diagonal = diagonalized[second, second]
+                    diagonalized[first, first] = (
+                        cosine * cosine * first_diagonal
+                        - 2.0 * cosine * sine * off_diagonal
+                        + sine * sine * second_diagonal
+                    )
+                    diagonalized[second, second] = (
+                        sine * sine * first_diagonal
+                        + 2.0 * cosine * sine * off_diagonal
+                        + cosine * cosine * second_diagonal
+                    )
+                    diagonalized[first, second] = 0.0
+                    diagonalized[second, first] = 0.0
+
+                    other = int(0)
+                    while other < 6:
+                        if other != first and other != second:
+                            other_first = diagonalized[other, first]
+                            other_second = diagonalized[other, second]
+                            rotated_first = cosine * other_first - sine * other_second
+                            rotated_second = sine * other_first + cosine * other_second
+                            diagonalized[other, first] = rotated_first
+                            diagonalized[first, other] = rotated_first
+                            diagonalized[other, second] = rotated_second
+                            diagonalized[second, other] = rotated_second
+                        other += 1
+                second += 1
+            first += 1
+        sweep += 1
+
+    return wp.min(wp.get_diag(diagonalized))
+
+
+@wp.func
+def compute_body_weight_mass_proportional(
+    smooth_diagonal: mat66f,
+    mass: wp.float32,
+    inertia_world: wp.mat33f,
+    sigma: wp.float32,
+    beta: wp.float32,
+    mass_floor: wp.float32 = 1.0e-8,
+    inertia_floor: wp.float32 = 1.0e-10,
+    eta_floor: wp.float32 = 1.0e-6,
+) -> BodyWeightResult:
+    """Compute a mass-proportional rigid-body weight and its inverse.
+
+    The implementation forms the symmetric normalization
+    ``M^-1/2 smooth_diagonal M^-1/2``. The world-space inertia square root
+    comes from a symmetric ``3 x 3`` eigendecomposition, and the normalized
+    minimum eigenvalue uses twelve fixed cyclic Jacobi sweeps. This bounded
+    device work is suitable for CUDA graph capture.
+
+    Finite asymmetric matrices are symmetrized. Positive mass below
+    ``mass_floor``, inertia eigenvalues below ``inertia_floor``, and normalized
+    smooth eigenvalues below ``eta_floor`` are clamped. Non-finite input,
+    nonpositive mass, or invalid policy parameters return
+    ``BODY_WEIGHT_STATUS_INVALID`` and zero matrices.
+
+    Args:
+        smooth_diagonal: Symmetric ``6 x 6`` body block ``A_ii`` in
+            linear-first twist order.
+        mass: Positive body mass [kg].
+        inertia_world: Symmetric body inertia about its center of mass in
+            world axes [kg m^2].
+        sigma: Lower spectral fraction in the weight clamp.
+        beta: Nominal weight transition threshold. The ``sigma`` floor may
+            exceed it for sufficiently stiff modes.
+        mass_floor: Minimum accepted positive mass [kg].
+        inertia_floor: Minimum principal moment [kg m^2].
+        eta_floor: Minimum dimensionless normalized smooth eigenvalue.
+
+    Returns:
+        The weight, inverse weight, spectral values, and validation status.
+    """
+    if (
+        not wp.isfinite(mass)
+        or not wp.isfinite(inertia_world)
+        or not wp.isfinite(smooth_diagonal)
+        or not wp.isfinite(sigma)
+        or not wp.isfinite(beta)
+        or not wp.isfinite(mass_floor)
+        or not wp.isfinite(inertia_floor)
+        or not wp.isfinite(eta_floor)
+        or mass <= 0.0
+        or sigma <= 0.0
+        or sigma > 1.0
+        or beta <= 0.0
+        or mass_floor <= 0.0
+        or inertia_floor <= 0.0
+        or eta_floor <= 0.0
+    ):
+        return _make_invalid_body_weight_result()
+
+    regularized_mass = mass
+    if regularized_mass < mass_floor:
+        regularized_mass = mass_floor
+
+    symmetric_inertia = _symmetrize_mat33(inertia_world)
+    symmetric_smooth = _symmetrize_mat66(smooth_diagonal)
+
+    inertia_axes, inertia_eigenvalues = wp.eig3(symmetric_inertia)
+    if not wp.isfinite(inertia_eigenvalues) or not wp.isfinite(inertia_axes):
+        return _make_invalid_body_weight_result()
+    regularized_inertia_eigenvalues = wp.max(inertia_eigenvalues, wp.vec3f(inertia_floor))
+
+    regularized_inertia = wp.mat33f(0.0)
+    inverse_inertia = wp.mat33f(0.0)
+    inverse_sqrt_inertia = wp.mat33f(0.0)
+    for row in range(3):
+        for col in range(3):
+            for index in range(3):
+                axis_product = inertia_axes[row, index] * inertia_axes[col, index]
+                principal_inertia = regularized_inertia_eigenvalues[index]
+                regularized_inertia[row, col] += axis_product * principal_inertia
+                inverse_inertia[row, col] += axis_product / principal_inertia
+                inverse_sqrt_inertia[row, col] += axis_product / wp.sqrt(principal_inertia)
+
+    inverse_sqrt_mass = 1.0 / wp.sqrt(regularized_mass)
+    inverse_sqrt_spatial_mass = mat66f(0.0)
+    for index in range(3):
+        inverse_sqrt_spatial_mass[index, index] = inverse_sqrt_mass
+    for row in range(3):
+        for col in range(3):
+            inverse_sqrt_spatial_mass[row + 3, col + 3] = inverse_sqrt_inertia[row, col]
+
+    normalized_smooth = inverse_sqrt_spatial_mass @ symmetric_smooth @ inverse_sqrt_spatial_mass
+    normalized_smooth = _symmetrize_mat66(normalized_smooth)
+    eta = _compute_symmetric_eigenvalue_min_fixed(normalized_smooth)
+    if not wp.isfinite(eta):
+        return _make_invalid_body_weight_result()
+    if eta < eta_floor:
+        eta = eta_floor
+
+    alpha = wp.max(sigma * eta, wp.min(beta, eta))
+    if not wp.isfinite(alpha) or alpha <= 0.0:
+        return _make_invalid_body_weight_result()
+
+    weight = mat66f(0.0)
+    inverse_weight = mat66f(0.0)
+    for index in range(3):
+        weight[index, index] = alpha * regularized_mass
+        inverse_weight[index, index] = 1.0 / (alpha * regularized_mass)
+    for row in range(3):
+        for col in range(3):
+            weight[row + 3, col + 3] = alpha * regularized_inertia[row, col]
+            inverse_weight[row + 3, col + 3] = inverse_inertia[row, col] / alpha
+
+    result = BodyWeightResult()
+    result.weight = weight
+    result.inverse_weight = inverse_weight
+    result.eta = eta
+    result.alpha = alpha
+    result.status = BODY_WEIGHT_STATUS_VALID
+    return result

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -1006,6 +1006,165 @@ def _compute_cts_contacts_residual(
 
 
 @wp.kernel
+def _pack_joint_constraint_reactions(
+    model_time_dt: wp.array[wp.float32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_num_dynamic_cts: wp.array[wp.int32],
+    model_joint_num_kinematic_cts: wp.array[wp.int32],
+    model_joint_num_friction_cts: wp.array[wp.int32],
+    model_joint_dynamic_cts_offset: wp.array[wp.int32],
+    model_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_joint_friction_cts_offset: wp.array[wp.int32],
+    model_joint_dynamic_cts_offset_total_cts: wp.array[wp.int32],
+    model_joint_kinematic_cts_offset_total_cts: wp.array[wp.int32],
+    model_joint_friction_cts_offset_total_cts: wp.array[wp.int32],
+    joint_dynamic_reaction: wp.array[wp.float32],
+    joint_kinematic_reaction: wp.array[wp.float32],
+    joint_friction_reaction: wp.array[wp.float32],
+    constraint_impulse: wp.array[wp.float32],
+):
+    """Pack force-valued joint reactions into the dual impulse layout."""
+    joint = wp.tid()
+    world = model_joint_wid[joint]
+    time_step = model_time_dt[world]
+    dynamic_count = model_joint_num_dynamic_cts[joint]
+    kinematic_count = model_joint_num_kinematic_cts[joint]
+    friction_count = model_joint_num_friction_cts[joint]
+    dynamic_source = model_joint_dynamic_cts_offset[joint]
+    kinematic_source = model_joint_kinematic_cts_offset[joint]
+    friction_source = model_joint_friction_cts_offset[joint]
+    dynamic_destination = model_joint_dynamic_cts_offset_total_cts[joint]
+    kinematic_destination = model_joint_kinematic_cts_offset_total_cts[joint]
+    friction_destination = model_joint_friction_cts_offset_total_cts[joint]
+    for row in range(dynamic_count):
+        constraint_impulse[dynamic_destination + row] = time_step * joint_dynamic_reaction[dynamic_source + row]
+    for row in range(kinematic_count):
+        constraint_impulse[kinematic_destination + row] = time_step * joint_kinematic_reaction[kinematic_source + row]
+    for row in range(friction_count):
+        constraint_impulse[friction_destination + row] = time_step * joint_friction_reaction[friction_source + row]
+
+
+@wp.kernel
+def _pack_limit_constraint_reactions(
+    model_time_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    limit_model_num_limits: wp.array[wp.int32],
+    limit_wid: wp.array[wp.int32],
+    limit_lid: wp.array[wp.int32],
+    limit_reaction: wp.array[wp.float32],
+    constraint_impulse: wp.array[wp.float32],
+):
+    """Pack force-valued limit reactions into the dual impulse layout."""
+    limit = wp.tid()
+    if limit >= limit_model_num_limits[0]:
+        return
+    world = limit_wid[limit]
+    destination = model_info_total_cts_offset[world] + data_info_limit_cts_group_offset[world] + limit_lid[limit]
+    constraint_impulse[destination] = model_time_dt[world] * limit_reaction[limit]
+
+
+@wp.kernel
+def _pack_contact_constraint_reactions(
+    model_time_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    contact_model_num_contacts: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_reaction: wp.array[wp.vec3f],
+    constraint_impulse: wp.array[wp.float32],
+):
+    """Pack force-valued contact reactions into the dual impulse layout."""
+    contact = wp.tid()
+    if contact >= contact_model_num_contacts[0]:
+        return
+    world = contact_wid[contact]
+    destination = (
+        model_info_total_cts_offset[world] + data_info_contact_cts_group_offset[world] + 3 * contact_cid[contact]
+    )
+    impulse = model_time_dt[world] * contact_reaction[contact]
+    for component in range(3):
+        constraint_impulse[destination + component] = impulse[component]
+
+
+@wp.kernel
+def _compute_constraint_velocity_from_body_velocity(
+    model_info_bodies_offset: wp.array[wp.int32],
+    body_velocity_previous: wp.array[wp.spatial_vectorf],
+    body_velocity: wp.array[wp.spatial_vectorf],
+    jacobian_offsets: wp.array[wp.int32],
+    jacobian_data: wp.array[wp.float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_velocity_bias: wp.array[wp.float32],
+    problem_impact_scale: wp.array[wp.float32],
+    constraint_velocity: wp.array[wp.float32],
+):
+    """Evaluate the unpreconditioned biased constraint velocity at a body velocity."""
+    world, row = wp.tid()
+    if row >= problem_dim[world]:
+        return
+    body_offset = model_info_bodies_offset[world]
+    body_count = model_info_bodies_offset[world + 1] - body_offset
+    body_dof_count = 6 * body_count
+    vector_index = problem_vio[world] + row
+    matrix_index = jacobian_offsets[world] + body_dof_count * row
+    impact_scale = problem_impact_scale[vector_index]
+    value = problem_velocity_bias[vector_index]
+    for body_local in range(body_count):
+        jacobian = wp.spatial_vectorf(0.0)
+        for dof in range(6):
+            jacobian[dof] = jacobian_data[matrix_index + 6 * body_local + dof]
+        value += wp.dot(jacobian, body_velocity[body_offset + body_local])
+        value += impact_scale * wp.dot(jacobian, body_velocity_previous[body_offset + body_local])
+    constraint_velocity[vector_index] = value
+
+
+@wp.kernel
+def _initialize_constraint_velocity_from_body_velocity_sparse(
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_velocity_bias: wp.array[wp.float32],
+    constraint_velocity: wp.array[wp.float32],
+):
+    world, row = wp.tid()
+    if row < problem_dim[world]:
+        vector_index = problem_vio[world] + row
+        constraint_velocity[vector_index] = problem_velocity_bias[vector_index]
+
+
+@wp.kernel
+def _accumulate_constraint_velocity_from_body_velocity_sparse(
+    model_info_bodies_offset: wp.array[wp.int32],
+    body_velocity_previous: wp.array[wp.spatial_vectorf],
+    body_velocity: wp.array[wp.spatial_vectorf],
+    jacobian_num_nzb: wp.array[wp.int32],
+    jacobian_nzb_start: wp.array[wp.int32],
+    jacobian_nzb_coords: wp.array2d[wp.int32],
+    jacobian_nzb_values: wp.array[vec6f],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_impact_scale: wp.array[wp.float32],
+    constraint_velocity: wp.array[wp.float32],
+):
+    world, local_nzb = wp.tid()
+    if local_nzb >= jacobian_num_nzb[world]:
+        return
+    nzb = jacobian_nzb_start[world] + local_nzb
+    coordinates = jacobian_nzb_coords[nzb]
+    row = coordinates[0]
+    if row >= problem_dim[world]:
+        return
+    vector_index = problem_vio[world] + row
+    body = model_info_bodies_offset[world] + coordinates[1] // 6
+    jacobian = jacobian_nzb_values[nzb]
+    value = wp.dot(jacobian, body_velocity[body])
+    value += problem_impact_scale[vector_index] * wp.dot(jacobian, body_velocity_previous[body])
+    wp.atomic_add(constraint_velocity, vector_index, value)
+
+
+@wp.kernel
 def _compute_dual_problem_metrics(
     # Inputs:
     problem_nbc: wp.array[wp.int32],
@@ -1028,6 +1187,7 @@ def _compute_dual_problem_metrics(
     solution_sigma: wp.array[wp.vec2f],
     solution_lambdas: wp.array[wp.float32],
     solution_v_plus: wp.array[wp.float32],
+    use_solution_velocity_for_ncp: wp.bool,
     # Buffers:
     buffer_s: wp.array[wp.float32],
     buffer_v: wp.array[wp.float32],
@@ -1072,15 +1232,19 @@ def _compute_dual_problem_metrics(
     # Compute the post-event constraint-space velocity error as: r_v_plus = || v_plus_est - v_plus_true ||_inf
     r_v_plus, r_v_plus_argmax = compute_vector_difference_infnorm(ncts, vio, solution_v_plus, buffer_v)
 
-    # Compute the De Saxce correction for each contact as: s = G(v_plus)
+    # Initialize the velocity and De Saxce correction from the frozen dual problem.
     compute_desaxce_corrections(nc, cio, vio, ccgo, problem_mu, buffer_v, buffer_s)
 
-    # Compute the CCP optimization objective as: f_ccp = 0.5 * lambda.dot(v_plus + v_f)
-    f_ccp = 0.5 * compute_double_dot_product(ncts, vio, solution_lambdas, buffer_v, problem_v_f)
+    # Force-output backends report an accepted velocity independently of the
+    # frozen dual problem. Test their NCP against that actual output state.
+    if use_solution_velocity_for_ncp:
+        for row in range(ncts):
+            buffer_v[vio + row] = solution_v_plus[vio + row]
+        compute_desaxce_corrections(nc, cio, vio, ccgo, problem_mu, buffer_v, buffer_s)
 
-    # Compute the NCP optimization objective as:  f_ncp = f_ccp + lambda.dot(s)
-    f_ncp = compute_dot_product(ncts, vio, solution_lambdas, buffer_s)
-    f_ncp += f_ccp
+    # Compute the objectives from the same velocity used by the NCP metrics.
+    f_ccp = 0.5 * compute_double_dot_product(ncts, vio, solution_lambdas, buffer_v, problem_v_f)
+    f_ncp = compute_dot_product(ncts, vio, solution_lambdas, buffer_s) + f_ccp
 
     # Compute the augmented post-event constraint-space velocity as: v_aug = v_plus + s
     compute_vector_sum(ncts, vio, buffer_v, buffer_s, buffer_v)
@@ -1193,6 +1357,7 @@ def _compute_dual_problem_metrics_sparse(
     problem_bound_upper: wp.array[wp.float32],
     solution_lambdas: wp.array[wp.float32],
     solution_v_plus: wp.array[wp.float32],
+    use_solution_velocity_for_ncp: wp.bool,
     # Buffers:
     buffer_s: wp.array[wp.float32],
     buffer_v: wp.array[wp.float32],
@@ -1236,15 +1401,19 @@ def _compute_dual_problem_metrics_sparse(
     # Compute the post-event constraint-space velocity error as: r_v_plus = || v_plus_est - v_plus_true ||_inf
     r_v_plus, r_v_plus_argmax = compute_vector_difference_infnorm(ncts, vio, solution_v_plus, buffer_v)
 
-    # Compute the De Saxce correction for each contact as: s = G(v_plus)
+    # Initialize the velocity and De Saxce correction from the frozen dual problem.
     compute_desaxce_corrections(nc, cio, vio, ccgo, problem_mu, buffer_v, buffer_s)
 
-    # Compute the CCP optimization objective as: f_ccp = 0.5 * lambda.dot(v_plus + v_f)
-    f_ccp = 0.5 * compute_double_dot_product(ncts, vio, solution_lambdas, buffer_v, problem_v_f)
+    # Force-output backends report an accepted velocity independently of the
+    # frozen dual problem. Test their NCP against that actual output state.
+    if use_solution_velocity_for_ncp:
+        for row in range(ncts):
+            buffer_v[vio + row] = solution_v_plus[vio + row]
+        compute_desaxce_corrections(nc, cio, vio, ccgo, problem_mu, buffer_v, buffer_s)
 
-    # Compute the NCP optimization objective as:  f_ncp = f_ccp + lambda.dot(s)
-    f_ncp = compute_dot_product(ncts, vio, solution_lambdas, buffer_s)
-    f_ncp += f_ccp
+    # Compute the objectives from the same velocity used by the NCP metrics.
+    f_ccp = 0.5 * compute_double_dot_product(ncts, vio, solution_lambdas, buffer_v, problem_v_f)
+    f_ncp = compute_dot_product(ncts, vio, solution_lambdas, buffer_s) + f_ccp
 
     # Compute the augmented post-event constraint-space velocity as: v_aug = v_plus + s
     compute_vector_sum(ncts, vio, buffer_v, buffer_s, buffer_v)
@@ -1371,6 +1540,9 @@ class SolutionMetrics:
         # Declare data buffers for metrics computations
         self._buffer_s: wp.array[wp.float32] | None = None
         self._buffer_v: wp.array[wp.float32] | None = None
+        self._constraint_impulse: wp.array[wp.float32] | None = None
+        self._constraint_velocity: wp.array[wp.float32] | None = None
+        self._zero_sigma: wp.array[wp.vec2f] | None = None
 
         # If a model is provided, finalize the metrics data allocations
         if model is not None:
@@ -1395,6 +1567,9 @@ class SolutionMetrics:
             # Allocate reusable buffers for metrics computations
             self._buffer_v = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
             self._buffer_s = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
+            self._constraint_impulse = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
+            self._constraint_velocity = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
+            self._zero_sigma = wp.zeros(model.size.num_worlds, dtype=wp.vec2f)
 
             # Allocate the metrics container data arrays
             self._data = SolutionMetricsData(
@@ -1480,9 +1655,175 @@ class SolutionMetrics:
             v_plus: The array of post-event constraint-space velocities of the current dual problem solution.
         """
         self._assert_has_data()
+        self.evaluate_primal(model, data, state_p, jacobians, limits, contacts)
+        self._evaluate_dual_problem_perf(sigma, lambdas, v_plus, problem)
+
+    def evaluate_primal(
+        self,
+        model: ModelKamino,
+        data: DataKamino,
+        state_p: StateKamino,
+        jacobians: DenseSystemJacobians | SparseSystemJacobians,
+        limits: LimitsKamino | None = None,
+        contacts: ContactsKamino | None = None,
+    ) -> None:
+        """Evaluate backend-neutral EOM and constraint metrics.
+
+        Args:
+            model: The model containing time-invariant simulation data.
+            data: The model data containing the final simulation state.
+            state_p: The state at the beginning of the time step.
+            jacobians: The system Jacobians used by the dynamics solve.
+            limits: Active joint-limit constraints.
+            contacts: Active contact constraints.
+        """
+        self._assert_has_data()
         self._evaluate_constraint_violations_perf(model, data, limits, contacts)
         self._evaluate_primal_problem_perf(model, data, state_p, jacobians)
-        self._evaluate_dual_problem_perf(sigma, lambdas, v_plus, problem)
+
+    def evaluate_from_constraint_forces(
+        self,
+        model: ModelKamino,
+        data: DataKamino,
+        state_p: StateKamino,
+        problem: DualProblem,
+        jacobians: DenseSystemJacobians | SparseSystemJacobians,
+        limits: LimitsKamino | None = None,
+        contacts: ContactsKamino | None = None,
+    ) -> None:
+        """Evaluate metrics from force-valued Kamino constraint outputs.
+
+        This path is intended for dynamics backends that do not natively solve
+        Kamino's dual problem. It packs their force-valued joint, limit, and
+        contact reactions into the same impulse-space layout as PADMM and
+        evaluates the measured constraint velocity from the final body
+        velocity. Velocity-dependent NCP and VI residuals and the reported dual
+        objectives use this measured velocity. ``r_v_plus`` compares it with the
+        velocity implied by the supplied analysis problem. That problem must
+        have been built at the backend's dynamics linearization before its solve.
+
+        Args:
+            model: The model containing time-invariant simulation data.
+            data: The model data containing the final body state and reactions.
+            state_p: The state at the beginning of the time step.
+            problem: Analysis dual problem built before the dynamics solve.
+            jacobians: Constraint Jacobians used by the dynamics solve.
+            limits: Active joint-limit constraints.
+            contacts: Active contact constraints.
+        """
+        self._assert_has_data()
+
+        self._constraint_impulse.zero_()
+        self._constraint_velocity.zero_()
+        if model.size.sum_of_num_joints > 0:
+            wp.launch(
+                _pack_joint_constraint_reactions,
+                dim=model.size.sum_of_num_joints,
+                inputs=[
+                    model.time.dt,
+                    model.joints.wid,
+                    model.joints.num_dynamic_cts,
+                    model.joints.num_kinematic_cts,
+                    model.joints.num_friction_cts,
+                    model.joints.dynamic_cts_offset,
+                    model.joints.kinematic_cts_offset,
+                    model.joints.friction_cts_offset,
+                    model.joints.dynamic_cts_offset_total_cts,
+                    model.joints.kinematic_cts_offset_total_cts,
+                    model.joints.friction_cts_offset_total_cts,
+                    data.joints.lambda_dyn_j,
+                    data.joints.lambda_kin_j,
+                    data.joints.lambda_f_j,
+                ],
+                outputs=[self._constraint_impulse],
+                device=model.device,
+            )
+        if limits is not None and limits.model_max_limits_host > 0:
+            wp.launch(
+                _pack_limit_constraint_reactions,
+                dim=limits.model_max_limits_host,
+                inputs=[
+                    model.time.dt,
+                    model.info.total_cts_offset,
+                    data.info.limit_cts_group_offset,
+                    limits.model_active_limits,
+                    limits.wid,
+                    limits.lid,
+                    limits.reaction,
+                ],
+                outputs=[self._constraint_impulse],
+                device=model.device,
+            )
+        if contacts is not None and contacts.model_max_contacts_host > 0:
+            wp.launch(
+                _pack_contact_constraint_reactions,
+                dim=contacts.model_max_contacts_host,
+                inputs=[
+                    model.time.dt,
+                    model.info.total_cts_offset,
+                    data.info.contact_cts_group_offset,
+                    contacts.model_active_contacts,
+                    contacts.wid,
+                    contacts.cid,
+                    contacts.reaction,
+                ],
+                outputs=[self._constraint_impulse],
+                device=model.device,
+            )
+
+        if isinstance(jacobians, DenseSystemJacobians):
+            wp.launch(
+                _compute_constraint_velocity_from_body_velocity,
+                dim=(model.size.num_worlds, model.size.max_of_max_total_cts),
+                inputs=[
+                    model.info.bodies_offset,
+                    state_p.u_i,
+                    data.bodies.u_i,
+                    jacobians.data.J_cts_offsets,
+                    jacobians.data.J_cts_data,
+                    problem.data.dim,
+                    problem.data.vio,
+                    problem.data.v_b,
+                    problem.data.v_i,
+                ],
+                outputs=[self._constraint_velocity],
+                device=model.device,
+            )
+        else:
+            jacobian = jacobians._J_cts.bsm
+            wp.launch(
+                _initialize_constraint_velocity_from_body_velocity_sparse,
+                dim=(model.size.num_worlds, model.size.max_of_max_total_cts),
+                inputs=[problem.data.dim, problem.data.vio, problem.data.v_b],
+                outputs=[self._constraint_velocity],
+                device=model.device,
+            )
+            wp.launch(
+                _accumulate_constraint_velocity_from_body_velocity_sparse,
+                dim=(model.size.num_worlds, jacobian.max_of_num_nzb),
+                inputs=[
+                    model.info.bodies_offset,
+                    state_p.u_i,
+                    data.bodies.u_i,
+                    jacobian.num_nzb,
+                    jacobian.nzb_start,
+                    jacobian.nzb_coords,
+                    jacobian.nzb_values,
+                    problem.data.dim,
+                    problem.data.vio,
+                    problem.data.v_i,
+                ],
+                outputs=[self._constraint_velocity],
+                device=model.device,
+            )
+        self.evaluate_primal(model, data, state_p, jacobians, limits, contacts)
+        self._evaluate_dual_problem_perf(
+            self._zero_sigma,
+            self._constraint_impulse,
+            self._constraint_velocity,
+            problem,
+            use_solution_velocity_for_ncp=True,
+        )
 
     ###
     # Internals
@@ -1669,6 +2010,7 @@ class SolutionMetrics:
         lambdas: wp.array[wp.float32],
         v_plus: wp.array[wp.float32],
         problem: DualProblem,
+        use_solution_velocity_for_ncp: bool = False,
     ):
         """
         Evaluates the dual problem performance metrics.
@@ -1678,6 +2020,9 @@ class SolutionMetrics:
             sigma: The array of sigma values for the dual problem.
             lambdas: The array of lambda values for the dual problem.
             v_plus: The array of v_plus values for the dual problem.
+            use_solution_velocity_for_ncp: Whether velocity-dependent NCP and
+                VI residuals and objectives use ``v_plus`` instead of the
+                velocity implied by the dual problem.
         """
         # Ensure metrics data is available
         self._assert_has_data()
@@ -1719,6 +2064,7 @@ class SolutionMetrics:
                     problem.data.bound_upper,
                     lambdas,
                     v_plus,
+                    use_solution_velocity_for_ncp,
                     # Buffers:
                     self._buffer_s,
                     self._buffer_v,
@@ -1764,6 +2110,7 @@ class SolutionMetrics:
                     sigma,
                     lambdas,
                     v_plus,
+                    use_solution_velocity_for_ncp,
                     # Buffers:
                     self._buffer_s,
                     self._buffer_v,

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -281,6 +281,12 @@ class PADMMSolver:
         block_dim = get_block_dim(tile_size, ratio=2, min_size=1)
         self._project_dual_convergence_accel_kernel = _make_project_dual_convergence_accel_kernel(block_dim)
 
+    def notify_model_changed(self, flags: object) -> None:
+        del flags
+
+    def validate_model_changed(self) -> None:
+        pass
+
     def reset(self, problem: DualProblem | None = None, world_mask: wp.array[wp.bool] | None = None):
         """
         Resets the all internal solver data to sentinel values.

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -11,6 +11,7 @@ import math
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+import numpy as np
 import warp as wp
 
 from ...core.types import override
@@ -27,6 +28,7 @@ __all__ = [
     "ConstraintStabilizationConfig",
     "DVISolverConfig",
     "ForwardKinematicsSolverConfig",
+    "LOXSolverConfig",
     "PADMMSolverConfig",
 ]
 
@@ -965,6 +967,277 @@ class DVISolverConfig:
         if self.contact_warmstart_method not in implemented_contact_warmstart_methods:
             raise ValueError(
                 f"DVI contact warmstart method is not implemented: {self.contact_warmstart_method}. "
+                f"Choose one of {sorted(implemented_contact_warmstart_methods)}."
+            )
+
+    @override
+    def __post_init__(self):
+        """Post-initialization to validate configurations."""
+        self.validate()
+
+
+@dataclass(kw_only=True)
+class LOXSolverConfig:
+    """A container to hold configurations for the LOX forward dynamics solver.
+
+    .. experimental::
+
+        The LOX backend supports rigid bodies only. Cable and deformable
+        extensions are not supported.
+    """
+
+    max_iterations: int = 25
+    """Maximum LOX splitting iterations per forward-dynamics solve."""
+
+    use_graph_conditionals: bool = True
+    """Whether to terminate LOX splitting with a device condition.
+
+    Outside graph capture, this permits early termination through an eager
+    :func:`warp.capture_while` loop. When disabled, or when CUDA graph
+    conditional nodes are unavailable during capture, the solver unrolls
+    :attr:`max_iterations` iterations instead.
+    """
+
+    fixed_iterations: bool = False
+    """Whether to skip convergence checks and run exactly :attr:`max_iterations`.
+
+    This reduces per-iteration synchronization for throughput-oriented
+    simulations. Failed projections still deactivate their worlds.
+    """
+
+    eliminate_fixed_world_islands: bool = True
+    """Whether to eliminate fixed-joint tree islands attached to the world.
+
+    Disable this to retain those bodies in the dynamic solve and compute their
+    fixed-joint support reactions. Bodies marked with :attr:`newton.BodyFlags.KINEMATIC`
+    remain prescribed.
+    """
+
+    projection_iterations: int = 5
+    """Primary unilateral projection sweeps per splitting iteration.
+
+    One colored Gauss--Seidel iteration visits every unilateral color; after
+    these iterations, one global mass-split Jacobi sweep smooths the resulting
+    impulses.
+    """
+
+    projection_method: Literal["jacobi", "gauss_seidel", "apgd"] = "gauss_seidel"
+    """Body-space unilateral projection method.
+
+    Select ``"jacobi"`` for mass-split parallel sweeps, ``"gauss_seidel"``
+    for sequential sweeps, or ``"apgd"`` for restarted acceleration of the
+    mass-split Jacobi map.
+    """
+
+    inertial_warmstart_fraction: float = 0.0
+    """Fraction of external-force acceleration pre-applied to the initial LOX guess.
+
+    Dynamic rigid bodies start from their step-start
+    velocity plus this fraction of ``dt`` times the acceleration due to State
+    forces and gravity. Prescribed rigid twists are always used in full.
+    """
+
+    joint_proximal_relaxation: float = 0.0
+    """Relaxation factor for exact candidate-pose structural joint residuals.
+
+    Zero retains the frozen linear residual. Positive values relax a stored
+    nonlinear residual correction toward the exact candidate-pose residual
+    while reusing the frozen Jacobian, primal matrix, and factorization. The
+    relaxation changes convergence speed without changing the nonlinear fixed
+    point.
+    """
+
+    position_tolerance: float = 1.0e-5
+    """Translational end-of-step convergence tolerance [m]."""
+
+    rotation_tolerance: float = 1.0e-5
+    """Rotational end-of-step convergence tolerance [rad]."""
+
+    velocity_tolerance: float = 1.0e-5
+    """Velocity-space convergence tolerance for actuator residuals [m/s or rad/s]."""
+
+    weight_sigma: float = 1.0e-3
+    """Relative lower scale used by the inertia-normalized body-weight clamp."""
+
+    weight_beta: float = 4.0
+    """Normalized smooth-weight transition threshold used by the body-weight heuristic.
+
+    The conditioning floor set by :attr:`weight_sigma` may dominate this
+    threshold for sufficiently stiff modes.
+    """
+
+    selective_weights: bool = True
+    """Whether to restrict proximal weights to unilateral-constraint incidence.
+
+    When enabled, the LOX splitting operator applies its proximal metric only
+    to rigid bodies incident to a unilateral constraint.
+    """
+
+    joint_penalty_scale: float = 100.0
+    """Dimensionless scale for effective-mass structural penalties and consensus weights."""
+
+    joint_multiplier_projected_fraction: float = 1.0
+    """Fraction of projected-twist feedback in structural updates, in [0, 1].
+
+    The default reconciles structural reactions with the twist that will be
+    integrated. Zero recovers the global-twist product-space ADMM update.
+    """
+
+    joint_warmstart_factor: float = 0.5
+    """Fraction of the previous structural reaction used to warm-start the next time step."""
+
+    impact_velocity_threshold: float = 1.0e-3
+    """Minimum approaching normal speed that enables restitution [m/s]."""
+
+    contact_recoverable_response: bool = False
+    """Whether speculative contacts permit overlap recoverable as the unreduced restitution response."""
+
+    contact_warmstart_method: Literal[
+        "key_and_position",
+        "geom_pair_net_force",
+        "key_and_position_with_net_force_backup",
+        "key_and_position_with_tangential_net_force",
+        "key_and_position_with_net_force_backup_and_tangential_net_force",
+    ] = "key_and_position"
+    """Method used to warm-start contacts."""
+
+    gauss_seidel_max_colors: int = 4
+    """Maximum colors used by Gauss--Seidel unilateral projection.
+
+    One selects the existing mass-split Jacobi projection. Values greater than
+    one process approximate colors sequentially while solving each color with
+    mass-split Jacobi. The multi-color path uses the smaller of this value and
+    its allocated
+    unilateral capacity, retaining one inert internal color for an empty
+    system. It finishes with one global Jacobi smoothing sweep.
+    """
+
+    @override
+    @staticmethod
+    def register_custom_attributes(builder: ModelBuilder) -> None:
+        """Register LOX custom attributes supported by the Kamino USD schema.
+
+        LOX-specific tuning options are currently Python-only. The shared
+        ``max_solver_iterations`` attribute is registered by
+        :class:`PADMMSolverConfig`.
+        """
+
+    @override
+    @staticmethod
+    def from_model(model: Model, **kwargs: dict[str, Any]) -> LOXSolverConfig:
+        """Creates a :class:`LOXSolverConfig` from model attributes if available.
+
+        Args:
+            model: The Newton model from which to parse configurations.
+        """
+        cfg = LOXSolverConfig(**kwargs)
+        kamino_attrs = getattr(model, "kamino", None)
+        if kamino_attrs is not None and hasattr(kamino_attrs, "max_solver_iterations"):
+            max_iterations = int(kamino_attrs.max_solver_iterations.numpy()[0])
+            if max_iterations >= 0:
+                cfg.max_iterations = max_iterations
+        cfg.validate()
+        return cfg
+
+    @override
+    def validate(self) -> None:
+        """Validates the current values held by this config instance."""
+        from ._src.solvers.warmstart import WarmstarterContacts  # noqa: PLC0415
+
+        iteration_fields = {
+            "max_iterations": self.max_iterations,
+            "projection_iterations": self.projection_iterations,
+        }
+        for name, value in iteration_fields.items():
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"Invalid {name}: {value}. Must be an integer greater than or equal to one.")
+        if not isinstance(self.use_graph_conditionals, bool):
+            raise ValueError(f"Invalid use_graph_conditionals: {self.use_graph_conditionals}. Must be a boolean.")
+        if not isinstance(self.fixed_iterations, bool):
+            raise ValueError(f"Invalid fixed_iterations: {self.fixed_iterations}. Must be a boolean.")
+        if not isinstance(self.eliminate_fixed_world_islands, bool):
+            raise ValueError(
+                f"Invalid eliminate_fixed_world_islands: {self.eliminate_fixed_world_islands}. Must be a boolean."
+            )
+        if (
+            not np.isfinite(self.joint_proximal_relaxation)
+            or self.joint_proximal_relaxation < 0.0
+            or self.joint_proximal_relaxation > 1.0
+        ):
+            raise ValueError(
+                f"Invalid joint_proximal_relaxation: {self.joint_proximal_relaxation}. Must be in range [0, 1]."
+            )
+        if self.projection_method not in ("jacobi", "gauss_seidel", "apgd"):
+            raise ValueError(
+                f"Invalid projection_method: {self.projection_method}. Must be 'jacobi', 'gauss_seidel', or 'apgd'."
+            )
+        if (
+            not isinstance(self.gauss_seidel_max_colors, int)
+            or isinstance(self.gauss_seidel_max_colors, bool)
+            or self.gauss_seidel_max_colors < 0
+            or (self.projection_method == "gauss_seidel" and self.gauss_seidel_max_colors == 0)
+        ):
+            raise ValueError(
+                f"Invalid gauss_seidel_max_colors: {self.gauss_seidel_max_colors}. "
+                "Must be positive for Gauss-Seidel and non-negative otherwise."
+            )
+        if (
+            not np.isfinite(self.inertial_warmstart_fraction)
+            or self.inertial_warmstart_fraction < 0.0
+            or self.inertial_warmstart_fraction > 1.0
+        ):
+            raise ValueError(
+                f"Invalid inertial_warmstart_fraction: {self.inertial_warmstart_fraction}. Must be in range [0, 1]."
+            )
+
+        if not np.isfinite(self.position_tolerance) or self.position_tolerance <= 0.0:
+            raise ValueError(f"Invalid position_tolerance: {self.position_tolerance}. Must be greater than zero.")
+        if not np.isfinite(self.rotation_tolerance) or self.rotation_tolerance <= 0.0:
+            raise ValueError(f"Invalid rotation_tolerance: {self.rotation_tolerance}. Must be greater than zero.")
+        if not np.isfinite(self.velocity_tolerance) or self.velocity_tolerance <= 0.0:
+            raise ValueError(f"Invalid velocity_tolerance: {self.velocity_tolerance}. Must be greater than zero.")
+        if not np.isfinite(self.weight_sigma) or self.weight_sigma <= 0.0 or self.weight_sigma > 1.0:
+            raise ValueError(f"Invalid weight_sigma: {self.weight_sigma}. Must be in range (0, 1].")
+        if not np.isfinite(self.weight_beta) or self.weight_beta < 1.0:
+            raise ValueError(f"Invalid weight_beta: {self.weight_beta}. Must be at least one.")
+        if not isinstance(self.selective_weights, bool):
+            raise ValueError(f"Invalid selective_weights: {self.selective_weights}. Must be a boolean.")
+        if not np.isfinite(self.joint_penalty_scale) or self.joint_penalty_scale <= 0.0:
+            raise ValueError(f"Invalid joint_penalty_scale: {self.joint_penalty_scale}. Must be greater than zero.")
+        if (
+            not np.isfinite(self.joint_multiplier_projected_fraction)
+            or self.joint_multiplier_projected_fraction < 0.0
+            or self.joint_multiplier_projected_fraction > 1.0
+        ):
+            raise ValueError(
+                "Invalid joint_multiplier_projected_fraction: "
+                f"{self.joint_multiplier_projected_fraction}. Must be in range [0, 1]."
+            )
+        if (
+            not np.isfinite(self.joint_warmstart_factor)
+            or self.joint_warmstart_factor < 0.0
+            or self.joint_warmstart_factor > 1.0
+        ):
+            raise ValueError(f"Invalid joint_warmstart_factor: {self.joint_warmstart_factor}. Must be in range [0, 1].")
+        if not np.isfinite(self.impact_velocity_threshold) or self.impact_velocity_threshold < 0.0:
+            raise ValueError(
+                f"Invalid impact_velocity_threshold: {self.impact_velocity_threshold}. Must be non-negative."
+            )
+        if not isinstance(self.contact_recoverable_response, bool):
+            raise ValueError(
+                f"Invalid contact_recoverable_response: {self.contact_recoverable_response}. Must be a boolean."
+            )
+        WarmstarterContacts.Method.from_string(self.contact_warmstart_method)
+        implemented_contact_warmstart_methods = {
+            "key_and_position",
+            "geom_pair_net_force",
+            "key_and_position_with_net_force_backup",
+            "key_and_position_with_tangential_net_force",
+            "key_and_position_with_net_force_backup_and_tangential_net_force",
+        }
+        if self.contact_warmstart_method not in implemented_contact_warmstart_methods:
+            raise ValueError(
+                f"LOX contact warmstart method is not implemented: {self.contact_warmstart_method}. "
                 f"Choose one of {sorted(implemented_contact_warmstart_methods)}."
             )
 

--- a/newton/_src/solvers/kamino/examples/rl/example_rl_drlegs.py
+++ b/newton/_src/solvers/kamino/examples/rl/example_rl_drlegs.py
@@ -59,6 +59,9 @@ wp.set_module_options({"enable_backward": False})
 # Walk task config
 # ---------------------------------------------------------------------------
 
+# The available policy predates the later DR Legs design update.
+_DR_LEGS_POLICY_ASSET_REF = "261cd1f429619d8ef4f546bd788ab9dea906b5e1"
+
 _DEFAULTS = {
     "action_scale": 0.4,
     "contact_duration": 0.3,
@@ -111,6 +114,7 @@ class Example:
         policy=None,
         headless: bool = False,
         max_steps: int = 10000,
+        dynamics_solver: str = "padmm",
     ):
         self.cfg = config
 
@@ -122,8 +126,13 @@ class Example:
         num_worlds = 1
 
         # USD model path
-        asset_path = newton.utils.download_asset("disneyresearch", ref="261cd1f429619d8ef4f546bd788ab9dea906b5e1")
+        asset_path = newton.utils.download_asset("disneyresearch", ref=_DR_LEGS_POLICY_ASSET_REF)
         usd_model_path = str(asset_path / config["usd_model"])
+
+        settings = RigidBodySim.default_settings(self.sim_dt)
+        settings.solver.dynamics_solver = dynamics_solver
+        if dynamics_solver == "lox":
+            settings.solver.integrator = "euler"
 
         # Create generic articulated body simulator
         self.sim_wrapper = RigidBodySim(
@@ -133,6 +142,7 @@ class Example:
             device=device,
             headless=headless,
             body_pose_offset=(0.0, 0.0, config["body_pose_offset_z"], 0.0, 0.0, 0.0, 1.0),
+            settings=settings,
             use_cuda_graph=True,
             render_config=ViewerConfig(
                 diffuse_scale=1.0,
@@ -482,6 +492,12 @@ if __name__ == "__main__":
         "--policy", type=str, default=None, help="Path to an rsl_rl checkpoint .pt file (overrides asset default)"
     )
     parser.add_argument(
+        "--dynamics-solver",
+        choices=("padmm", "lox"),
+        default="padmm",
+        help="Kamino rigid-body dynamics backend.",
+    )
+    parser.add_argument(
         "--mode",
         choices=["sync", "async"],
         default="sync",
@@ -510,7 +526,7 @@ if __name__ == "__main__":
     torch_device = "cuda" if device.is_cuda else "cpu"
 
     # Load config from YAML (with hardcoded fallback defaults)
-    asset_path = newton.utils.download_asset("disneyresearch", ref="261cd1f429619d8ef4f546bd788ab9dea906b5e1")
+    asset_path = newton.utils.download_asset("disneyresearch", ref=_DR_LEGS_POLICY_ASSET_REF)
     config = _load_drlegs_config(asset_path)
 
     # CLI overrides
@@ -538,6 +554,7 @@ if __name__ == "__main__":
         policy=policy,
         headless=args.headless,
         max_steps=args.num_steps,
+        dynamics_solver=args.dynamics_solver,
     )
 
     try:

--- a/newton/_src/solvers/kamino/examples/rl/simulation.py
+++ b/newton/_src/solvers/kamino/examples/rl/simulation.py
@@ -154,6 +154,8 @@ class SimulatorFromNewton:
             self._newton_state,
             self._newton_contacts,
             self._contacts,
+            cull_speculative_contacts=self._config.solver.dynamics_solver != "lox",
+            skip_fully_prescribed_contacts=self._config.solver.dynamics_solver == "lox",
         )
 
     def step(self):
@@ -164,6 +166,7 @@ class SimulatorFromNewton:
         only for rendering via :meth:`RigidBodySim.render`.
         """
         self._state_p.copy_from(self._state_n)
+        dt = self._config.dt if isinstance(self._config.dt, float) else None
 
         if self._use_newton_collisions:
             self._run_newton_collision(self._state_p)
@@ -173,6 +176,7 @@ class SimulatorFromNewton:
                 control=self._control,
                 contacts=self._contacts,
                 detector=None,
+                dt=dt,
             )
         else:
             self._solver.step(
@@ -181,6 +185,7 @@ class SimulatorFromNewton:
                 control=self._control,
                 contacts=self._contacts,
                 detector=self._collision_detector,
+                dt=dt,
             )
 
     def reset(self, **kwargs):

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -18,6 +18,7 @@ import warp as wp
 from ...core.types import override
 from ...geometry.types import GeoType
 from ...sim import (
+    BodyFlags,
     Contacts,
     Control,
     JointType,
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
         ConstraintStabilizationConfig,
         DVISolverConfig,
         ForwardKinematicsSolverConfig,
+        LOXSolverConfig,
         MaterialManagerConfig,
         PADMMSolverConfig,
     )
@@ -180,8 +182,9 @@ class SolverKamino(SolverBase, CouplingInterface):
 
         sparse_jacobian: bool | None = None
         """
-        Whether to use a sparse Jacobian representation. When unspecified, defaults to `True` for DVI and `False`
-        for PADMM.
+        Whether the solver should use a sparse Jacobian. ``None`` selects the
+        backend default: sparse for DVI and LOX, and dense for PADMM. LOX
+        requires sparse Jacobians.
         """
 
         sparse_dynamics: bool = False
@@ -242,6 +245,13 @@ class SolverKamino(SolverBase, CouplingInterface):
         If `None`, default values will be used.
         """
 
+        lox: LOXSolverConfig | None = None
+        """
+        Configurations for the LOX dynamics solver.\n
+        See :class:`LOXSolverConfig` for more details.\n
+        If `None`, default values will be used.
+        """
+
         fk: ForwardKinematicsSolverConfig | None = None
         """
         Configurations for the forward kinematics solver.\n
@@ -272,7 +282,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         Defaults to `"euler"`.
         """
 
-        dynamics_solver: Literal["padmm", "dvi"] = "padmm"
+        dynamics_solver: Literal["padmm", "dvi", "lox"] = "padmm"
         """
         The forward dynamics solver to use. Construct the config with this value
         so solver-dependent defaults are initialized consistently. Defaults to
@@ -325,6 +335,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             config.CollisionDetectorConfig.register_custom_attributes(builder)
             config.PADMMSolverConfig.register_custom_attributes(builder)
             config.DVISolverConfig.register_custom_attributes(builder)
+            config.LOXSolverConfig.register_custom_attributes(builder)
             config.MaterialManagerConfig.register_custom_attributes(builder)
 
             # Register KaminoSceneAPI custom attributes for each individual solver-level configurations
@@ -379,6 +390,7 @@ class SolverKamino(SolverBase, CouplingInterface):
                 "dynamics": config.ConstrainedDynamicsConfig,
                 "padmm": config.PADMMSolverConfig,
                 "dvi": config.DVISolverConfig,
+                "lox": config.LOXSolverConfig,
                 "fk": config.ForwardKinematicsSolverConfig,
                 "materials": config.MaterialManagerConfig,
             }
@@ -411,7 +423,17 @@ class SolverKamino(SolverBase, CouplingInterface):
             from ._src.core.joints import JointCorrectionMode  # noqa: PLC0415
 
             # Ensure that the sparsity settings are compatible with each other
-            if self.sparse_dynamics and not self.sparse_jacobian:
+            sparse_jacobian = self.sparse_jacobian
+            if self.dynamics_solver == "lox":
+                if sparse_jacobian is None:
+                    sparse_jacobian = True
+                    self.sparse_jacobian = True
+                elif not isinstance(sparse_jacobian, bool):
+                    raise ValueError(f"Invalid sparse_jacobian: {sparse_jacobian}. Must be a boolean or None.")
+                elif not sparse_jacobian:
+                    raise ValueError("The LOX solver requires `sparse_jacobian=True`.")
+
+            if self.sparse_dynamics and not sparse_jacobian:
                 raise ValueError(
                     "Sparsity setting mismatch: `sparse_dynamics` solver "
                     "option requires that `sparse_jacobian` is set to `True`."
@@ -426,6 +448,8 @@ class SolverKamino(SolverBase, CouplingInterface):
                 raise ValueError("PADMM solver config cannot be None.")
             elif self.dvi is None:
                 raise ValueError("DVI solver config cannot be None.")
+            elif self.lox is None:
+                raise ValueError("LOX solver config cannot be None.")
 
             # Validate specialized sub-configurations
             # using their own built-in validations
@@ -437,9 +461,10 @@ class SolverKamino(SolverBase, CouplingInterface):
             self.dynamics.validate()
             self.padmm.validate()
             self.dvi.validate()
+            self.lox.validate()
             self.materials.validate()
 
-            supported_dynamics_solvers = {"padmm", "dvi"}
+            supported_dynamics_solvers = {"padmm", "dvi", "lox"}
             if self.dynamics_solver not in supported_dynamics_solvers:
                 raise ValueError(
                     f"Invalid dynamics solver: {self.dynamics_solver}. Must be one of {supported_dynamics_solvers}."
@@ -455,6 +480,11 @@ class SolverKamino(SolverBase, CouplingInterface):
                 and self.padmm.penalty_update_method != "fixed"
             ):
                 raise ValueError("Adaptive PADMM penalty updates require `sparse_dynamics=True`.")
+            if self.dynamics_solver == "lox":
+                if self.sparse_dynamics:
+                    raise ValueError("The LOX solver requires dense dynamics.")
+                if self.dynamics.linear_solver_type != "LLTB":
+                    raise ValueError("The LOX solver requires the LLTB linear solver.")
 
             # Conversion to JointCorrectionMode will raise an error if the input string is invalid.
             JointCorrectionMode.from_string(self.rotation_correction)
@@ -480,7 +510,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             from . import config  # noqa: PLC0415
 
             if self.sparse_jacobian is None:
-                self.sparse_jacobian = self.dynamics_solver == "dvi"
+                self.sparse_jacobian = self.dynamics_solver in {"dvi", "lox"}
 
             # Default-initialize any sub-configurations that were not explicitly provided by the user
             if self.collision_detector is None and self.use_collision_detector:
@@ -509,6 +539,8 @@ class SolverKamino(SolverBase, CouplingInterface):
                 # Storage backends share one convergence schedule; sparse
                 # optimizations must not silently weaken DVI semantics.
                 self.dvi = config.DVISolverConfig()
+            if self.lox is None:
+                self.lox = config.LOXSolverConfig()
             if self.materials is None:
                 self.materials = config.MaterialManagerConfig()
 
@@ -746,18 +778,17 @@ class SolverKamino(SolverBase, CouplingInterface):
         # as class variables if not already done
         self._import_kamino()
 
-        # Validate that the model does not contain unsupported components
-        self._validate_model_compatibility(model)
-
         # Cache configurations; either from the user-provided config or from the model's custom attributes
         # NOTE: `Config.from_model` will default-initialize if no relevant custom attributes were
         # found on the model, so `self._config` will always be fully initialized after this step.
         if config is None:
             config = self.Config.from_model(model)
-        else:
-            # Validate the user-provided config. Protects against modifying the config after initialization.
-            config.validate()
+        # Protect against modifying a previously initialized configuration.
+        config.validate()
         self._config = config
+
+        # Validate solver-specific model compatibility after resolving the selected backend.
+        self._validate_model_compatibility(model, self._config)
 
         # Create a Kamino model from the Newton model
         self._model_kamino = self._kamino.ModelKamino.from_newton(model)
@@ -786,7 +817,6 @@ class SolverKamino(SolverBase, CouplingInterface):
         )
         # Scratch scalar for material update validation
         self._material_update_conflict = wp.empty(1, dtype=wp.int32, device=model.device)
-
         # Create a collision detector if enabled in the config, otherwise
         # set to `None` to disable internal collision detection in Kamino
         self._collision_detector_kamino = None
@@ -842,6 +872,11 @@ class SolverKamino(SolverBase, CouplingInterface):
             contacts=self._contacts_kamino,
             config=self._config,
         )
+        self._cull_speculative_contacts = self._config.dynamics.cull_speculative_contacts
+        self._skip_fully_prescribed_contacts = False
+        if self._config.dynamics_solver == "lox":
+            self._cull_speculative_contacts = False
+            self._skip_fully_prescribed_contacts = True
 
         # Initialize the internal Kamino control wrapper
         self._control_kamino = self._kamino.ControlKamino()
@@ -851,8 +886,8 @@ class SolverKamino(SolverBase, CouplingInterface):
     def status(self) -> wp.array[Any]:
         """Per-world terminal solver status on the simulation device.
 
-        The active backend defines the array's Warp struct type. Both PADMM and
-        DVI provide ``converged``, ``iterations``, ``r_p``, ``r_d``, and ``r_c``
+        The active backend defines the array's Warp struct type. PADMM, DVI, and
+        LOX provide ``converged``, ``iterations``, ``r_p``, ``r_d``, and ``r_c``
         fields. Backend-specific fields may also be present.
 
         Residuals are absolute maxima, not relative or dimensionless values.
@@ -874,11 +909,49 @@ class SolverKamino(SolverBase, CouplingInterface):
         violation; and ``r_c = max |lambda_k dot v_k|`` [J] is the maximum
         inequality complementarity violation.
 
+        LOX reports its native convergence flag and splitting iteration count.
+        When :attr:`Config.compute_solution_metrics` is enabled, ``r_p``,
+        ``r_d``, and ``r_c`` contain the NCP primal, dual, and complementarity
+        residuals evaluated from the final constraint reactions and velocity.
+        These fields are NaN when solution metrics are disabled. LOX also
+        provides ``accepted``, ``failed``, and ``iteration_limit`` fields.
+
         The returned array aliases the solver's device-resident storage; reading
         it does not synchronize or copy data to the host. Terminal status is
         available regardless of :attr:`Config.collect_solver_info`.
         """
         return self._solver_kamino.solver_status
+
+    @property
+    def metrics(self) -> Any | None:
+        """Solution metrics evaluator, or ``None`` when metrics are disabled.
+
+        Enable metrics with :attr:`Config.compute_solution_metrics` and access
+        the per-world metric arrays through ``solver.metrics.data`` after each
+        call to :meth:`step`.
+        """
+        return self._solver_kamino.metrics
+
+    def lox_joint_penalty_scale_seed(self, dt: float) -> list[float]:
+        """Estimate and apply a timestep-aware LOX joint penalty scale.
+
+        Call this once after constructing a LOX solver and before capturing or
+        stepping the simulation. The operation performs a one-time dense
+        structural analysis and synchronizes with the host.
+
+        Args:
+            dt: Simulation time step [s].
+
+        Returns:
+            The estimated and applied dimensionless structural ALM penalty
+            scale for each world.
+
+        Raises:
+            ValueError: If this solver does not use the LOX dynamics backend.
+        """
+        if self._config.dynamics_solver != "lox":
+            raise ValueError("LOX joint penalty scale seeding requires the LOX dynamics backend.")
+        return self._solver_kamino.solver_fd.joint_penalty_scale_seed(dt)
 
     @override
     def reset(
@@ -981,6 +1054,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         _preserve_if_unset(state_kamino.dq_j, StateFlags.JOINT_QD)
         _preserve_if_unset(state_kamino.q_i, StateFlags.BODY_Q)
         _preserve_if_unset(state_kamino.u_i, StateFlags.BODY_QD)
+        _preserve_if_unset(state_kamino.lambda_w_i, StateFlags.BODY_QD)
 
         # Execute the reset operation of the Kamino solver,
         # to write the reset state to `state_kamino`.
@@ -1046,8 +1120,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._detector = self._collision_detector_kamino
         elif contacts is not None:
             self._detector = None
-            # The contacts container is `None` when the model admits no possible contacts.
-            if self._contacts_kamino is not None:
+            if self.model.body_count > 0 and self._contacts_kamino is not None:
                 self._kamino.convert_contacts_newton_to_kamino(
                     model=self.model,
                     state=state_in,
@@ -1056,12 +1129,14 @@ class SolverKamino(SolverBase, CouplingInterface):
                     convert_forces=False,
                     friction_mix_mode=self._config.materials.friction_mix_mode,
                     restitution_mix_mode=self._config.materials.restitution_mix_mode,
-                    cull_speculative_contacts=self._config.dynamics.cull_speculative_contacts,
+                    cull_speculative_contacts=self._cull_speculative_contacts,
+                    skip_fully_prescribed_contacts=self._skip_fully_prescribed_contacts,
                 )
         else:
             self._detector = None
             # Clear the internal contacts container to avoid using stale contacts from previous steps.
-            self._contacts_kamino.clear()
+            if self._contacts_kamino is not None:
+                self._contacts_kamino.clear()
 
         # Convert Newton body-frame poses to Kamino CoM-frame poses
         self._kamino.convert_body_origin_to_com(
@@ -1080,12 +1155,15 @@ class SolverKamino(SolverBase, CouplingInterface):
             dt=dt,
         )
 
-        # Convert back from Kamino CoM-frame to Newton body-frame poses
-        self._kamino.convert_body_com_to_origin(
-            body_com=self._model_kamino.bodies.i_r_com_i,
-            body_q_com=state_in_kamino.q_i,
-            body_q=state_in_kamino.q_i,
-        )
+        # Convert back from Kamino CoM-frame to Newton body-frame poses. When
+        # stepping in place, the output write replaced the aliased input pose,
+        # so converting it twice would apply the CoM offset twice.
+        if state_in_kamino.q_i.ptr != state_out_kamino.q_i.ptr:
+            self._kamino.convert_body_com_to_origin(
+                body_com=self._model_kamino.bodies.i_r_com_i,
+                body_q_com=state_in_kamino.q_i,
+                body_q=state_in_kamino.q_i,
+            )
         self._kamino.convert_body_com_to_origin(
             body_com=self._model_kamino.bodies.i_r_com_i,
             body_q_com=state_out_kamino.q_i,
@@ -1160,6 +1238,12 @@ class SolverKamino(SolverBase, CouplingInterface):
                 "SolverKamino.notify_model_changed: flags 0x%x not yet supported",
                 unsupported,
             )
+
+    def get_max_contact_count(self) -> int:
+        """Return the maximum number of rigid contacts that Kamino can generate."""
+        if self._contacts_kamino is None:
+            return 0
+        return self._contacts_kamino.model_max_contacts_host
 
     @override
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
@@ -1252,7 +1336,15 @@ class SolverKamino(SolverBase, CouplingInterface):
                 default=0.0,
             )
         )
-
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="body_lox_dual_impulse",
+                assignment=Model.AttributeAssignment.STATE,
+                frequency=Model.AttributeFrequency.BODY,
+                dtype=wp.spatial_vectorf,
+                default=wp.spatial_vectorf(0.0),
+            )
+        )
         # Register FK custom actuation types
         builder.add_custom_attribute(
             ModelBuilder.CustomAttribute(
@@ -1290,7 +1382,7 @@ class SolverKamino(SolverBase, CouplingInterface):
                 raise ImportError("Kamino backend not found.") from e
 
     @staticmethod
-    def _validate_model_compatibility(model: Model):
+    def _validate_model_compatibility(model: Model, config: SolverKamino.Config):
         """
         Validates that the model does not contain components unsupported by SolverKamino:
         - particles
@@ -1298,7 +1390,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         - triangles, edges, tetrahedra
         - muscles
         - distance or rod joints
-        - bodies with singular inertial properties that are attached to movable bodies
+        - bodies with singular inertial properties that are attached to movable bodies for non-LOX backends
 
         Args:
             model: The Newton model to validate.
@@ -1308,6 +1400,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         """
 
         unsupported_features = []
+        use_lox = config.dynamics_solver == "lox"
         if model.particle_count > 0:
             unsupported_features.append(f"particles (found {model.particle_count})")
         if model.spring_count > 0:
@@ -1339,14 +1432,15 @@ class SolverKamino(SolverBase, CouplingInterface):
                 joint_desc = [f"{name} ({count} instances)" for name, count in unsupported_joint_types.items()]
                 unsupported_features.append("joint types: " + ", ".join(joint_desc))
 
-        singular_bodies = SolverKamino._find_unsupported_singular_inertia_bodies(model)
-        if len(singular_bodies) > 0:
-            unsupported_features.append(
-                "bodies with singular inertial properties that are attached to movable bodies:\n"
-                + "\n".join(f"      - {desc}" for desc in singular_bodies)
-                + "\n    Import with `collapse_fixed_joints=True` to merge these bodies into their neighbors,"
-                "\n    or give them a non-zero mass and inertia."
-            )
+        if not use_lox:
+            singular_bodies = SolverKamino._find_unsupported_singular_inertia_bodies(model)
+            if len(singular_bodies) > 0:
+                unsupported_features.append(
+                    "bodies with singular inertial properties that are attached to movable bodies:\n"
+                    + "\n".join(f"      - {desc}" for desc in singular_bodies)
+                    + "\n    Import with `collapse_fixed_joints=True` to merge these bodies into their neighbors,"
+                    "\n    or give them a non-zero mass and inertia."
+                )
 
         # If any unsupported features were found, raise an error
         if len(unsupported_features) > 0:
@@ -1357,11 +1451,12 @@ class SolverKamino(SolverBase, CouplingInterface):
 
     @staticmethod
     def _find_unsupported_singular_inertia_bodies(model: Model) -> list[str]:
-        """Finds bodies whose singular inertial properties make them unsafe to simulate.
+        """Find bodies whose singular inertial properties make them unsafe to simulate.
 
         A body with singular inverse mass or inertia cannot respond to all applied wrenches in the
-        dual formulation. Such a body is only safe in two situations:
+        dual formulation. Such a body is only safe in these situations:
 
+        - It is explicitly kinematic, so its velocity is prescribed independently of inertia.
         - It is welded to the world, so a permanently frozen velocity is the correct answer.
         - It only has a free joint to the world, and is not attached to any other bodies.
           It then stays at its initial velocity.
@@ -1381,7 +1476,12 @@ class SolverKamino(SolverBase, CouplingInterface):
         inv_mass = model.body_inv_mass.numpy()
         inv_inertia = model.body_inv_inertia.numpy()
         singular_inertia = np.linalg.matrix_rank(inv_inertia) < 3
-        singular = [b for b in range(model.body_count) if inv_mass[b] == 0.0 or singular_inertia[b]]
+        body_flags = model.body_flags.numpy()
+        singular = [
+            b
+            for b in range(model.body_count)
+            if not (body_flags[b] & int(BodyFlags.KINEMATIC)) and (inv_mass[b] == 0.0 or singular_inertia[b])
+        ]
         if not singular:
             return []
 

--- a/newton/_src/solvers/kamino/tests/__init__.py
+++ b/newton/_src/solvers/kamino/tests/__init__.py
@@ -52,7 +52,6 @@ def setup_tests(verbose: bool = False, device: wp.DeviceLike | str | None = None
     # Warp configuration
     wp.init()
     wp.config.mode = "release"
-    wp.config.enable_backward = False
     wp.config.verify_fp = False
     wp.config.verify_cuda = False
 

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_lox.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_lox.py
@@ -1,0 +1,886 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for the LOX Kamino dynamics backend."""
+
+import math
+import unittest
+from unittest import mock
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton._src.solvers.kamino.config as kamino_config
+from newton._src.solvers.kamino._src.core.model import ModelKamino
+from newton._src.solvers.kamino._src.geometry.detector import CollisionDetector
+from newton._src.solvers.kamino._src.solver_kamino_impl import SolverKaminoImpl
+from newton._src.solvers.kamino.solver_kamino import SolverKamino
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+from newton.tests.utils.basics import (
+    build_box_on_plane,
+    build_boxes_hinged,
+    build_cartpole,
+)
+
+
+def _build_revolute_dynamics_model(
+    *,
+    damping: float,
+    friction: float,
+    velocity: float,
+    armature: float = 0.0,
+    target_ke: float = 0.0,
+    target_kd: float = 0.0,
+    effort_limit: float = math.inf,
+    actuator_mode: newton.JointTargetMode | None = None,
+    device: wp.DeviceLike = None,
+) -> newton.Model:
+    """Build a gravity-free world-to-body hinge with consistent initial velocity."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    body = builder.add_link(
+        mass=1.0,
+        inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        lock_inertia=True,
+    )
+    joint = builder.add_joint_revolute(
+        parent=-1,
+        child=body,
+        axis=newton.Axis.Y,
+        damping=damping,
+        friction=friction,
+        armature=armature,
+        target_ke=target_ke,
+        target_kd=target_kd,
+        effort_limit=effort_limit,
+        actuator_mode=actuator_mode,
+    )
+    builder.add_articulation([joint])
+    builder.body_qd[body] = wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, velocity, 0.0)
+    builder.joint_qd[builder.joint_qd_start[joint]] = velocity
+    builder.end_world()
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, 0.0))
+    return model
+
+
+def _build_massless_fixed_child_drive_model(
+    *,
+    include_massless_fixed_child: bool = True,
+    device: wp.DeviceLike = None,
+) -> newton.Model:
+    """Build a driven link with an optional massless fixed child."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    inertia = wp.mat33f(0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01)
+    driven = builder.add_link(mass=1.0, inertia=inertia, lock_inertia=True)
+    revolute = builder.add_joint_revolute(
+        parent=-1,
+        child=driven,
+        axis=newton.Axis.Z,
+        armature=0.1,
+        target_ke=650.0,
+        target_kd=100.0,
+        effort_limit=math.inf,
+        actuator_mode=newton.JointTargetMode.POSITION,
+    )
+    joints = [revolute]
+    if include_massless_fixed_child:
+        child = builder.add_link(
+            xform=wp.transformf(wp.vec3f(0.0, 0.0, 0.1), wp.quat_identity(dtype=wp.float32)),
+            mass=0.0,
+            inertia=wp.mat33f(),
+            lock_inertia=True,
+        )
+        joints.append(
+            builder.add_joint_fixed(
+                parent=driven,
+                child=child,
+                parent_xform=wp.transformf(
+                    wp.vec3f(0.0, 0.0, 0.1),
+                    wp.quat_identity(dtype=wp.float32),
+                ),
+            )
+        )
+    builder.add_articulation(joints)
+    builder.end_world()
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, 0.0))
+    return model
+
+
+def _build_driven_link_with_grounded_fixed_base(*, device: wp.DeviceLike = None) -> tuple[newton.Model, int]:
+    """Build a driven link whose prescribed base overlaps the ground."""
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    inertia = wp.mat33f(0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01)
+    base = builder.add_link(
+        xform=wp.transformf(wp.vec3f(0.0, 0.0, 0.05), wp.quat_identity(dtype=wp.float32)),
+        mass=1.0,
+        inertia=inertia,
+        lock_inertia=True,
+    )
+    builder.add_shape_box(
+        base,
+        hx=0.1,
+        hy=0.1,
+        hz=0.1,
+        cfg=newton.ModelBuilder.ShapeConfig(density=0.0),
+    )
+    driven = builder.add_link(
+        xform=wp.transformf(wp.vec3f(0.0, 0.0, 0.25), wp.quat_identity(dtype=wp.float32)),
+        mass=1.0,
+        inertia=inertia,
+        lock_inertia=True,
+    )
+    fixed = builder.add_joint_fixed(
+        parent=-1,
+        child=base,
+        parent_xform=wp.transformf(wp.vec3f(0.0, 0.0, 0.05), wp.quat_identity(dtype=wp.float32)),
+    )
+    revolute = builder.add_joint_revolute(
+        parent=base,
+        child=driven,
+        axis=newton.Axis.Z,
+        armature=0.1,
+        target_ke=650.0,
+        target_kd=100.0,
+        effort_limit=math.inf,
+        actuator_mode=newton.JointTargetMode.POSITION,
+    )
+    builder.add_articulation([fixed, revolute])
+    builder.add_ground_plane(cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
+    builder.end_world()
+    model = builder.finalize(device=device)
+    model.rigid_contact_max = 16
+    return model, driven
+
+
+def _build_zero_mass_prismatic_anchor_model(*, device: wp.DeviceLike = None) -> tuple[newton.Model, int, int]:
+    """Build a zero-mass anchor connected to a dynamic prismatic child."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    anchor = builder.add_link()
+    child = builder.add_link()
+    builder.add_shape_box(anchor, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
+    builder.add_shape_box(child)
+    fixed = builder.add_joint_fixed(parent=-1, child=anchor)
+    prismatic = builder.add_joint_prismatic(parent=anchor, child=child, axis=newton.Axis.Z)
+    builder.add_articulation([fixed, prismatic])
+    builder.end_world()
+    return builder.finalize(device=device), anchor, child
+
+
+def _build_prescribed_only_model(*, device: wp.DeviceLike = None) -> tuple[newton.Model, int]:
+    """Build a world containing only one zero-mass body."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    body = builder.add_link()
+    builder.add_shape_box(body, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
+    fixed = builder.add_joint_fixed(parent=-1, child=body)
+    builder.add_articulation([fixed])
+    builder.end_world()
+    return builder.finalize(device=device), body
+
+
+def _build_flagged_kinematic_model(*, device: wp.DeviceLike = None) -> tuple[newton.Model, int]:
+    """Build a massive free body whose motion is prescribed by its body flag."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    body = builder.add_link(
+        mass=1.0,
+        inertia=wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        lock_inertia=True,
+    )
+    builder.body_flags[body] = int(newton.BodyFlags.KINEMATIC)
+    joint = builder.add_joint_free(parent=-1, child=body)
+    builder.add_articulation([joint])
+    builder.end_world()
+    return builder.finalize(device=device), body
+
+
+class TestSolverKaminoLOX(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def make_config(
+        self,
+        compute_solution_metrics: bool = False,
+        sparse_jacobian: bool = True,
+    ) -> SolverKamino.Config:
+        return SolverKamino.Config(
+            dynamics_solver="lox",
+            compute_solution_metrics=compute_solution_metrics,
+            sparse_jacobian=sparse_jacobian,
+            lox=kamino_config.LOXSolverConfig(
+                max_iterations=25,
+                projection_iterations=5,
+            ),
+        )
+
+    def test_free_fall_advances_projected_velocity_and_pose(self):
+        """Advance the projected velocity and pose of a free-falling rigid body."""
+        model = ModelKamino.from_newton(build_box_on_plane(ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        time_step = 0.01
+
+        solver.step(state_previous, state_next, control, dt=time_step)
+
+        gravity = model.gravity.vector.numpy()[0]
+        expected_velocity = time_step * gravity
+        np.testing.assert_allclose(state_next.u_i.numpy()[0, :3], expected_velocity, rtol=0.0, atol=5.0e-4)
+        expected_height = state_previous.q_i.numpy()[0, 2] + time_step * expected_velocity[2]
+        self.assertAlmostEqual(float(state_next.q_i.numpy()[0, 2]), float(expected_height), places=5)
+        self.assertTrue(np.isfinite(state_next.q_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+
+    def test_moreau_free_fall_uses_midpoint_configuration(self):
+        """Compose LOX forward dynamics with Kamino's Moreau integrator."""
+        model = ModelKamino.from_newton(build_box_on_plane(ground=False).finalize(device=self.device))
+        config = self.make_config()
+        config.integrator = "moreau"
+        config.use_collision_detector = True
+        solver = SolverKaminoImpl(model=model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        time_step = 0.01
+
+        solver.step(state_previous, state_next, model.control(), dt=time_step)
+
+        gravity = model.gravity.vector.numpy()[0]
+        expected_velocity = time_step * gravity
+        np.testing.assert_allclose(state_next.u_i.numpy()[0, :3], expected_velocity, rtol=0.0, atol=5.0e-4)
+        expected_height = state_previous.q_i.numpy()[0, 2] + 0.5 * time_step * expected_velocity[2]
+        self.assertAlmostEqual(float(state_next.q_i.numpy()[0, 2]), float(expected_height), places=6)
+
+    def test_standard_integrators_apply_angular_velocity_damping(self):
+        """Apply Kamino angular damping after a LOX forward-dynamics solve."""
+        for integrator in ("euler", "moreau"):
+            with self.subTest(integrator=integrator):
+                builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+                build_box_on_plane(builder=builder, ground=False)
+                model = ModelKamino.from_newton(builder.finalize(device=self.device))
+                config = self.make_config()
+                config.integrator = integrator
+                config.use_collision_detector = True
+                config.angular_velocity_damping = 0.5
+                solver = SolverKaminoImpl(model=model, config=config)
+                state_previous = model.state()
+                state_next = model.state()
+                state_previous.u_i.assign([wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 1.0, 0.0)])
+                time_step = 0.1
+
+                solver.step(state_previous, state_next, model.control(), dt=time_step)
+
+                expected_angular_velocity = 1.0 - config.angular_velocity_damping * time_step
+                self.assertAlmostEqual(float(state_next.u_i.numpy()[0, 4]), expected_angular_velocity, places=5)
+
+    def test_free_fall_uses_each_world_time_step(self):
+        """Advance each rigid world with its configured device-side time step."""
+        builder = build_box_on_plane(ground=False)
+        build_box_on_plane(builder=builder, ground=False)
+        model = ModelKamino.from_newton(builder.finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        time_step = np.asarray([0.01, 0.025], dtype=np.float32)
+        model.time.dt.assign(time_step)
+        model.time.inv_dt.assign(1.0 / time_step)
+
+        solver.step(state_previous, state_next, model.control(), dt=None)
+
+        gravity = model.gravity.vector.numpy()[: model.size.num_worlds]
+        body_world = model.bodies.wid.numpy()
+        expected_velocity = time_step[body_world, None] * gravity[body_world]
+        np.testing.assert_allclose(state_next.u_i.numpy()[:, :3], expected_velocity, rtol=0.0, atol=5.0e-4)
+        expected_height = state_previous.q_i.numpy()[:, 2] + time_step[body_world] * expected_velocity[:, 2]
+        np.testing.assert_allclose(state_next.q_i.numpy()[:, 2], expected_height, rtol=0.0, atol=1.0e-6)
+
+    def test_zero_mass_joint_anchor_is_prescribed_and_eliminated(self):
+        """Use a prescribed anchor velocity in the dynamic child's joint bias."""
+        model, anchor, child = _build_zero_mass_prismatic_anchor_model(device=self.device)
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        prescribed_velocity = np.zeros((2, 6), dtype=np.float32)
+        prescribed_velocity[anchor, 0] = 0.25
+        state_previous.body_qd.assign(prescribed_velocity)
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.01)
+
+        np.testing.assert_allclose(state_next.body_qd.numpy()[anchor], prescribed_velocity[anchor], rtol=0.0, atol=0.0)
+        self.assertAlmostEqual(float(state_next.body_qd.numpy()[child, 0]), 0.25, places=4)
+        self.assertLess(float(state_next.body_qd.numpy()[child, 2]), -1.0e-3)
+        self.assertTrue(np.isfinite(state_next.body_q.numpy()).all())
+        self.assertTrue(np.isfinite(state_next.body_qd.numpy()).all())
+
+    def test_prescribed_only_world_preserves_velocity_without_body_unknowns(self):
+        """Preserve velocity in a prescribed-only world with no body unknowns."""
+        model, body = _build_prescribed_only_model(device=self.device)
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        prescribed_velocity = np.asarray([[0.2, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+        state_previous.body_qd.assign(prescribed_velocity)
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.01)
+
+        np.testing.assert_allclose(state_next.body_qd.numpy()[body], prescribed_velocity[body], rtol=0.0, atol=0.0)
+
+    def test_body_flag_marks_massive_body_as_kinematic(self):
+        """Prescribe a massive body's motion through BodyFlags.KINEMATIC."""
+        model, body = _build_flagged_kinematic_model(device=self.device)
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        prescribed_velocity = np.asarray([[0.2, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+        state_previous.body_qd.assign(prescribed_velocity)
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.01)
+
+        np.testing.assert_allclose(state_next.body_qd.numpy()[body], prescribed_velocity[body], rtol=0.0, atol=0.0)
+
+    def test_kinematic_flag_change_requires_solver_rebuild(self):
+        """Reject a runtime immovability change after Kamino has culled constraints."""
+        model, _body = _build_flagged_kinematic_model(device=self.device)
+        solver = SolverKamino(model, config=self.make_config())
+
+        model.body_flags.fill_(int(newton.BodyFlags.DYNAMIC))
+        with self.assertRaisesRegex(RuntimeError, "immovability.*recreate SolverKamino"):
+            solver.notify_model_changed(newton.ModelFlags.BODY_PROPERTIES)
+
+    def test_kinematic_joint_friction_is_projection_noop(self):
+        """Ignore joint friction when both incident bodies are prescribed."""
+        model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=1.0,
+            velocity=0.25,
+            device=self.device,
+        )
+        model.body_flags.fill_(int(newton.BodyFlags.KINEMATIC))
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.01)
+
+        np.testing.assert_allclose(
+            state_next.body_qd.numpy(),
+            state_previous.body_qd.numpy(),
+            rtol=0.0,
+            atol=0.0,
+        )
+
+    def test_native_model_joint_friction_uses_zero_force(self):
+        """Use zero joint friction when a native Kamino model has no source values."""
+        source_model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=1.0,
+            velocity=0.25,
+            device=self.device,
+        )
+        model = ModelKamino.from_newton(source_model)
+        model._model = None
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKaminoImpl(model=model, config=config)
+        state_next = model.state()
+
+        solver.step(model.state(), state_next, model.control(), contacts=None, dt=0.01)
+
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_next.dq_j.numpy()).all())
+
+    def test_kinematic_joint_effort_is_projection_noop(self):
+        """Ignore bounded actuator effort when both incident bodies are prescribed."""
+        model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=0.0,
+            velocity=0.25,
+            target_ke=100.0,
+            effort_limit=1.0,
+            actuator_mode=newton.JointTargetMode.POSITION,
+            device=self.device,
+        )
+        model.body_flags.fill_(int(newton.BodyFlags.KINEMATIC))
+        config = self.make_config()
+        config.use_collision_detector = False
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.01)
+
+        np.testing.assert_allclose(
+            state_next.body_qd.numpy(),
+            state_previous.body_qd.numpy(),
+            rtol=0.0,
+            atol=0.0,
+        )
+
+    def test_joint_damping_is_implicit_in_the_smooth_row(self):
+        """Apply joint damping implicitly through the smooth row."""
+        time_step = 0.1
+        damping = 4.0
+        initial_velocity = 2.0
+        model = _build_revolute_dynamics_model(damping=damping, friction=0.0, velocity=initial_velocity)
+        solver = SolverKamino(model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=time_step)
+
+        expected = initial_velocity / (1.0 + time_step * damping)
+        self.assertAlmostEqual(float(state_next.joint_qd.numpy()[0]), expected, places=4)
+
+    def test_relaxed_joint_proximal_preserves_nonlinear_fixed_point(self):
+        """Converge a relaxed joint correction to the exact candidate-pose constraint."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        SolverKamino.register_custom_attributes(builder)
+        builder.begin_world()
+        inertia = wp.mat33f(0.2, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.4)
+        parent = builder.add_link(mass=1.0, inertia=inertia, lock_inertia=True)
+        child = builder.add_link(
+            xform=wp.transformf(wp.vec3f(0.0, 0.0, 1.0), wp.quat_identity(dtype=wp.float32)),
+            mass=1.0,
+            inertia=inertia,
+            lock_inertia=True,
+        )
+        root = builder.add_joint_revolute(parent=-1, child=parent, axis=newton.Axis.Y)
+        fixed = builder.add_joint_fixed(
+            parent=parent,
+            child=child,
+            parent_xform=wp.transformf(
+                wp.vec3f(0.0, 0.0, 1.0),
+                wp.quat_identity(dtype=wp.float32),
+            ),
+        )
+        builder.add_articulation([root, fixed])
+        builder.end_world()
+        model = builder.finalize(device=self.device)
+
+        config = self.make_config()
+        config.use_collision_detector = False
+        config.lox.fixed_iterations = True
+        config.lox.max_iterations = 20
+        config.lox.joint_proximal_relaxation = 0.5
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        velocity = np.zeros((model.body_count, 6), dtype=np.float32)
+        velocity[parent] = (0.0, 0.0, 0.0, 0.0, 5.0, 0.0)
+        velocity[child] = (8.0, -5.0, 3.0, 18.0, -12.0, 15.0)
+        state_previous.body_qd.assign(velocity)
+
+        solver.step(state_previous, state_next, model.control(), contacts=None, dt=0.05)
+
+        poses = state_next.body_q.numpy()
+        parent_position = poses[parent, :3]
+        parent_axis = poses[parent, 3:6]
+        parent_scalar = poses[parent, 6]
+        joint_offset = np.array((0.0, 0.0, 1.0), dtype=np.float32)
+        rotated_offset = joint_offset + 2.0 * (
+            parent_scalar * np.cross(parent_axis, joint_offset)
+            + np.cross(parent_axis, np.cross(parent_axis, joint_offset))
+        )
+        position_error = poses[child, :3] - parent_position - rotated_offset
+        np.testing.assert_allclose(position_error, 0.0, atol=1.0e-5)
+
+    def test_position_drive_with_massless_fixed_child(self):
+        """Track a target when the driven body has a massless fixed child."""
+        cases = ((False, "euler"), (True, "euler"), (True, "moreau"))
+        for include_massless_fixed_child, integrator in cases:
+            with self.subTest(
+                include_massless_fixed_child=include_massless_fixed_child,
+                integrator=integrator,
+            ):
+                model = _build_massless_fixed_child_drive_model(
+                    include_massless_fixed_child=include_massless_fixed_child,
+                    device=self.device,
+                )
+                config = self.make_config()
+                config.integrator = integrator
+                config.use_collision_detector = integrator == "moreau"
+                solver = SolverKamino(model, config=config)
+                state_previous = model.state()
+                state_next = model.state()
+                control = model.control()
+                control.joint_target_q.assign([0.2])
+
+                for _ in range(240):
+                    solver.step(state_previous, state_next, control, contacts=None, dt=1.0 / 600.0)
+                    state_previous, state_next = state_next, state_previous
+
+                self.assertGreater(float(state_previous.joint_q.numpy()[0]), 0.1)
+                if include_massless_fixed_child:
+                    body_q = state_previous.body_q.numpy()
+                    body_qd = state_previous.body_qd.numpy()
+                    np.testing.assert_allclose(body_qd[1], body_qd[0], rtol=0.0, atol=1.0e-4)
+                    np.testing.assert_allclose(body_q[1, 3:], body_q[0, 3:], rtol=0.0, atol=1.0e-5)
+                    np.testing.assert_allclose(body_q[1, :2], body_q[0, :2], rtol=0.0, atol=1.0e-5)
+                    self.assertAlmostEqual(float(body_q[1, 2] - body_q[0, 2]), 0.1, places=5)
+
+    def test_prescribed_contact_does_not_reject_dynamic_world(self):
+        """Ignore contacts whose two incident bodies are prescribed."""
+        model, _driven = _build_driven_link_with_grounded_fixed_base(device=self.device)
+        shape_pairs = wp.array([(0, 1)], dtype=wp.vec2i, device=self.device)
+        collision_pipeline = newton.CollisionPipeline(
+            model,
+            broad_phase="explicit",
+            shape_pairs_filtered=shape_pairs,
+        )
+        contacts = collision_pipeline.contacts()
+        config = self.make_config(sparse_jacobian=True)
+        config.use_collision_detector = False
+        config.lox.projection_method = "gauss_seidel"
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        control.joint_target_q.assign([0.2])
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_previous)
+
+        collision_pipeline.collide(state_previous, contacts)
+        self.assertGreater(int(contacts.rigid_contact_count.numpy()[0]), 0)
+        solver.step(state_previous, state_next, control, contacts, dt=1.0 / 600.0)
+        state_previous, state_next = state_next, state_previous
+
+        for _ in range(119):
+            collision_pipeline.collide(state_previous, contacts)
+            solver.step(state_previous, state_next, control, contacts, dt=1.0 / 600.0)
+            state_previous, state_next = state_next, state_previous
+
+        self.assertGreater(float(state_previous.joint_q.numpy()[0]), 0.1)
+
+    def test_joint_effort_limit_saturates_implicit_drive(self):
+        """Clamp the internal implicit drive while retaining its full stiffness."""
+        time_step = 0.1
+        model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=0.0,
+            velocity=0.0,
+            armature=1.0,
+            target_ke=100.0,
+            effort_limit=1.0,
+            actuator_mode=newton.JointTargetMode.POSITION,
+            device=self.device,
+        )
+        config = self.make_config()
+        config.lox.max_iterations = 40
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        control.joint_target_q.assign([1.0])
+
+        solver.step(state_previous, state_next, control, contacts=None, dt=time_step)
+
+        self.assertAlmostEqual(float(state_next.joint_qd.numpy()[0]), 0.05, places=4)
+
+    def test_joint_effort_limit_without_dynamic_row(self):
+        """Apply a bounded implicit drive without armature or passive damping."""
+        model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=0.0,
+            velocity=0.0,
+            armature=0.0,
+            target_ke=100.0,
+            effort_limit=1.0,
+            actuator_mode=newton.JointTargetMode.POSITION,
+            device=self.device,
+        )
+        solver = SolverKamino(model, config=self.make_config())
+        state_next = model.state()
+        control = model.control()
+        control.joint_target_q.assign([1.0])
+
+        solver.step(model.state(), state_next, control, contacts=None, dt=0.1)
+
+        self.assertAlmostEqual(float(state_next.joint_qd.numpy()[0]), 0.1, places=4)
+
+    def test_unsaturated_joint_effort_preserves_implicit_drive(self):
+        """Retain implicit PD behavior when a finite effort bound is inactive."""
+        time_step = 0.1
+        results = []
+        for effort_limit in (math.inf, 1000.0):
+            model = _build_revolute_dynamics_model(
+                damping=0.0,
+                friction=0.0,
+                velocity=0.0,
+                armature=1.0,
+                target_ke=100.0,
+                effort_limit=effort_limit,
+                actuator_mode=newton.JointTargetMode.POSITION,
+                device=self.device,
+            )
+            config = self.make_config()
+            config.lox.max_iterations = 40
+            solver = SolverKamino(model, config=config)
+            state_previous = model.state()
+            state_next = model.state()
+            control = model.control()
+            control.joint_target_q.assign([1.0])
+
+            solver.step(state_previous, state_next, control, contacts=None, dt=time_step)
+            results.append(float(state_next.joint_qd.numpy()[0]))
+
+        self.assertGreater(results[0], 1.0)
+        self.assertAlmostEqual(results[1], results[0], places=4)
+
+    def test_joint_effort_limit_excludes_external_joint_force(self):
+        """Keep external joint forces outside the actuator effort bound."""
+        time_step = 0.1
+        model = _build_revolute_dynamics_model(
+            damping=0.0,
+            friction=0.0,
+            velocity=0.0,
+            armature=1.0,
+            target_ke=100.0,
+            effort_limit=0.5,
+            actuator_mode=newton.JointTargetMode.POSITION,
+            device=self.device,
+        )
+        config = self.make_config()
+        solver = SolverKamino(model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        control.joint_f.assign([20.0])
+
+        solver.step(state_previous, state_next, control, contacts=None, dt=time_step)
+
+        self.assertAlmostEqual(float(state_next.joint_qd.numpy()[0]), 0.975, places=4)
+
+    def test_one_color_gauss_seidel_matches_rigid_jacobi(self):
+        """Dispatch one-color rigid Gauss--Seidel through the exact Jacobi path."""
+        results = {}
+        for projection_method, max_colors in (("jacobi", 0), ("gauss_seidel", 1)):
+            model = _build_revolute_dynamics_model(
+                damping=0.0,
+                friction=5.0,
+                velocity=2.0,
+                device=self.device,
+            )
+            config = self.make_config()
+            config.lox.projection_method = projection_method
+            config.lox.gauss_seidel_max_colors = max_colors
+            solver = SolverKamino(model, config=config)
+            state_next = model.state()
+
+            solver.step(model.state(), state_next, model.control(), contacts=None, dt=0.1)
+
+            results[projection_method] = (
+                state_next.body_qd.numpy(),
+                state_next.joint_qd.numpy(),
+            )
+
+        for colored_value, jacobi_value in zip(results["gauss_seidel"], results["jacobi"], strict=True):
+            np.testing.assert_array_equal(colored_value, jacobi_value)
+
+    def test_box_on_plane_projects_detected_contact(self):
+        """Project detected contacts to keep a box above the plane."""
+        model = ModelKamino.from_newton(build_box_on_plane(ground=True).finalize(device=self.device))
+        detector = CollisionDetector(
+            model,
+            config=kamino_config.CollisionDetectorConfig(pipeline="unified"),
+        )
+        contacts = detector.contacts
+        solver = SolverKaminoImpl(
+            model=model,
+            contacts=contacts,
+            config=self.make_config(compute_solution_metrics=True),
+        )
+        state_previous = model.state()
+        state_next = model.state()
+
+        solver.step(
+            state_previous,
+            state_next,
+            model.control(),
+            contacts=contacts,
+            detector=detector,
+            dt=0.01,
+        )
+
+        self.assertGreater(int(contacts.model_active_contacts.numpy()[0]), 0)
+        self.assertGreaterEqual(float(contacts.reaction.numpy()[0, 2]), 0.0)
+        self.assertGreaterEqual(float(contacts.velocity.numpy()[0, 2]), -2.0e-4)
+        self.assertGreaterEqual(float(state_next.u_i.numpy()[0, 2]), -2.0e-4)
+        self.assertGreater(float(state_next.w_i.numpy()[0, 2]), 0.0)
+        self.assertGreaterEqual(int(contacts.mode.numpy()[0]), 0)
+        self.assertTrue(np.isfinite(state_next.q_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+        np.testing.assert_array_equal(solver.solver_fd.world_failed.numpy(), [False])
+        contact_residual_max = solver.solver_fd.contact_residual_max.numpy()
+        self.assertTrue(np.isfinite(contact_residual_max).all())
+        self.assertLessEqual(float(contact_residual_max[0]), 1.0e-4)
+        metric_values = np.asarray(
+            [
+                solver.metrics.data.r_eom.numpy()[0],
+                solver.metrics.data.r_v_plus.numpy()[0],
+                solver.metrics.data.r_ncp_primal.numpy()[0],
+                solver.metrics.data.r_ncp_dual.numpy()[0],
+                solver.metrics.data.r_ncp_compl.numpy()[0],
+                solver.metrics.data.r_vi_natmap.numpy()[0],
+            ]
+        )
+        self.assertTrue(np.isfinite(metric_values).all())
+        self.assertLess(float(metric_values[0]), 1.0e-3)
+        self.assertLess(float(metric_values[2]), 1.0e-5)
+
+    def test_product_space_structural_split_hinged_contact(self):
+        """Enforce structural joints and contact for hinged bodies."""
+        model = ModelKamino.from_newton(build_boxes_hinged(z_offset=0.0, ground=True).finalize(device=self.device))
+        detector = CollisionDetector(
+            model,
+            config=kamino_config.CollisionDetectorConfig(pipeline="unified"),
+        )
+        contacts = detector.contacts
+        config = self.make_config(compute_solution_metrics=True)
+        config.lox.max_iterations = 10
+        config.lox.projection_iterations = 3
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+
+        for _ in range(20):
+            solver.step(
+                state_previous,
+                state_next,
+                model.control(),
+                contacts=contacts,
+                detector=detector,
+                dt=0.01,
+            )
+            state_previous, state_next = state_next, state_previous
+
+        splitting = solver.solver_fd.splitting
+        self.assertGreater(int(contacts.model_active_contacts.numpy()[0]), 0)
+        np.testing.assert_array_equal(solver.solver_fd.world_failed.numpy(), [False])
+        self.assertTrue(np.isfinite(splitting.residual_structural.numpy()).all())
+        self.assertTrue(np.isfinite(splitting.residual_structural_projected.numpy()).all())
+        self.assertLess(float(solver.metrics.data.r_cts_joints.numpy()[0]), 1.0e-3)
+        self.assertLess(float(solver.metrics.data.r_eom.numpy()[0]), 1.0e-3)
+
+    def test_cartpole_projects_detected_joint_limit(self):
+        """Project detected joint limits for a cartpole."""
+        model = ModelKamino.from_newton(build_cartpole(ground=False, limits=True).finalize(device=self.device))
+        solver = SolverKaminoImpl(
+            model=model,
+            config=self.make_config(compute_solution_metrics=True),
+        )
+        state_previous = model.state()
+        state_next = model.state()
+        pose = state_previous.q_i.numpy()
+        pose[:, 1] += 4.1
+        state_previous.q_i.assign(pose)
+
+        solver.step(state_previous, state_next, model.control(), dt=0.01)
+
+        limits = solver._limits
+        self.assertGreater(int(limits.model_active_limits.numpy()[0]), 0)
+        self.assertGreater(float(limits.reaction.numpy()[0]), 0.0)
+        self.assertGreaterEqual(float(limits.velocity.numpy()[0]), -2.0e-4)
+        self.assertLess(float(state_next.dq_j.numpy()[0]), -0.09)
+        self.assertTrue(np.isfinite(state_next.q_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+        np.testing.assert_array_equal(solver.solver_fd.world_failed.numpy(), [False])
+        limit_residual_max = solver.solver_fd.limit_residual_max.numpy()
+        self.assertTrue(np.isfinite(limit_residual_max).all())
+        self.assertLessEqual(float(limit_residual_max[0]), 1.0e-4)
+        metric_values = np.asarray(
+            [
+                solver.metrics.data.r_eom.numpy()[0],
+                solver.metrics.data.r_v_plus.numpy()[0],
+                solver.metrics.data.r_ncp_primal.numpy()[0],
+                solver.metrics.data.r_ncp_dual.numpy()[0],
+                solver.metrics.data.r_ncp_compl.numpy()[0],
+                solver.metrics.data.r_vi_natmap.numpy()[0],
+            ]
+        )
+        self.assertTrue(np.isfinite(metric_values).all())
+        self.assertLess(float(metric_values[0]), 2.0e-2)
+        self.assertLess(float(metric_values[2]), 1.0e-5)
+
+    def test_cartpole_sustained_joint_force_remains_bounded(self):
+        """Keep cartpole motion bounded under sustained joint force."""
+        model = ModelKamino.from_newton(build_cartpole(ground=False, limits=True).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        control.tau_j.assign(np.asarray([10.0, 0.0], dtype=np.float32))
+
+        for _ in range(300):
+            solver.step(state_previous, state_next, control, dt=0.001)
+            state_previous, state_next = state_next, state_previous
+
+        body_velocity = state_previous.u_i.numpy()
+        joint_residual = solver._data.joints.r_j.numpy()
+        self.assertTrue(np.isfinite(body_velocity).all())
+        self.assertTrue(np.isfinite(joint_residual).all())
+        self.assertLess(float(np.max(np.abs(body_velocity))), 100.0)
+        self.assertLess(float(np.max(np.abs(joint_residual))), 1.0e-2)
+        np.testing.assert_array_equal(solver.solver_fd.world_failed.numpy(), [False])
+
+    def test_cuda_graph_capture_uses_conditional_loop(self):
+        """Use a conditional LOX loop during CUDA graph capture."""
+        if not self.device.is_cuda or not wp.is_conditional_graph_supported():
+            self.skipTest("CUDA conditional graph nodes require CUDA 12.4 or newer.")
+        model = ModelKamino.from_newton(build_box_on_plane(ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+
+        with mock.patch.object(wp, "capture_while", wraps=wp.capture_while) as capture_while:
+            with wp.ScopedCapture() as capture:
+                solver.step(state_previous, state_next, control, dt=0.01)
+
+        capture_while.assert_called_once()
+        wp.capture_launch(capture.graph)
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+
+    def test_cuda_graph_capture_can_unroll_conditional_loop(self):
+        """Unroll captured LOX splitting iterations when graph conditionals are disabled."""
+        if not self.device.is_cuda:
+            self.skipTest("CUDA graph capture requires a CUDA device.")
+        model = ModelKamino.from_newton(build_box_on_plane(ground=False).finalize(device=self.device))
+        config = self.make_config()
+        config.lox.use_graph_conditionals = False
+        solver = SolverKaminoImpl(model=model, config=config)
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+
+        with mock.patch.object(wp, "capture_while", wraps=wp.capture_while) as capture_while:
+            with wp.ScopedCapture() as capture:
+                solver.step(state_previous, state_next, control, dt=0.01)
+
+        capture_while.assert_not_called()
+        wp.capture_launch(capture.graph)
+        self.assertTrue(np.isfinite(state_next.u_i.numpy()).all())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_lox_scenarios.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_lox_scenarios.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical multi-step scenarios for the LOX Kamino backend."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton._src.solvers.kamino.config as kamino_config
+from newton._src.solvers.kamino._src.core.model import ModelKamino
+from newton._src.solvers.kamino._src.geometry.detector import CollisionDetector
+from newton._src.solvers.kamino._src.solver_kamino_impl import SolverKaminoImpl
+from newton._src.solvers.kamino.solver_kamino import SolverKamino
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+from newton.tests.utils.basics import (
+    build_box_on_plane,
+    build_box_pendulum,
+    build_box_pendulum_vertical,
+    build_boxes_hinged,
+)
+
+
+class TestSolverKaminoLOXScenarios(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(device="cpu", clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    @staticmethod
+    def make_config(*, solve_tightly: bool = True) -> SolverKamino.Config:
+        tolerance = 1.0e-9 if solve_tightly else 1.0e-5
+        return SolverKamino.Config(
+            dynamics_solver="lox",
+            lox=kamino_config.LOXSolverConfig(
+                max_iterations=25,
+                projection_iterations=10,
+                position_tolerance=tolerance,
+                rotation_tolerance=tolerance,
+            ),
+        )
+
+    def test_free_fall_matches_discrete_solution(self):
+        model = ModelKamino.from_newton(build_box_on_plane(z_offset=0.5, ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        initial_position = state_previous.q_i.numpy()[0, :3].copy()
+        time_step = 0.005
+        step_count = 80
+
+        for _ in range(step_count):
+            solver.step(state_previous, state_next, control, dt=time_step)
+            state_previous, state_next = state_next, state_previous
+
+        gravity = model.gravity.vector.numpy()[0]
+        acceleration = gravity
+        expected_velocity = step_count * time_step * acceleration
+        expected_position = initial_position + 0.5 * step_count * (step_count + 1) * time_step**2 * acceleration
+        np.testing.assert_allclose(state_previous.u_i.numpy()[0, :3], expected_velocity, rtol=2.0e-5, atol=2.0e-5)
+        np.testing.assert_allclose(state_previous.q_i.numpy()[0, :3], expected_position, rtol=2.0e-5, atol=2.0e-5)
+
+    def test_default_tolerance_free_fall_uses_direct_unconstrained_solve(self):
+        model = ModelKamino.from_newton(build_box_on_plane(z_offset=0.5, ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config(solve_tightly=False))
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        time_step = 0.005
+        step_count = 80
+
+        for _ in range(step_count):
+            solver.step(state_previous, state_next, control, dt=time_step)
+            state_previous, state_next = state_next, state_previous
+
+        gravity = model.gravity.vector.numpy()[0]
+        expected_velocity = step_count * time_step * gravity
+        velocity_error = float(np.linalg.norm(state_previous.u_i.numpy()[0, :3] - expected_velocity))
+        self.assertLess(velocity_error, 3.0e-4, msg=f"default-tolerance velocity error: {velocity_error:.6g} m/s")
+
+    def test_resting_box_supports_weight_without_drift(self):
+        model = ModelKamino.from_newton(build_box_on_plane(ground=True).finalize(device=self.device))
+        detector = CollisionDetector(model, config=kamino_config.CollisionDetectorConfig(pipeline="unified"))
+        contacts = detector.contacts
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        rest_height = float(state_previous.q_i.numpy()[0, 2])
+        height_history = []
+        speed_history = []
+        normal_force_history = []
+
+        for _ in range(200):
+            solver.step(
+                state_previous,
+                state_next,
+                control,
+                contacts=contacts,
+                detector=detector,
+                dt=0.01,
+            )
+            state_previous, state_next = state_next, state_previous
+            height_history.append(float(state_previous.q_i.numpy()[0, 2]))
+            speed_history.append(float(np.linalg.norm(state_previous.u_i.numpy()[0, :3])))
+            active_contact_count = int(contacts.model_active_contacts.numpy()[0])
+            normal_force_history.append(float(np.sum(contacts.reaction.numpy()[:active_contact_count, 2])))
+
+        late_heights = np.asarray(height_history[-50:])
+        late_speeds = np.asarray(speed_history[-50:])
+        late_normal_forces = np.asarray(normal_force_history[-50:])
+        self.assertLess(
+            float(np.max(np.abs(late_heights - rest_height))),
+            2.0e-3,
+            msg=f"late height range: [{late_heights.min():.6g}, {late_heights.max():.6g}] m",
+        )
+        self.assertLess(
+            float(np.max(late_speeds)),
+            2.0e-2,
+            msg=f"maximum late translational speed: {late_speeds.max():.6g} m/s",
+        )
+        self.assertAlmostEqual(float(np.mean(late_normal_forces)), 9.81, delta=0.15)
+
+    def test_dropped_box_settles_after_impact(self):
+        model = ModelKamino.from_newton(build_box_on_plane(z_offset=0.5, ground=True).finalize(device=self.device))
+        detector = CollisionDetector(model, config=kamino_config.CollisionDetectorConfig(pipeline="unified"))
+        contacts = detector.contacts
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        rest_height = 0.1
+        height_history = []
+        speed_history = []
+        had_contact = False
+
+        for _ in range(400):
+            solver.step(
+                state_previous,
+                state_next,
+                control,
+                contacts=contacts,
+                detector=detector,
+                dt=0.01,
+            )
+            state_previous, state_next = state_next, state_previous
+            height_history.append(float(state_previous.q_i.numpy()[0, 2]))
+            speed_history.append(float(np.linalg.norm(state_previous.u_i.numpy()[0, :3])))
+            had_contact = had_contact or int(contacts.model_active_contacts.numpy()[0]) > 0
+
+        self.assertTrue(
+            had_contact,
+            msg=(
+                f"no contact; max spatial speed={max(speed_history):.6g}, "
+                f"final pose={state_previous.q_i.numpy()[0].tolist()}, "
+                f"final joint position={solver.data.joints.q_j.numpy().tolist()}"
+            ),
+        )
+        late_heights = np.asarray(height_history[-100:])
+        late_speeds = np.asarray(speed_history[-100:])
+        self.assertLess(
+            float(np.max(np.abs(late_heights - rest_height))),
+            5.0e-3,
+            msg=f"late height range: [{late_heights.min():.6g}, {late_heights.max():.6g}] m",
+        )
+        self.assertLess(
+            float(np.max(late_speeds)),
+            5.0e-2,
+            msg=f"maximum late translational speed: {late_speeds.max():.6g} m/s",
+        )
+
+    def test_vertical_pendulum_remains_at_rest(self):
+        model = ModelKamino.from_newton(build_box_pendulum_vertical(ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        initial_pose = state_previous.q_i.numpy().copy()
+        speed_history = []
+        residual_history = []
+
+        for _ in range(200):
+            solver.step(state_previous, state_next, control, dt=0.01)
+            state_previous, state_next = state_next, state_previous
+            speed_history.append(float(np.linalg.norm(state_previous.u_i.numpy()[0])))
+            residual_history.append(float(np.max(np.abs(solver.data.joints.r_j.numpy()), initial=0.0)))
+            self.assertFalse(bool(solver.solver_fd.world_failed.numpy()[0]))
+
+        late_speeds = np.asarray(speed_history[-50:])
+        late_residuals = np.asarray(residual_history[-50:])
+        pose_error = float(np.max(np.abs(state_previous.q_i.numpy() - initial_pose)))
+        self.assertLess(pose_error, 2.0e-3, msg=f"final pose component error: {pose_error:.6g}")
+        self.assertLess(float(np.max(late_speeds)), 2.0e-2)
+        self.assertLess(float(np.max(late_residuals)), 2.0e-3)
+
+    def test_horizontal_pendulum_preserves_joint_constraint(self):
+        model = ModelKamino.from_newton(build_box_pendulum(ground=False).finalize(device=self.device))
+        solver = SolverKaminoImpl(model=model, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        residual_history = []
+
+        for _ in range(400):
+            solver.step(state_previous, state_next, control, dt=0.005)
+            state_previous, state_next = state_next, state_previous
+            residual_history.append(float(np.max(np.abs(solver.data.joints.r_j.numpy()), initial=0.0)))
+            self.assertFalse(bool(solver.solver_fd.world_failed.numpy()[0]))
+
+        late_residuals = np.asarray(residual_history[-100:])
+        self.assertTrue(np.isfinite(state_previous.q_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_previous.u_i.numpy()).all())
+        self.assertLess(
+            float(np.max(late_residuals)),
+            5.0e-3,
+            msg=f"maximum late structural residual: {late_residuals.max():.6g} m or rad",
+        )
+
+    def test_hinged_boxes_resting_contacts_preserve_joint_constraint(self):
+        model = ModelKamino.from_newton(build_boxes_hinged(ground=True).finalize(device=self.device))
+        detector = CollisionDetector(model, config=kamino_config.CollisionDetectorConfig(pipeline="unified"))
+        contacts = detector.contacts
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        residual_history = []
+        speed_history = []
+        had_contact = False
+
+        for _ in range(300):
+            solver.step(
+                state_previous,
+                state_next,
+                control,
+                contacts=contacts,
+                detector=detector,
+                dt=0.005,
+            )
+            state_previous, state_next = state_next, state_previous
+            residual_history.append(float(np.max(np.abs(solver.data.joints.r_j.numpy()), initial=0.0)))
+            speed_history.append(float(np.linalg.norm(state_previous.u_i.numpy()[0])))
+            had_contact = had_contact or int(contacts.model_active_contacts.numpy()[0]) > 0
+            self.assertFalse(bool(solver.solver_fd.world_failed.numpy()[0]))
+
+        self.assertTrue(
+            had_contact,
+            msg=(
+                f"no contact; max spatial speed={max(speed_history):.6g}, "
+                f"final pose={state_previous.q_i.numpy()[0].tolist()}, "
+                f"final joint position={solver.data.joints.q_j.numpy().tolist()}"
+            ),
+        )
+        late_residuals = np.asarray(residual_history[-100:])
+        late_speeds = np.asarray(speed_history[-100:])
+        self.assertTrue(np.isfinite(state_previous.q_i.numpy()).all())
+        self.assertTrue(np.isfinite(state_previous.u_i.numpy()).all())
+        self.assertLess(
+            float(np.max(late_residuals)),
+            5.0e-3,
+            msg=f"maximum late structural residual: {late_residuals.max():.6g} m or rad",
+        )
+        self.assertLess(
+            float(np.max(late_speeds)),
+            1.0e-1,
+            msg=f"maximum late spatial speed: {late_speeds.max():.6g}",
+        )
+
+    def test_hinged_boxes_drop_settles_with_bounded_joint_error(self):
+        model = ModelKamino.from_newton(build_boxes_hinged(z_offset=0.5, ground=True).finalize(device=self.device))
+        detector = CollisionDetector(model, config=kamino_config.CollisionDetectorConfig(pipeline="unified"))
+        contacts = detector.contacts
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=self.make_config())
+        state_previous = model.state()
+        state_next = model.state()
+        control = model.control()
+        residual_history = []
+        speed_history = []
+        height_history = []
+        had_contact = False
+
+        for _ in range(600):
+            solver.step(
+                state_previous,
+                state_next,
+                control,
+                contacts=contacts,
+                detector=detector,
+                dt=0.005,
+            )
+            state_previous, state_next = state_next, state_previous
+            residual_history.append(float(np.max(np.abs(solver.data.joints.r_j.numpy()), initial=0.0)))
+            speed_history.append(float(np.max(np.linalg.norm(state_previous.u_i.numpy(), axis=1), initial=0.0)))
+            height_history.append(state_previous.q_i.numpy()[:, 2].copy())
+            had_contact = had_contact or int(contacts.model_active_contacts.numpy()[0]) > 0
+            self.assertFalse(bool(solver.solver_fd.world_failed.numpy()[0]))
+
+        self.assertTrue(had_contact)
+        late_residuals = np.asarray(residual_history[-100:])
+        late_speeds = np.asarray(speed_history[-100:])
+        late_heights = np.asarray(height_history[-100:])
+        self.assertLess(
+            float(np.max(late_residuals)),
+            5.0e-3,
+            msg=f"maximum late structural residual: {late_residuals.max():.6g} m or rad",
+        )
+        self.assertLess(
+            float(np.max(late_speeds)),
+            1.0e-1,
+            msg=f"maximum late spatial speed: {late_speeds.max():.6g}",
+        )
+        self.assertLess(
+            float(np.max(np.abs(late_heights - 0.05))),
+            1.0e-2,
+            msg=f"late body height range: [{late_heights.min():.6g}, {late_heights.max():.6g}] m",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/_src/solvers/kamino/tests/test_solvers_lox_colored_gauss_seidel.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_lox_colored_gauss_seidel.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for LOX colored Gauss--Seidel projection."""
+
+import unittest
+from itertools import product
+from types import SimpleNamespace
+
+import numpy as np
+import warp as wp
+
+from newton._src.solvers.kamino._src.core.types import mat36f, mat66f, vec6f
+from newton._src.solvers.kamino._src.solvers.lox.colored_gauss_seidel import (
+    ColoredGaussSeidelProjection,
+    _ColorFamily,
+)
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+
+def _empty(device, dtype):
+    return wp.empty(0, dtype=dtype, device=device)
+
+
+def _make_adapter(device, endpoints):
+    count = len(endpoints)
+    empty_int = _empty(device, wp.int32)
+    empty_vec6 = _empty(device, vec6f)
+    contact_jacobian = np.zeros((count, 3, 6), dtype=np.float32)
+    contact_jacobian[:, 0, 1] = 1.0
+    contact_jacobian[:, 1, 2] = 1.0
+    contact_jacobian[:, 2, 0] = 1.0
+    contact_jacobian_first = wp.array(contact_jacobian, dtype=mat36f, device=device)
+    contact_jacobian_second = wp.zeros(count, dtype=mat36f, device=device)
+    body_count = max((max(pair) for pair in endpoints), default=-1) + 1
+    return SimpleNamespace(
+        device=device,
+        body_constraint_count=wp.zeros(body_count, dtype=wp.int32, device=device),
+        static_body_constraint_count=wp.zeros(body_count, dtype=wp.int32, device=device),
+        friction_capacity=0,
+        friction_world=empty_int,
+        friction_local=empty_int,
+        world_friction_count=wp.zeros(1, dtype=wp.int32, device=device),
+        friction_body_first=empty_int,
+        friction_body_second=empty_int,
+        friction_jacobian_first=empty_vec6,
+        friction_jacobian_second=empty_vec6,
+        friction_impulse_bound=_empty(device, wp.float32),
+        friction_projection_delassus=_empty(device, wp.float32),
+        friction_reaction=_empty(device, wp.float32),
+        contact_capacity=count,
+        contact_world=wp.zeros(count, dtype=wp.int32, device=device),
+        contact_local=wp.array(np.arange(count, dtype=np.int32), dtype=wp.int32, device=device),
+        world_contact_count=wp.array([count], dtype=wp.int32, device=device),
+        contact_body_first=wp.array([pair[0] for pair in endpoints], dtype=wp.int32, device=device),
+        contact_body_second=wp.array([pair[1] for pair in endpoints], dtype=wp.int32, device=device),
+        contact_jacobian_first=contact_jacobian_first,
+        contact_jacobian_second=contact_jacobian_second,
+        contact_bias=wp.zeros(count, dtype=wp.vec3f, device=device),
+        contact_friction=wp.zeros(count, dtype=wp.float32, device=device),
+        contact_projection_delassus=wp.zeros(count, dtype=wp.mat33f, device=device),
+        contact_reaction=wp.zeros(count, dtype=wp.vec3f, device=device),
+        limit_capacity=0,
+        limit_world=empty_int,
+        limit_local=empty_int,
+        world_limit_count=wp.zeros(1, dtype=wp.int32, device=device),
+        limit_body_first=empty_int,
+        limit_body_second=empty_int,
+        limit_jacobian_first=empty_vec6,
+        limit_jacobian_second=empty_vec6,
+        limit_bias=_empty(device, wp.float32),
+        limit_projection_delassus=_empty(device, wp.float32),
+        limit_reaction=_empty(device, wp.float32),
+    )
+
+
+class TestLOXColoredGaussSeidel(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(device="cpu", clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def test_colors_propagate_updates_sequentially(self):
+        """Expose each completed color's velocity update to the following color."""
+        adapter = _make_adapter(self.device, [(0, -1), (0, -1)])
+        adapter.contact_bias.assign([[0.0, 0.0, -1.0], [0.0, 0.0, -2.0]])
+        projection = ColoredGaussSeidelProjection(adapter, 2)
+        inverse_weight = wp.array([np.eye(6, dtype=np.float32)], dtype=mat66f, device=self.device)
+        prepared_status = wp.zeros(1, dtype=wp.int32, device=self.device)
+        projection.prepare(inverse_weight, prepared_status)
+        self.assertEqual(len(np.unique(projection.contact.colors.numpy())), 2)
+
+        projected_twist = wp.zeros(1, dtype=vec6f, device=self.device)
+        projection_status = wp.zeros(1, dtype=wp.int32, device=self.device)
+        projection.project(
+            1,
+            wp.ones(1, dtype=wp.bool, device=self.device),
+            wp.zeros(1, dtype=wp.int32, device=self.device),
+            inverse_weight,
+            projected_twist,
+            wp.zeros(1, dtype=vec6f, device=self.device),
+            prepared_status,
+            projection_status,
+        )
+        np.testing.assert_allclose(projected_twist.numpy()[0, 0], 2.0, rtol=0.0, atol=2.0e-6)
+        np.testing.assert_allclose(adapter.contact_reaction.numpy()[:, 2], [0.0, 2.0], rtol=0.0, atol=2.0e-6)
+
+    def test_projection_clears_scratch_across_consecutive_calls(self):
+        """Clear stale body deltas after valid and rejected projection calls."""
+        adapter = _make_adapter(self.device, [(0, -1)])
+        adapter.contact_bias.assign([[0.0, 0.0, -1.0]])
+        projection = ColoredGaussSeidelProjection(adapter, 2)
+        inverse_weight = wp.array([np.eye(6, dtype=np.float32)], dtype=mat66f, device=self.device)
+        prepared_status = wp.ones(1, dtype=wp.int32, device=self.device)
+        projection.prepare(inverse_weight, prepared_status)
+        twist_delta = wp.full(1, vec6f(3.0), dtype=vec6f, device=self.device)
+        projected_twist = wp.zeros(1, dtype=vec6f, device=self.device)
+        projection_status = wp.ones(1, dtype=wp.int32, device=self.device)
+        arguments = (
+            wp.ones(1, dtype=wp.bool, device=self.device),
+            wp.zeros(1, dtype=wp.int32, device=self.device),
+            inverse_weight,
+            projected_twist,
+            twist_delta,
+            prepared_status,
+            projection_status,
+        )
+
+        projection.project(1, *arguments)
+        np.testing.assert_array_equal(twist_delta.numpy(), np.zeros((1, 6), dtype=np.float32))
+
+        twist_delta.fill_(vec6f(5.0))
+        prepared_status.zero_()
+        projection.project(1, *arguments)
+        np.testing.assert_array_equal(projection_status.numpy(), [0])
+        np.testing.assert_array_equal(twist_delta.numpy(), np.zeros((1, 6), dtype=np.float32))
+
+    def test_invalid_world_discards_only_its_color_delta(self):
+        """Keep a malformed world's partial update out of every color barrier."""
+        adapter = _make_adapter(self.device, [(0, -1), (1, -1)])
+        adapter.contact_world.assign([0, 1])
+        adapter.contact_local.assign([0, 0])
+        adapter.world_friction_count = wp.zeros(2, dtype=wp.int32, device=self.device)
+        adapter.world_contact_count = wp.ones(2, dtype=wp.int32, device=self.device)
+        adapter.world_limit_count = wp.zeros(2, dtype=wp.int32, device=self.device)
+        jacobians = adapter.contact_jacobian_first.numpy()
+        jacobians[1] = 0.0
+        adapter.contact_jacobian_first.assign(jacobians)
+        adapter.contact_bias.assign([[0.0, 0.0, -1.0], [0.0, 0.0, -1.0]])
+        projection = ColoredGaussSeidelProjection(adapter, 2)
+        inverse_weight = wp.array([np.eye(6, dtype=np.float32)] * 2, dtype=mat66f, device=self.device)
+        prepared_status = wp.zeros(2, dtype=wp.int32, device=self.device)
+        projection.prepare(inverse_weight, prepared_status)
+        np.testing.assert_array_equal(prepared_status.numpy(), [1, 0])
+
+        projected_twist = wp.zeros(2, dtype=vec6f, device=self.device)
+        projection_status = wp.zeros(2, dtype=wp.int32, device=self.device)
+        twist_delta = wp.zeros(2, dtype=vec6f, device=self.device)
+        projection.project(
+            1,
+            wp.ones(2, dtype=wp.bool, device=self.device),
+            wp.array([0, 1], dtype=wp.int32, device=self.device),
+            inverse_weight,
+            projected_twist,
+            twist_delta,
+            prepared_status,
+            projection_status,
+        )
+        np.testing.assert_allclose(projected_twist.numpy()[:, 0], [1.0, 0.0], rtol=0.0, atol=2.0e-6)
+        np.testing.assert_array_equal(projection_status.numpy(), [1, 0])
+        np.testing.assert_array_equal(twist_delta.numpy(), np.zeros((2, 6), dtype=np.float32))
+
+    def test_projection_validates_unconstrained_body(self):
+        """Accept finite twists and reject NaN/Inf even on unconstrained bodies."""
+        devices = [wp.get_device("cpu")]
+        if wp.is_cuda_available():
+            devices.append(wp.get_device("cuda:0"))
+        for device in devices:
+            for fused, value in product([False, True] if device.is_cuda else [False], [2.0e38, np.inf, np.nan]):
+                with self.subTest(device=device.alias, fused=fused, value=value):
+                    adapter = _make_adapter(device, [(0, -1)])
+                    adapter.body_constraint_count = wp.zeros(2, dtype=wp.int32, device=device)
+                    adapter.static_body_constraint_count = wp.zeros(2, dtype=wp.int32, device=device)
+                    adapter.world_friction_count = wp.zeros(2, dtype=wp.int32, device=device)
+                    adapter.world_limit_count = wp.zeros(2, dtype=wp.int32, device=device)
+                    adapter.world_contact_count = wp.array([1, 0], dtype=wp.int32, device=device)
+                    adapter.contact_bias.assign([[0.0, 0.0, -1.0]])
+                    if fused:
+                        adapter.model = SimpleNamespace(
+                            info=SimpleNamespace(
+                                bodies_offset=wp.array([0, 1], dtype=wp.int32, device=device),
+                                num_bodies=wp.ones(2, dtype=wp.int32, device=device),
+                            )
+                        )
+                        adapter.world_friction_offset = wp.zeros(2, dtype=wp.int32, device=device)
+                        adapter.world_limit_offset = wp.zeros(2, dtype=wp.int32, device=device)
+                        adapter.world_contact_offset = wp.array([0, 1], dtype=wp.int32, device=device)
+                    projection = ColoredGaussSeidelProjection(adapter, 2)
+                    inverse_weight = wp.array([np.eye(6, dtype=np.float32)] * 2, dtype=mat66f, device=device)
+                    prepared_status = wp.zeros(2, dtype=wp.int32, device=device)
+                    projection.prepare(inverse_weight, prepared_status)
+                    velocity = np.zeros((2, 6), dtype=np.float32)
+                    velocity[1] = 2.0e38
+                    velocity[1, 5] = value
+                    projected_twist = wp.array(velocity, dtype=vec6f, device=device)
+                    projection_status = wp.zeros(2, dtype=wp.int32, device=device)
+                    twist_delta = wp.zeros(2, dtype=vec6f, device=device)
+                    projection.project(
+                        1,
+                        wp.ones(2, dtype=wp.bool, device=device),
+                        wp.array([0, 1], dtype=wp.int32, device=device),
+                        inverse_weight,
+                        projected_twist,
+                        twist_delta,
+                        prepared_status,
+                        projection_status,
+                    )
+                    np.testing.assert_array_equal(projection_status.numpy(), [1, int(np.isfinite(value))])
+                    np.testing.assert_array_equal(projected_twist.numpy()[1], velocity[1])
+                    self.assertAlmostEqual(float(projected_twist.numpy()[0, 0]), 1.0)
+                    np.testing.assert_array_equal(twist_delta.numpy(), np.zeros((2, 6), dtype=np.float32))
+
+    @unittest.skipUnless(wp.is_cuda_available(), "CUDA is required for block synchronization")
+    def test_world_colored_matches_global_colored(self):
+        """Match the single-launch world traversal to the global colored path."""
+        device = wp.get_device("cuda:0")
+        world_count = device.sm_count * 4
+        world_ids = np.arange(world_count, dtype=np.int32)
+        zeros = np.zeros(world_count, dtype=np.int32)
+        ones = np.ones(world_count, dtype=np.int32)
+        empty_int = _empty(device, wp.int32)
+        empty_vec6 = _empty(device, vec6f)
+        world_offset = wp.array(world_ids, dtype=wp.int32, device=device)
+        zero_world_offset = wp.zeros(world_count, dtype=wp.int32, device=device)
+        zero_world_count = wp.zeros(world_count, dtype=wp.int32, device=device)
+        contact_jacobian = np.zeros((world_count, 3, 6), dtype=np.float32)
+        contact_jacobian[:, 2, 0] = 1.0
+        adapter = SimpleNamespace(
+            device=device,
+            model=SimpleNamespace(
+                info=SimpleNamespace(
+                    bodies_offset=world_offset,
+                    num_bodies=wp.array(ones, dtype=wp.int32, device=device),
+                )
+            ),
+            body_constraint_count=wp.ones(world_count, dtype=wp.int32, device=device),
+            static_body_constraint_count=wp.zeros(world_count, dtype=wp.int32, device=device),
+            friction_capacity=0,
+            friction_world=empty_int,
+            friction_local=empty_int,
+            world_friction_offset=zero_world_offset,
+            world_friction_count=zero_world_count,
+            friction_body_first=empty_int,
+            friction_body_second=empty_int,
+            friction_jacobian_first=empty_vec6,
+            friction_jacobian_second=empty_vec6,
+            friction_impulse_bound=_empty(device, wp.float32),
+            friction_projection_delassus=_empty(device, wp.float32),
+            friction_reaction=_empty(device, wp.float32),
+            contact_capacity=world_count,
+            contact_world=wp.array(world_ids, dtype=wp.int32, device=device),
+            contact_local=wp.array(zeros, dtype=wp.int32, device=device),
+            world_contact_offset=world_offset,
+            world_contact_count=wp.array(ones, dtype=wp.int32, device=device),
+            contact_body_first=wp.array(world_ids, dtype=wp.int32, device=device),
+            contact_body_second=wp.full(world_count, -1, dtype=wp.int32, device=device),
+            contact_jacobian_first=wp.array(contact_jacobian, dtype=mat36f, device=device),
+            contact_jacobian_second=wp.zeros(world_count, dtype=mat36f, device=device),
+            contact_bias=wp.full(world_count, wp.vec3f(0.0, 0.0, -1.0), dtype=wp.vec3f, device=device),
+            contact_friction=wp.full(world_count, 0.4, dtype=wp.float32, device=device),
+            contact_projection_delassus=wp.zeros(world_count, dtype=wp.mat33f, device=device),
+            contact_reaction=wp.full(
+                world_count,
+                wp.vec3f(0.0, 0.0, 0.2),
+                dtype=wp.vec3f,
+                device=device,
+            ),
+            limit_capacity=0,
+            limit_world=empty_int,
+            limit_local=empty_int,
+            world_limit_offset=zero_world_offset,
+            world_limit_count=zero_world_count,
+            limit_body_first=empty_int,
+            limit_body_second=empty_int,
+            limit_jacobian_first=empty_vec6,
+            limit_jacobian_second=empty_vec6,
+            limit_bias=_empty(device, wp.float32),
+            limit_projection_delassus=_empty(device, wp.float32),
+            limit_reaction=_empty(device, wp.float32),
+        )
+        projection = ColoredGaussSeidelProjection(adapter, 2)
+        inverse_weight = wp.array(
+            np.repeat(np.eye(6, dtype=np.float32)[None, :, :], world_count, axis=0),
+            dtype=mat66f,
+            device=device,
+        )
+        prepared_status = wp.zeros(world_count, dtype=wp.int32, device=device)
+        projection.prepare(inverse_weight, prepared_status)
+
+        def run(use_world_projection):
+            adapter.model.info.bodies_offset = world_offset if use_world_projection else None
+            projected_twist = wp.zeros(world_count, dtype=vec6f, device=device)
+            twist_delta = wp.zeros(world_count, dtype=vec6f, device=device)
+            projection_status = wp.zeros(world_count, dtype=wp.int32, device=device)
+            adapter.contact_reaction.fill_(wp.vec3f(0.0, 0.0, 0.2))
+            projection.project(
+                3,
+                wp.ones(world_count, dtype=wp.bool, device=device),
+                wp.array(world_ids, dtype=wp.int32, device=device),
+                inverse_weight,
+                projected_twist,
+                twist_delta,
+                prepared_status,
+                projection_status,
+            )
+            return projected_twist.numpy(), adapter.contact_reaction.numpy(), projection_status.numpy()
+
+        global_result = run(False)
+        world_result = run(True)
+        for global_value, world_value in zip(global_result[:-1], world_result[:-1], strict=True):
+            np.testing.assert_allclose(world_value, global_value, rtol=0.0, atol=2.0e-6)
+        np.testing.assert_array_equal(world_result[-1], global_result[-1])
+
+    @unittest.skipUnless(wp.is_cuda_available(), "CUDA is required for graph capture")
+    def test_cuda_graph_capture_replays_large_color_compaction(self):
+        """Capture the parallel color-prefix scan and cursor copy path."""
+        device = wp.get_device("cuda:0")
+        color_count = 96
+        capacity = 2 * color_count + 11
+        colors = np.arange(capacity, dtype=np.int32) % color_count
+        colors[::17] = -1
+        family = _ColorFamily(capacity, color_count, device)
+        family.colors.assign(colors)
+        family.compact(color_count, device)
+
+        with wp.ScopedCapture(device=device) as capture:
+            family.compact(color_count, device)
+        wp.capture_launch(capture.graph)
+
+        valid = colors >= 0
+        expected_counts = np.bincount(colors[valid], minlength=color_count).astype(np.int32)
+        expected_offsets = np.zeros(color_count, dtype=np.int32)
+        expected_offsets[1:] = np.cumsum(expected_counts[:-1], dtype=np.int32)
+        counts = family.counts.numpy()
+        offsets = family.offsets.numpy()
+        order = family.order.numpy()[: int(np.sum(expected_counts))]
+        np.testing.assert_array_equal(counts, expected_counts)
+        np.testing.assert_array_equal(offsets, expected_offsets)
+        np.testing.assert_array_equal(np.sort(order), np.flatnonzero(valid))
+
+    @unittest.skipUnless(wp.is_cuda_available(), "CUDA is required for graph capture")
+    def test_cuda_graph_capture_replays_coloring_and_projection(self):
+        """Capture and replay device coloring, metric preparation, and projection."""
+        device = wp.get_device("cuda:0")
+        adapter = _make_adapter(device, [(0, -1), (0, -1)])
+        adapter.contact_bias.assign([[0.0, 0.0, -1.0], [0.0, 0.0, -2.0]])
+        projection = ColoredGaussSeidelProjection(adapter, 2)
+        inverse_weight = wp.array([np.eye(6, dtype=np.float32)], dtype=mat66f, device=device)
+        prepared_status = wp.zeros(1, dtype=wp.int32, device=device)
+        projection_status = wp.zeros(1, dtype=wp.int32, device=device)
+        projected_twist = wp.zeros(1, dtype=vec6f, device=device)
+        twist_delta = wp.zeros(1, dtype=vec6f, device=device)
+        world_active = wp.ones(1, dtype=wp.bool, device=device)
+        body_world = wp.zeros(1, dtype=wp.int32, device=device)
+
+        def run():
+            projection.prepare(inverse_weight, prepared_status)
+            projection.project(
+                1,
+                world_active,
+                body_world,
+                inverse_weight,
+                projected_twist,
+                twist_delta,
+                prepared_status,
+                projection_status,
+            )
+
+        run()
+        projected_twist.zero_()
+        adapter.contact_reaction.zero_()
+        with wp.ScopedCapture(device=device) as capture:
+            run()
+        wp.capture_launch(capture.graph)
+        np.testing.assert_allclose(projected_twist.numpy()[0, 0], 2.0, rtol=0.0, atol=2.0e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/_src/solvers/kamino/tests/test_solvers_lox_contact.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_lox_contact.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for LOX local Coulomb-contact primitives."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+from newton._src.solvers.kamino._src.solvers.lox.contact import (
+    compute_contact_scaled_alart_curnier_residual,
+    solve_contact_coulomb_newton,
+)
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+
+@wp.kernel
+def _solve_contacts(
+    delassus: wp.array[wp.mat33f],
+    free_velocity: wp.array[wp.vec3f],
+    friction: wp.array[wp.float32],
+    reaction: wp.array[wp.vec3f],
+    velocity: wp.array[wp.vec3f],
+    residual: wp.array[wp.vec3f],
+):
+    contact = wp.tid()
+    reaction_i = solve_contact_coulomb_newton(delassus[contact], free_velocity[contact], friction[contact])
+    velocity_i = delassus[contact] @ reaction_i + free_velocity[contact]
+    reaction[contact] = reaction_i
+    velocity[contact] = velocity_i
+    residual[contact] = compute_contact_scaled_alart_curnier_residual(
+        delassus[contact], reaction_i, velocity_i, friction[contact]
+    )
+
+
+class TestLOXContact(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(device="cpu", clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def _solve(
+        self,
+        delassus: np.ndarray,
+        free_velocity: np.ndarray,
+        friction: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        delassus_wp = wp.array(delassus, dtype=wp.mat33f, device=self.device)
+        free_velocity_wp = wp.array(free_velocity, dtype=wp.vec3f, device=self.device)
+        friction_wp = wp.array(friction, dtype=wp.float32, device=self.device)
+        reaction_wp = wp.empty(len(friction), dtype=wp.vec3f, device=self.device)
+        velocity_wp = wp.empty(len(friction), dtype=wp.vec3f, device=self.device)
+        residual_wp = wp.empty(len(friction), dtype=wp.vec3f, device=self.device)
+
+        wp.launch(
+            _solve_contacts,
+            dim=len(friction),
+            inputs=[delassus_wp, free_velocity_wp, friction_wp],
+            outputs=[reaction_wp, velocity_wp, residual_wp],
+            device=self.device,
+        )
+        return reaction_wp.numpy(), velocity_wp.numpy(), residual_wp.numpy()
+
+    def test_separating_contact(self):
+        """Leave a separating contact inactive."""
+        delassus = np.asarray([np.diag([3.0, 4.0, 2.0])], dtype=np.float32)
+        free_velocity = np.asarray([[-4.0, 2.0, 0.25]], dtype=np.float32)
+        friction = np.asarray([0.7], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus, free_velocity, friction)
+
+        np.testing.assert_array_equal(reaction[0], np.zeros(3, dtype=np.float32))
+        np.testing.assert_allclose(velocity[0], free_velocity[0], rtol=0.0, atol=1.0e-7)
+        self.assertLess(np.linalg.norm(residual[0]), 1.0e-6)
+
+    def test_frictionless_contact_skips_degenerate_tangent_block(self):
+        """Solve frictionless contact with a degenerate tangent block."""
+        # Only W_N is used in the frictionless branch, which protects the
+        # prototype while preprocessing regularizes active frictional blocks.
+        delassus = np.asarray([np.diag([0.0, 0.0, 2.0])], dtype=np.float32)
+        free_velocity = np.asarray([[3.0, -2.0, -1.0]], dtype=np.float32)
+        friction = np.asarray([0.0], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus, free_velocity, friction)
+
+        np.testing.assert_allclose(reaction[0], [0.0, 0.0, 0.5], rtol=0.0, atol=1.0e-7)
+        np.testing.assert_allclose(velocity[0], [3.0, -2.0, 0.0], rtol=0.0, atol=1.0e-7)
+        self.assertTrue(np.all(np.isfinite(residual[0])))
+        self.assertLess(np.linalg.norm(residual[0]), 1.0e-6)
+
+    def test_sticking_contact(self):
+        """Solve a sticking frictional contact."""
+        delassus = np.asarray([np.diag([3.0, 4.0, 2.0])], dtype=np.float32)
+        free_velocity = np.asarray([[0.2, -0.1, -1.0]], dtype=np.float32)
+        friction = np.asarray([0.8], dtype=np.float32)
+        expected_reaction = np.asarray([-0.2 / 3.0, 0.025, 0.5], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus, free_velocity, friction)
+
+        np.testing.assert_allclose(reaction[0], expected_reaction, rtol=2.0e-6, atol=2.0e-7)
+        np.testing.assert_allclose(velocity[0], np.zeros(3), rtol=0.0, atol=2.0e-7)
+        self.assertLess(np.linalg.norm(reaction[0, :2]), friction[0] * reaction[0, 2])
+        self.assertLess(np.linalg.norm(residual[0]), 1.0e-6)
+
+    def test_sliding_contact(self):
+        """Project a sliding contact onto the Coulomb cone."""
+        delassus = np.asarray([np.diag([1.0, 1.0, 2.0])], dtype=np.float32)
+        free_velocity = np.asarray([[2.0, 0.0, -1.0]], dtype=np.float32)
+        friction = np.asarray([0.5], dtype=np.float32)
+        expected_reaction = np.asarray([-0.25, 0.0, 0.5], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus, free_velocity, friction)
+
+        np.testing.assert_allclose(reaction[0], expected_reaction, rtol=2.0e-6, atol=2.0e-7)
+        np.testing.assert_allclose(velocity[0], [1.75, 0.0, 0.0], rtol=2.0e-6, atol=2.0e-7)
+        self.assertAlmostEqual(np.linalg.norm(reaction[0, :2]), friction[0] * reaction[0, 2], delta=2.0e-7)
+        self.assertLess(np.dot(reaction[0, :2], velocity[0, :2]), 0.0)
+        self.assertLess(np.linalg.norm(residual[0]), 1.0e-6)
+
+    def test_strongly_coupled_full_block(self):
+        """Solve a strongly coupled contact Delassus block."""
+        delassus_i = np.asarray(
+            [
+                [1.7, 0.25, 0.35],
+                [0.25, 0.8, -0.15],
+                [0.35, -0.15, 2.0],
+            ],
+            dtype=np.float32,
+        )
+        friction = np.asarray([0.5], dtype=np.float32)
+        expected_reaction = np.asarray([-0.18, -0.135, 0.45], dtype=np.float32)
+        expected_velocity = np.asarray([0.28, 0.21, 0.0], dtype=np.float32)
+        free_velocity_i = expected_velocity - delassus_i @ expected_reaction
+
+        reaction, velocity, residual = self._solve(delassus_i[None, ...], free_velocity_i[None, ...], friction)
+
+        np.testing.assert_allclose(reaction[0], expected_reaction, rtol=2.0e-5, atol=2.0e-6)
+        np.testing.assert_allclose(velocity[0], expected_velocity, rtol=2.0e-5, atol=2.0e-6)
+        self.assertLess(np.linalg.norm(residual[0]), 2.0e-6)
+
+    def test_bracketed_bisection_fallback(self):
+        """Keep the bounded bisection fallback stable for a difficult contact."""
+        # This coupled problem rejects multiple pure Newton steps and does not
+        # reach the root tolerance within the bounded local solve.
+        delassus_i = np.asarray(
+            [
+                [7.38549845, -0.55674596, -2.21409240],
+                [-0.55674596, 0.53603802, -0.05816527],
+                [-2.21409240, -0.05816527, 3.05015024],
+            ],
+            dtype=np.float32,
+        )
+        free_velocity_i = np.asarray([-3.11677977, -4.67238632, -0.97200092], dtype=np.float32)
+        friction = np.asarray([5.40898023], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus_i[None, ...], free_velocity_i[None, ...], friction)
+
+        self.assertTrue(np.all(np.isfinite(reaction[0])))
+        self.assertAlmostEqual(velocity[0, 2], 0.0, delta=1.0e-5)
+        self.assertLess(np.dot(reaction[0, :2], velocity[0, :2]), 0.0)
+        self.assertLess(np.linalg.norm(residual[0]), 3.0e-2)
+
+    def test_nearly_singular_regularized_block(self):
+        """Stabilize contact reactions for a nearly singular Delassus block."""
+        delassus_i = np.diag([1.0e-6, 2.0e-6, 1.0]).astype(np.float32)
+        expected_reaction = np.asarray([-0.1, 0.1, 1.0], dtype=np.float32)
+        free_velocity_i = -(delassus_i @ expected_reaction)
+        friction = np.asarray([0.5], dtype=np.float32)
+
+        reaction, velocity, residual = self._solve(delassus_i[None, ...], free_velocity_i[None, ...], friction)
+
+        np.testing.assert_allclose(reaction[0], expected_reaction, rtol=2.0e-5, atol=2.0e-6)
+        np.testing.assert_allclose(velocity[0], np.zeros(3), rtol=0.0, atol=2.0e-7)
+        self.assertTrue(np.all(np.isfinite(reaction[0])))
+        self.assertTrue(np.all(np.isfinite(residual[0])))
+        self.assertLess(np.linalg.norm(residual[0]), 1.0e-6)
+
+
+if __name__ == "__main__":
+    setup_tests()
+    unittest.main(verbosity=2)

--- a/newton/_src/solvers/kamino/tests/test_solvers_lox_sweep.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_lox_sweep.py
@@ -1,0 +1,678 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for LOX body-space projection sweeps."""
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+import warp as wp
+
+from newton._src.solvers.kamino._src.core.types import mat36f, mat66f, vec6f
+from newton._src.solvers.kamino._src.solvers.lox.jacobi import project_constraints_jacobi
+from newton._src.solvers.kamino._src.solvers.lox.projection import (
+    PROJECTION_STATUS_VALID,
+    prepare_jacobi_projection_data,
+)
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+
+def _project_constraints_accelerated(
+    projection_iterations,
+    adapter,
+    world_active,
+    body_world,
+    inverse_weight,
+    projected_twist,
+    theta,
+    beta,
+    restart_dot,
+    **offsets,
+):
+    project_constraints_jacobi(
+        projection_iterations,
+        world_active,
+        body_world,
+        adapter.friction_world,
+        adapter.friction_local,
+        adapter.world_friction_count,
+        adapter.friction_body_first,
+        adapter.friction_body_second,
+        adapter.friction_jacobian_first,
+        adapter.friction_jacobian_second,
+        adapter.friction_impulse_bound,
+        adapter.friction_projection_delassus,
+        adapter.contact_world,
+        adapter.contact_local,
+        adapter.world_contact_count,
+        adapter.contact_body_first,
+        adapter.contact_body_second,
+        adapter.contact_jacobian_first,
+        adapter.contact_jacobian_second,
+        adapter.contact_bias,
+        adapter.contact_friction,
+        adapter.contact_projection_delassus,
+        adapter.limit_world,
+        adapter.limit_local,
+        adapter.world_limit_count,
+        adapter.limit_body_first,
+        adapter.limit_body_second,
+        adapter.limit_jacobian_first,
+        adapter.limit_jacobian_second,
+        adapter.limit_bias,
+        adapter.limit_projection_delassus,
+        inverse_weight,
+        projected_twist,
+        adapter.projection_twist_delta,
+        adapter.contact_reaction,
+        adapter.limit_reaction,
+        adapter.friction_reaction,
+        adapter.world_jacobi_projection_status,
+        adapter.projection_status,
+        accelerated=True,
+        theta=theta,
+        beta=beta,
+        restart_dot=restart_dot,
+        friction_trial=adapter.friction_acceleration_trial,
+        friction_previous=adapter.friction_acceleration_previous,
+        contact_trial=adapter.contact_acceleration_trial,
+        contact_previous=adapter.contact_acceleration_previous,
+        limit_trial=adapter.limit_acceleration_trial,
+        limit_previous=adapter.limit_acceleration_previous,
+        **offsets,
+    )
+
+
+class TestLOXSweep(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(device="cpu", clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    @unittest.skipUnless(wp.is_cuda_available(), "CUDA is required for block synchronization")
+    def test_world_jacobi_matches_global_jacobi(self):
+        """Match the occupancy-gated world Jacobi path to the global path."""
+        device = wp.get_device("cuda:0")
+        world_count = device.sm_count * 4
+        world_ids = np.arange(world_count, dtype=np.int32)
+        zeros = np.zeros(world_count, dtype=np.int32)
+        ones = np.ones(world_count, dtype=np.int32)
+        minus_ones = -ones
+
+        body_world = wp.array(world_ids, dtype=wp.int32, device=device)
+        world_active = wp.ones(world_count, dtype=wp.bool, device=device)
+        world_offset = wp.array(world_ids, dtype=wp.int32, device=device)
+        world_count_one = wp.array(ones, dtype=wp.int32, device=device)
+        constraint_world = wp.array(world_ids, dtype=wp.int32, device=device)
+        constraint_local = wp.array(zeros, dtype=wp.int32, device=device)
+        body_first = wp.array(world_ids, dtype=wp.int32, device=device)
+        body_second = wp.array(minus_ones, dtype=wp.int32, device=device)
+
+        friction_jacobian_values = np.zeros((world_count, 6), dtype=np.float32)
+        friction_jacobian_values[:, 0] = 1.0
+        friction_jacobian_first = wp.array(friction_jacobian_values, dtype=vec6f, device=device)
+        friction_jacobian_second = wp.zeros(world_count, dtype=vec6f, device=device)
+        friction_impulse_bound = wp.full(world_count, 10.0, dtype=wp.float32, device=device)
+        friction_delassus = wp.ones(world_count, dtype=wp.float32, device=device)
+
+        contact_jacobian_values = np.zeros((world_count, 3, 6), dtype=np.float32)
+        contact_jacobian_values[:, 0, 3] = 1.0
+        contact_jacobian_values[:, 1, 4] = 1.0
+        contact_jacobian_values[:, 2, 2] = 1.0
+        contact_jacobian_first = wp.array(contact_jacobian_values, dtype=mat36f, device=device)
+        contact_jacobian_second = wp.zeros(world_count, dtype=mat36f, device=device)
+        contact_bias = wp.zeros(world_count, dtype=wp.vec3f, device=device)
+        contact_friction = wp.zeros(world_count, dtype=wp.float32, device=device)
+        contact_delassus = wp.array(
+            np.repeat(np.eye(3, dtype=np.float32)[None, :, :], world_count, axis=0),
+            dtype=wp.mat33f,
+            device=device,
+        )
+
+        limit_jacobian_values = np.zeros((world_count, 6), dtype=np.float32)
+        limit_jacobian_values[:, 1] = 1.0
+        limit_jacobian_first = wp.array(limit_jacobian_values, dtype=vec6f, device=device)
+        limit_jacobian_second = wp.zeros(world_count, dtype=vec6f, device=device)
+        limit_bias = wp.zeros(world_count, dtype=wp.float32, device=device)
+        limit_delassus = wp.ones(world_count, dtype=wp.float32, device=device)
+
+        inverse_weight_values = np.repeat(np.eye(6, dtype=np.float32)[None, :, :], world_count, axis=0)
+        inverse_weight_values[:, np.arange(6), np.arange(6)] = [2.0, 0.5, 3.0, 4.0, 5.0, 6.0]
+        inverse_weight = wp.array(inverse_weight_values, dtype=mat66f, device=device)
+        initial_twist = np.zeros((world_count, 6), dtype=np.float32)
+        initial_twist[:, :3] = [-1.0, -2.0, -3.0]
+        prepared_status = wp.full(world_count, PROJECTION_STATUS_VALID, dtype=wp.int32, device=device)
+
+        def run(use_world_projection: bool):
+            projected_twist = wp.array(initial_twist, dtype=vec6f, device=device)
+            twist_delta = wp.zeros(world_count, dtype=vec6f, device=device)
+            contact_reaction = wp.full(
+                world_count,
+                wp.vec3f(0.0, 0.0, 0.25),
+                dtype=wp.vec3f,
+                device=device,
+            )
+            limit_reaction = wp.full(world_count, 0.5, dtype=wp.float32, device=device)
+            friction_reaction = wp.full(world_count, 0.1, dtype=wp.float32, device=device)
+            world_status = wp.zeros(world_count, dtype=wp.int32, device=device)
+            offsets = {}
+            if use_world_projection:
+                offsets = {
+                    "world_body_offset": world_offset,
+                    "world_body_count": world_count_one,
+                    "world_friction_offset": world_offset,
+                    "world_contact_offset": world_offset,
+                    "world_limit_offset": world_offset,
+                }
+            project_constraints_jacobi(
+                3,
+                world_active,
+                body_world,
+                constraint_world,
+                constraint_local,
+                world_count_one,
+                body_first,
+                body_second,
+                friction_jacobian_first,
+                friction_jacobian_second,
+                friction_impulse_bound,
+                friction_delassus,
+                constraint_world,
+                constraint_local,
+                world_count_one,
+                body_first,
+                body_second,
+                contact_jacobian_first,
+                contact_jacobian_second,
+                contact_bias,
+                contact_friction,
+                contact_delassus,
+                constraint_world,
+                constraint_local,
+                world_count_one,
+                body_first,
+                body_second,
+                limit_jacobian_first,
+                limit_jacobian_second,
+                limit_bias,
+                limit_delassus,
+                inverse_weight,
+                projected_twist,
+                twist_delta,
+                contact_reaction,
+                limit_reaction,
+                friction_reaction,
+                prepared_status,
+                world_status,
+                **offsets,
+            )
+            return (
+                projected_twist.numpy(),
+                contact_reaction.numpy(),
+                limit_reaction.numpy(),
+                friction_reaction.numpy(),
+                twist_delta.numpy(),
+                world_status.numpy(),
+            )
+
+        global_result = run(False)
+        world_result = run(True)
+        for global_value, world_value in zip(global_result[:-1], world_result[:-1], strict=True):
+            np.testing.assert_allclose(world_value, global_value, rtol=0.0, atol=2.0e-6)
+        np.testing.assert_array_equal(world_result[-1], global_result[-1])
+
+    @unittest.skipUnless(wp.is_cuda_available(), "CUDA is required for block synchronization")
+    def test_accelerated_jacobi_accepts_world_offsets(self):
+        """Match accelerated Jacobi with and without world offsets."""
+        device = wp.get_device("cuda:0")
+        world_count = device.sm_count * 4
+        world_ids = np.arange(world_count, dtype=np.int32)
+        zeros = np.zeros(world_count, dtype=np.int32)
+        ones = np.ones(world_count, dtype=np.int32)
+        minus_ones = -ones
+        initial_twist = np.repeat(
+            np.asarray([[-1.0, 0.2, 0.1, 0.8, -0.4, 0.0]], dtype=np.float32),
+            world_count,
+            axis=0,
+        )
+        inverse_weight = wp.array(
+            np.repeat(np.eye(6, dtype=np.float32)[None, :, :], world_count, axis=0),
+            dtype=mat66f,
+            device=device,
+        )
+        body_world = wp.array(world_ids, dtype=wp.int32, device=device)
+        world_active = wp.ones(world_count, dtype=wp.bool, device=device)
+        world_offset = wp.array(world_ids, dtype=wp.int32, device=device)
+        world_count_one = wp.array(ones, dtype=wp.int32, device=device)
+
+        def make_adapter():
+            adapter = SimpleNamespace(
+                device=device,
+                friction_capacity=world_count,
+                contact_capacity=world_count,
+                limit_capacity=world_count,
+            )
+            adapter.friction_world = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.friction_local = wp.array(zeros, dtype=wp.int32, device=device)
+            adapter.world_friction_count = wp.array(ones, dtype=wp.int32, device=device)
+            adapter.friction_body_first = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.friction_body_second = wp.array(minus_ones, dtype=wp.int32, device=device)
+            friction_jacobian = np.zeros((world_count, 6), dtype=np.float32)
+            friction_jacobian[:, 3] = 1.0
+            adapter.friction_jacobian_first = wp.array(friction_jacobian, dtype=vec6f, device=device)
+            adapter.friction_jacobian_second = wp.zeros(world_count, dtype=vec6f, device=device)
+            adapter.friction_impulse_bound = wp.full(world_count, 0.4, dtype=wp.float32, device=device)
+            adapter.friction_projection_delassus = wp.ones(world_count, dtype=wp.float32, device=device)
+            adapter.friction_reaction = wp.full(world_count, 0.1, dtype=wp.float32, device=device)
+            adapter.friction_acceleration_trial = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.friction_acceleration_previous = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.friction_velocity = wp.zeros(world_count, dtype=wp.float32, device=device)
+
+            adapter.contact_world = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.contact_local = wp.array(zeros, dtype=wp.int32, device=device)
+            adapter.world_contact_count = wp.array(ones, dtype=wp.int32, device=device)
+            adapter.contact_body_first = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.contact_body_second = wp.array(minus_ones, dtype=wp.int32, device=device)
+            contact_jacobian = np.zeros((world_count, 3, 6), dtype=np.float32)
+            contact_jacobian[:, 0, 1] = 1.0
+            contact_jacobian[:, 1, 2] = 1.0
+            contact_jacobian[:, 2, 0] = 1.0
+            adapter.contact_jacobian_first = wp.array(contact_jacobian, dtype=mat36f, device=device)
+            adapter.contact_jacobian_second = wp.zeros(world_count, dtype=mat36f, device=device)
+            adapter.contact_bias = wp.full(
+                world_count,
+                wp.vec3f(0.0, 0.0, -0.2),
+                dtype=wp.vec3f,
+                device=device,
+            )
+            adapter.contact_friction = wp.full(world_count, 0.5, dtype=wp.float32, device=device)
+            adapter.contact_projection_delassus = wp.array(
+                np.repeat(np.eye(3, dtype=np.float32)[None, :, :], world_count, axis=0),
+                dtype=wp.mat33f,
+                device=device,
+            )
+            adapter.contact_reaction = wp.zeros(world_count, dtype=wp.vec3f, device=device)
+            adapter.contact_acceleration_trial = wp.zeros(world_count, dtype=wp.vec3f, device=device)
+            adapter.contact_acceleration_previous = wp.zeros(world_count, dtype=wp.vec3f, device=device)
+            adapter.contact_velocity = wp.zeros(world_count, dtype=wp.vec3f, device=device)
+
+            adapter.limit_world = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.limit_local = wp.array(zeros, dtype=wp.int32, device=device)
+            adapter.world_limit_count = wp.array(ones, dtype=wp.int32, device=device)
+            adapter.limit_body_first = wp.array(world_ids, dtype=wp.int32, device=device)
+            adapter.limit_body_second = wp.array(minus_ones, dtype=wp.int32, device=device)
+            limit_jacobian = np.zeros((world_count, 6), dtype=np.float32)
+            limit_jacobian[:, 4] = 1.0
+            adapter.limit_jacobian_first = wp.array(limit_jacobian, dtype=vec6f, device=device)
+            adapter.limit_jacobian_second = wp.zeros(world_count, dtype=vec6f, device=device)
+            adapter.limit_bias = wp.full(world_count, -0.1, dtype=wp.float32, device=device)
+            adapter.limit_projection_delassus = wp.ones(world_count, dtype=wp.float32, device=device)
+            adapter.limit_reaction = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.limit_acceleration_trial = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.limit_acceleration_previous = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.limit_velocity = wp.zeros(world_count, dtype=wp.float32, device=device)
+            adapter.world_jacobi_projection_status = wp.full(
+                world_count,
+                PROJECTION_STATUS_VALID,
+                dtype=wp.int32,
+                device=device,
+            )
+            adapter.projection_status = wp.zeros(world_count, dtype=wp.int32, device=device)
+            adapter.projection_twist_delta = wp.zeros(world_count, dtype=vec6f, device=device)
+            return adapter
+
+        def run(use_world_projection: bool):
+            adapter = make_adapter()
+            projected_twist = wp.array(initial_twist, dtype=vec6f, device=device)
+            theta = wp.ones(world_count, dtype=wp.float32, device=device)
+            beta = wp.zeros(world_count, dtype=wp.float32, device=device)
+            restart_dot = wp.zeros(world_count, dtype=wp.float32, device=device)
+            offsets = {}
+            if use_world_projection:
+                offsets = {
+                    "world_body_offset": world_offset,
+                    "world_body_count": world_count_one,
+                    "world_friction_offset": world_offset,
+                    "world_contact_offset": world_offset,
+                    "world_limit_offset": world_offset,
+                }
+            _project_constraints_accelerated(
+                3,
+                adapter,
+                world_active,
+                body_world,
+                inverse_weight,
+                projected_twist,
+                theta,
+                beta,
+                restart_dot,
+                **offsets,
+            )
+            return (
+                projected_twist.numpy(),
+                adapter.projection_twist_delta.numpy(),
+                adapter.friction_reaction.numpy(),
+                adapter.friction_acceleration_trial.numpy(),
+                adapter.friction_acceleration_previous.numpy(),
+                adapter.friction_velocity.numpy(),
+                adapter.contact_reaction.numpy(),
+                adapter.contact_acceleration_trial.numpy(),
+                adapter.contact_acceleration_previous.numpy(),
+                adapter.contact_velocity.numpy(),
+                adapter.limit_reaction.numpy(),
+                adapter.limit_acceleration_trial.numpy(),
+                adapter.limit_acceleration_previous.numpy(),
+                adapter.limit_velocity.numpy(),
+                theta.numpy(),
+                beta.numpy(),
+                restart_dot.numpy(),
+                adapter.projection_status.numpy(),
+            )
+
+        global_result = run(False)
+        world_result = run(True)
+        for global_value, world_value in zip(global_result[:-1], world_result[:-1], strict=True):
+            np.testing.assert_allclose(world_value, global_value, rtol=0.0, atol=2.0e-6)
+        np.testing.assert_array_equal(world_result[-1], global_result[-1])
+
+    def test_mass_split_jacobi_scales_body_contributions(self):
+        """Scale Jacobi body contributions by constraint multiplicity."""
+        inverse_weight_values = np.repeat(np.eye(6, dtype=np.float32)[None, :, :], 2, axis=0)
+        inverse_weight_values[:, 0, 0] = [2.0, 4.0]
+        inverse_weight = wp.array(inverse_weight_values, dtype=mat66f, device=self.device)
+        projected_twist = wp.array([[-1.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0] * 6], dtype=vec6f, device=self.device)
+        twist_delta = wp.zeros(2, dtype=vec6f, device=self.device)
+        body_world = wp.zeros(2, dtype=wp.int32, device=self.device)
+        body_constraint_count = wp.array([2, 1], dtype=wp.int32, device=self.device)
+        static_body_constraint_count = wp.zeros(2, dtype=wp.int32, device=self.device)
+
+        contact_jacobian = np.zeros((2, 3, 6), dtype=np.float32)
+        contact_jacobian[:, 0, 1] = 1.0
+        contact_jacobian[:, 1, 2] = 1.0
+        contact_jacobian[:, 2, 0] = 1.0
+        contact_world = wp.zeros(2, dtype=wp.int32, device=self.device)
+        contact_local = wp.array([0, 1], dtype=wp.int32, device=self.device)
+        world_contact_count = wp.array([2], dtype=wp.int32, device=self.device)
+        contact_body_first = wp.zeros(2, dtype=wp.int32, device=self.device)
+        contact_body_second = wp.array([1, -1], dtype=wp.int32, device=self.device)
+        contact_jacobian_first = wp.array(contact_jacobian, dtype=mat36f, device=self.device)
+        contact_jacobian_second_values = np.zeros_like(contact_jacobian)
+        contact_jacobian_second_values[0] = contact_jacobian[0]
+        contact_jacobian_second = wp.array(contact_jacobian_second_values, dtype=mat36f, device=self.device)
+        contact_bias = wp.zeros(2, dtype=wp.vec3f, device=self.device)
+        contact_friction = wp.zeros(2, dtype=wp.float32, device=self.device)
+        contact_delassus = wp.zeros(2, dtype=wp.mat33f, device=self.device)
+        contact_reaction = wp.zeros(2, dtype=wp.vec3f, device=self.device)
+
+        empty_int = wp.empty(0, dtype=wp.int32, device=self.device)
+        empty_vec6 = wp.empty(0, dtype=vec6f, device=self.device)
+        empty_float = wp.empty(0, dtype=wp.float32, device=self.device)
+        world_limit_count = wp.zeros(1, dtype=wp.int32, device=self.device)
+        prepared_status = wp.zeros(1, dtype=wp.int32, device=self.device)
+        projection_status = wp.zeros(1, dtype=wp.int32, device=self.device)
+        world_active = wp.ones(1, dtype=wp.bool, device=self.device)
+
+        prepare_jacobi_projection_data(
+            empty_int,
+            empty_int,
+            world_limit_count,
+            empty_int,
+            empty_int,
+            empty_vec6,
+            empty_vec6,
+            contact_world,
+            contact_local,
+            world_contact_count,
+            contact_body_first,
+            contact_body_second,
+            contact_jacobian_first,
+            contact_jacobian_second,
+            contact_bias,
+            contact_friction,
+            empty_int,
+            empty_int,
+            world_limit_count,
+            empty_int,
+            empty_int,
+            empty_vec6,
+            empty_vec6,
+            body_constraint_count,
+            static_body_constraint_count,
+            inverse_weight,
+            empty_float,
+            contact_delassus,
+            empty_float,
+            prepared_status,
+        )
+        project_constraints_jacobi(
+            1,
+            world_active,
+            body_world,
+            empty_int,
+            empty_int,
+            world_limit_count,
+            empty_int,
+            empty_int,
+            empty_vec6,
+            empty_vec6,
+            empty_float,
+            empty_float,
+            contact_world,
+            contact_local,
+            world_contact_count,
+            contact_body_first,
+            contact_body_second,
+            contact_jacobian_first,
+            contact_jacobian_second,
+            contact_bias,
+            contact_friction,
+            contact_delassus,
+            empty_int,
+            empty_int,
+            world_limit_count,
+            empty_int,
+            empty_int,
+            empty_vec6,
+            empty_vec6,
+            empty_float,
+            empty_float,
+            inverse_weight,
+            projected_twist,
+            twist_delta,
+            contact_reaction,
+            empty_float,
+            empty_float,
+            prepared_status,
+            projection_status,
+        )
+
+        np.testing.assert_allclose(contact_delassus.numpy()[:, 2, 2], [8.0, 4.0], rtol=0.0, atol=1.0e-6)
+        np.testing.assert_allclose(contact_reaction.numpy()[:, 2], [0.125, 0.25], rtol=0.0, atol=1.0e-6)
+        np.testing.assert_allclose(
+            projected_twist.numpy(),
+            [[-0.25, 0.0, 0.0, 0.0, 0.0, 0.0], [0.5, 0.0, 0.0, 0.0, 0.0, 0.0]],
+            rtol=0.0,
+            atol=1.0e-6,
+        )
+        np.testing.assert_array_equal(projection_status.numpy(), [PROJECTION_STATUS_VALID])
+
+    def test_accelerated_jacobi_projects_all_rigid_constraint_families(self):
+        """Match one rigid Jacobi sweep with its first accelerated step."""
+        device = self.device
+        adapter = SimpleNamespace(device=device, friction_capacity=1, contact_capacity=1, limit_capacity=1)
+        adapter.friction_world = wp.array([0], dtype=wp.int32, device=device)
+        adapter.friction_local = wp.array([0], dtype=wp.int32, device=device)
+        adapter.world_friction_count = wp.array([1], dtype=wp.int32, device=device)
+        adapter.friction_body_first = wp.array([0], dtype=wp.int32, device=device)
+        adapter.friction_body_second = wp.array([-1], dtype=wp.int32, device=device)
+        adapter.friction_jacobian_first = wp.array([[0, 0, 0, 1, 0, 0]], dtype=vec6f, device=device)
+        adapter.friction_jacobian_second = wp.zeros(1, dtype=vec6f, device=device)
+        adapter.friction_impulse_bound = wp.array([0.4], dtype=wp.float32, device=device)
+        adapter.friction_reaction = wp.array([0.1], dtype=wp.float32, device=device)
+        adapter.friction_velocity = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.friction_projection_delassus = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.friction_acceleration_trial = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.friction_acceleration_previous = wp.zeros(1, dtype=wp.float32, device=device)
+
+        adapter.contact_world = wp.array([0], dtype=wp.int32, device=device)
+        adapter.contact_local = wp.array([0], dtype=wp.int32, device=device)
+        adapter.world_contact_count = wp.array([1], dtype=wp.int32, device=device)
+        adapter.contact_body_first = wp.array([0], dtype=wp.int32, device=device)
+        adapter.contact_body_second = wp.array([-1], dtype=wp.int32, device=device)
+        contact_jacobian = np.zeros((1, 3, 6), dtype=np.float32)
+        contact_jacobian[0, 0, 1] = 1.0
+        contact_jacobian[0, 1, 2] = 1.0
+        contact_jacobian[0, 2, 0] = 1.0
+        adapter.contact_jacobian_first = wp.array(contact_jacobian, dtype=mat36f, device=device)
+        adapter.contact_jacobian_second = wp.zeros(1, dtype=mat36f, device=device)
+        adapter.contact_bias = wp.array([[0.0, 0.0, -0.2]], dtype=wp.vec3f, device=device)
+        adapter.contact_friction = wp.array([0.5], dtype=wp.float32, device=device)
+        adapter.contact_reaction = wp.zeros(1, dtype=wp.vec3f, device=device)
+        adapter.contact_velocity = wp.zeros(1, dtype=wp.vec3f, device=device)
+        adapter.contact_projection_delassus = wp.zeros(1, dtype=wp.mat33f, device=device)
+        adapter.contact_acceleration_trial = wp.zeros(1, dtype=wp.vec3f, device=device)
+        adapter.contact_acceleration_previous = wp.zeros(1, dtype=wp.vec3f, device=device)
+
+        adapter.limit_world = wp.array([0], dtype=wp.int32, device=device)
+        adapter.limit_local = wp.array([0], dtype=wp.int32, device=device)
+        adapter.world_limit_count = wp.array([1], dtype=wp.int32, device=device)
+        adapter.limit_body_first = wp.array([0], dtype=wp.int32, device=device)
+        adapter.limit_body_second = wp.array([-1], dtype=wp.int32, device=device)
+        adapter.limit_jacobian_first = wp.array([[0, 0, 0, 0, 1, 0]], dtype=vec6f, device=device)
+        adapter.limit_jacobian_second = wp.zeros(1, dtype=vec6f, device=device)
+        adapter.limit_bias = wp.array([-0.1], dtype=wp.float32, device=device)
+        adapter.limit_reaction = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.limit_velocity = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.limit_projection_delassus = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.limit_acceleration_trial = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.limit_acceleration_previous = wp.zeros(1, dtype=wp.float32, device=device)
+        adapter.world_jacobi_projection_status = wp.zeros(1, dtype=wp.int32, device=device)
+        adapter.projection_status = wp.zeros(1, dtype=wp.int32, device=device)
+        adapter.projection_twist_delta = wp.zeros(1, dtype=vec6f, device=device)
+
+        inverse_weight_host = np.eye(6, dtype=np.float32)
+        inverse_weight_host[0, 0] = 2.0
+        inverse_weight_host[1, 1] = 1.5
+        inverse_weight_host[2, 2] = 0.75
+        inverse_weight_host[0, 1] = 0.35
+        inverse_weight_host[1, 0] = 0.35
+        inverse_weight = wp.array([inverse_weight_host], dtype=mat66f, device=device)
+        prepare_jacobi_projection_data(
+            adapter.friction_world,
+            adapter.friction_local,
+            adapter.world_friction_count,
+            adapter.friction_body_first,
+            adapter.friction_body_second,
+            adapter.friction_jacobian_first,
+            adapter.friction_jacobian_second,
+            adapter.contact_world,
+            adapter.contact_local,
+            adapter.world_contact_count,
+            adapter.contact_body_first,
+            adapter.contact_body_second,
+            adapter.contact_jacobian_first,
+            adapter.contact_jacobian_second,
+            adapter.contact_bias,
+            adapter.contact_friction,
+            adapter.limit_world,
+            adapter.limit_local,
+            adapter.world_limit_count,
+            adapter.limit_body_first,
+            adapter.limit_body_second,
+            adapter.limit_jacobian_first,
+            adapter.limit_jacobian_second,
+            wp.array([3], dtype=wp.int32, device=device),
+            wp.zeros(1, dtype=wp.int32, device=device),
+            inverse_weight,
+            adapter.friction_projection_delassus,
+            adapter.contact_projection_delassus,
+            adapter.limit_projection_delassus,
+            adapter.world_jacobi_projection_status,
+        )
+        candidate = np.array([[-1.0, 0.2, 0.1, 0.8, -0.4, 0.0]], dtype=np.float32)
+        world_active = wp.ones(1, dtype=wp.bool, device=device)
+        body_world = wp.array([0], dtype=wp.int32, device=device)
+        jacobi_projected_twist = wp.array(candidate, dtype=vec6f, device=device)
+        jacobi_friction_reaction = wp.array([0.1], dtype=wp.float32, device=device)
+        jacobi_contact_reaction = wp.zeros(1, dtype=wp.vec3f, device=device)
+        jacobi_limit_reaction = wp.zeros(1, dtype=wp.float32, device=device)
+        jacobi_status = wp.zeros(1, dtype=wp.int32, device=device)
+        project_constraints_jacobi(
+            1,
+            world_active,
+            body_world,
+            adapter.friction_world,
+            adapter.friction_local,
+            adapter.world_friction_count,
+            adapter.friction_body_first,
+            adapter.friction_body_second,
+            adapter.friction_jacobian_first,
+            adapter.friction_jacobian_second,
+            adapter.friction_impulse_bound,
+            adapter.friction_projection_delassus,
+            adapter.contact_world,
+            adapter.contact_local,
+            adapter.world_contact_count,
+            adapter.contact_body_first,
+            adapter.contact_body_second,
+            adapter.contact_jacobian_first,
+            adapter.contact_jacobian_second,
+            adapter.contact_bias,
+            adapter.contact_friction,
+            adapter.contact_projection_delassus,
+            adapter.limit_world,
+            adapter.limit_local,
+            adapter.world_limit_count,
+            adapter.limit_body_first,
+            adapter.limit_body_second,
+            adapter.limit_jacobian_first,
+            adapter.limit_jacobian_second,
+            adapter.limit_bias,
+            adapter.limit_projection_delassus,
+            inverse_weight,
+            jacobi_projected_twist,
+            wp.zeros(1, dtype=vec6f, device=device),
+            jacobi_contact_reaction,
+            jacobi_limit_reaction,
+            jacobi_friction_reaction,
+            adapter.world_jacobi_projection_status,
+            jacobi_status,
+        )
+
+        projected_twist = wp.array(candidate, dtype=vec6f, device=device)
+        _project_constraints_accelerated(
+            1,
+            adapter,
+            world_active,
+            body_world,
+            inverse_weight,
+            projected_twist,
+            wp.ones(1, dtype=wp.float32, device=device),
+            wp.zeros(1, dtype=wp.float32, device=device),
+            wp.zeros(1, dtype=wp.float32, device=device),
+        )
+
+        np.testing.assert_allclose(adapter.friction_reaction.numpy(), jacobi_friction_reaction.numpy(), atol=1.0e-6)
+        np.testing.assert_allclose(adapter.contact_reaction.numpy(), jacobi_contact_reaction.numpy(), atol=1.0e-6)
+        np.testing.assert_allclose(adapter.limit_reaction.numpy(), jacobi_limit_reaction.numpy(), atol=1.0e-6)
+        np.testing.assert_allclose(projected_twist.numpy(), jacobi_projected_twist.numpy(), atol=2.0e-6)
+        contact_reaction = adapter.contact_reaction.numpy()[0]
+        self.assertGreaterEqual(float(contact_reaction[2]), 0.0)
+        self.assertLessEqual(float(np.linalg.norm(contact_reaction[:2])), 0.5 * float(contact_reaction[2]) + 1.0e-6)
+        self.assertGreaterEqual(float(adapter.limit_reaction.numpy()[0]), 0.0)
+        self.assertLessEqual(abs(float(adapter.friction_reaction.numpy()[0])), 0.4 + 1.0e-6)
+        expected = candidate[0].copy()
+        expected += inverse_weight_host @ (
+            float(adapter.friction_reaction.numpy()[0]) * adapter.friction_jacobian_first.numpy()[0]
+        )
+        expected += inverse_weight_host @ (contact_jacobian[0].T @ contact_reaction)
+        expected += inverse_weight_host @ (
+            float(adapter.limit_reaction.numpy()[0]) * adapter.limit_jacobian_first.numpy()[0]
+        )
+        np.testing.assert_allclose(projected_twist.numpy()[0], expected, atol=2.0e-6)
+        np.testing.assert_array_equal(adapter.projection_status.numpy(), [PROJECTION_STATUS_VALID])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/examples/kamino/example_kamino_basic_dr_testmech.py
+++ b/newton/examples/kamino/example_kamino_basic_dr_testmech.py
@@ -25,6 +25,7 @@ class Example:
         self.sim_substeps = max(1, round(self.frame_dt / self.sim_dt))
         self.sim_time = 0.0
         self.world_count = args.world_count if args else 1
+        self.dynamics_solver = str(getattr(args, "dynamics_solver", "padmm")).lower()
         self.viewer = viewer
         self.device = wp.get_device()
 
@@ -59,14 +60,18 @@ class Example:
         self.model = builder.finalize(skip_validation_joints=True)
 
         # Create the Kamino solver for the given model
-        self.config = newton.solvers.SolverKamino.Config.from_model(self.model)
+        self.config = newton.solvers.SolverKamino.Config.from_model(
+            self.model,
+            dynamics_solver=self.dynamics_solver,
+        )
         self.config.use_collision_detector = False
         self.config.use_fk_solver = False
-        self.config.padmm.max_iterations = 200
-        self.config.padmm.primal_tolerance = 1e-6
-        self.config.padmm.dual_tolerance = 1e-6
-        self.config.padmm.compl_tolerance = 1e-6
-        self.config.padmm.rho_0 = 0.01
+        if self.dynamics_solver == "padmm":
+            self.config.padmm.max_iterations = 200
+            self.config.padmm.primal_tolerance = 1e-6
+            self.config.padmm.dual_tolerance = 1e-6
+            self.config.padmm.compl_tolerance = 1e-6
+            self.config.padmm.rho_0 = 0.01
         self.solver = newton.solvers.SolverKamino(self.model, config=self.config)
 
         # Create state and control data containers
@@ -91,7 +96,7 @@ class Example:
 
     def capture(self):
         self.graph = None
-        if self.device.is_cuda and not wp.config.verify_cuda:
+        if not self.device.is_cuda or not wp.config.verify_cuda:
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -125,6 +130,7 @@ class Example:
         parser = newton.examples.create_parser()
         newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=1)
+        parser.add_argument("--dynamics-solver", choices=("padmm", "lox"), default="padmm")
         return parser
 
 

--- a/newton/examples/kamino/example_kamino_basic_fourbar.py
+++ b/newton/examples/kamino/example_kamino_basic_fourbar.py
@@ -30,6 +30,7 @@ class Example:
         self.sim_dt = self.frame_dt / self.sim_substeps
         self.sim_time = 0.0
         self.world_count = args.world_count if args else 1
+        self.dynamics_solver = str(getattr(args, "dynamics_solver", "padmm")).lower()
         self.viewer = viewer
         self.device = wp.get_device()
 
@@ -71,20 +72,24 @@ class Example:
         self.model.joint_target_kd.fill_(0.001)
 
         # Create and configure settings for SolverKamino and the collision detector
-        solver_config = newton.solvers.SolverKamino.Config.from_model(self.model)
+        solver_config = newton.solvers.SolverKamino.Config.from_model(
+            self.model,
+            dynamics_solver=self.dynamics_solver,
+        )
         solver_config.use_collision_detector = True
         solver_config.use_fk_solver = True
         solver_config.collision_detector.pipeline = "primitive"
         solver_config.collision_detector.max_contacts = 32 * self.model.world_count
         solver_config.dynamics.preconditioning = True
-        solver_config.padmm.primal_tolerance = 1e-4
-        solver_config.padmm.dual_tolerance = 1e-4
-        solver_config.padmm.compl_tolerance = 1e-4
-        solver_config.padmm.max_iterations = 200
-        solver_config.padmm.rho_0 = 0.1
-        solver_config.padmm.use_acceleration = True
-        solver_config.padmm.warmstart_mode = "containers"
-        solver_config.padmm.contact_warmstart_method = "geom_pair_net_force"
+        if self.dynamics_solver == "padmm":
+            solver_config.padmm.primal_tolerance = 1e-4
+            solver_config.padmm.dual_tolerance = 1e-4
+            solver_config.padmm.compl_tolerance = 1e-4
+            solver_config.padmm.max_iterations = 200
+            solver_config.padmm.rho_0 = 0.1
+            solver_config.padmm.use_acceleration = True
+            solver_config.padmm.warmstart_mode = "containers"
+            solver_config.padmm.contact_warmstart_method = "geom_pair_net_force"
 
         # Create the Kamino solver for the given model
         self.solver = newton.solvers.SolverKamino(model=self.model, config=solver_config)
@@ -113,8 +118,7 @@ class Example:
         )
         self.solver.reset(state=self.state_0, config=reset_config)
 
-        # Capture the simulation graph if running on CUDA
-        # NOTE: This only has an effect on GPU devices
+        # Capture with CUDA graphs on GPU or APIC graphs on CPU.
         self.capture()
 
         # If only a single-world is created, set initial
@@ -127,7 +131,7 @@ class Example:
 
     def capture(self):
         self.graph = None
-        if self.device.is_cuda and not wp.config.verify_cuda:
+        if not self.device.is_cuda or not wp.config.verify_cuda:
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -166,6 +170,7 @@ class Example:
         parser = newton.examples.create_parser()
         newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=1)
+        parser.add_argument("--dynamics-solver", choices=("padmm", "lox"), default="padmm")
         parser.add_argument(
             "--from-usd",
             action=argparse.BooleanOptionalAction,

--- a/newton/examples/kamino/example_kamino_basic_heterogeneous.py
+++ b/newton/examples/kamino/example_kamino_basic_heterogeneous.py
@@ -10,6 +10,7 @@
 
 import argparse
 
+import numpy as np
 import warp as wp
 
 import newton
@@ -26,6 +27,8 @@ class Example:
         self.frame_dt = 1.0 / self.fps
         self.sim_substeps = max(1, round(self.frame_dt / self.sim_dt))
         self.sim_time = 0.0
+        self.scenario = getattr(args, "scenario", "all") if args else "all"
+        self.dynamics_solver = getattr(args, "dynamics_solver", "padmm") if args else "padmm"
         self.viewer = viewer
         self.device = wp.get_device()
 
@@ -50,6 +53,8 @@ class Example:
         # model builder API, depending on the command-line argument `--from-usd`
         builder = newton.ModelBuilder()
         if args is not None and args.from_usd:
+            if args.z_offset != 0.0:
+                raise ValueError("--z-offset requires --no-from-usd.")
             # Load all basic USD assets and add them to the builder
             asset_names = [
                 "boxes_fourbar",
@@ -59,33 +64,46 @@ class Example:
                 "box_on_plane",
                 "cartpole",
             ]
+            if self.scenario != "all":
+                asset_names = [self.scenario]
             for asset_name in asset_names:
                 asset_file = get_kamino_basics_asset(f"{asset_name}.usda")
                 builder.add_world(builder=load_basic_asset_from_usd(asset_file))
         else:
             # Manually build the heterogeneous basic models using the builder API
-            basics.make_basics_heterogeneous_builder(builder=builder, ground=True)
+            if self.scenario == "all":
+                basics.make_basics_heterogeneous_builder(builder=builder, ground=True)
+            else:
+                build_scenario = getattr(basics, f"build_{self.scenario}")
+                build_scenario(builder=builder, z_offset=args.z_offset if args else 0.0, ground=True)
 
         # Create the model from the builder
         builder.request_contact_attributes("force")  # For contact visualization
         self.model = builder.finalize(skip_validation_joints=True)
 
         # Create and configure settings for SolverKamino and the collision detector
-        solver_config = newton.solvers.SolverKamino.Config.from_model(self.model)
+        solver_config = newton.solvers.SolverKamino.Config.from_model(
+            self.model,
+            dynamics_solver=self.dynamics_solver,
+        )
         solver_config.use_collision_detector = True
         solver_config.use_fk_solver = True
-        solver_config.collision_detector.pipeline = "primitive"
+        solver_config.collision_detector.pipeline = "primitive" if args is None or args.from_usd else "unified"
         solver_config.collision_detector.max_contacts = 32 * self.model.world_count
         solver_config.dynamics.preconditioning = True
-        solver_config.padmm.primal_tolerance = 1e-4
-        solver_config.padmm.dual_tolerance = 1e-4
-        solver_config.padmm.compl_tolerance = 1e-4
-        solver_config.padmm.max_iterations = 200
-        solver_config.padmm.rho_0 = 0.1
-        solver_config.padmm.use_acceleration = True
-        solver_config.padmm.warmstart_mode = "containers"
-        solver_config.padmm.contact_warmstart_method = "geom_pair_net_force"
-
+        if self.dynamics_solver == "padmm":
+            solver_config.padmm.primal_tolerance = 1e-4
+            solver_config.padmm.dual_tolerance = 1e-4
+            solver_config.padmm.compl_tolerance = 1e-4
+            solver_config.padmm.max_iterations = 200
+            solver_config.padmm.rho_0 = 0.1
+            solver_config.padmm.use_acceleration = True
+            solver_config.padmm.warmstart_mode = "containers"
+            solver_config.padmm.contact_warmstart_method = "geom_pair_net_force"
+        else:
+            tolerance = getattr(args, "lox_tolerance", 1.0e-7) if args else 1.0e-7
+            solver_config.lox.position_tolerance = tolerance
+            solver_config.lox.rotation_tolerance = tolerance
         # Create the Kamino solver for the given model
         self.solver = newton.solvers.SolverKamino(model=self.model, config=solver_config)
 
@@ -107,14 +125,19 @@ class Example:
         # If only a single-world is created, set initial
         # camera position for better view of the system
         if hasattr(self.viewer, "set_camera"):
-            camera_pos = wp.vec3(0.0, -15.0, 1.6)
-            pitch = -1.5
-            yaw = 92.0
+            if self.scenario == "all":
+                camera_pos = wp.vec3(0.0, -15.0, 1.6)
+                pitch = -1.5
+                yaw = 92.0
+            else:
+                camera_pos = wp.vec3(1.5, -2.5, 1.0)
+                pitch = -10.0
+                yaw = 115.0
             self.viewer.set_camera(camera_pos, pitch, yaw)
 
     def capture(self):
         self.graph = None
-        if self.device.is_cuda and not wp.config.verify_cuda:
+        if not self.device.is_cuda or not wp.config.verify_cuda:
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -146,7 +169,12 @@ class Example:
         self.viewer.end_frame()
 
     def test_final(self):
-        pass  # TODO: Add some assertions here once we have a more meaningful test scenario
+        assert self.graph is not None
+        arrays = (self.state_0.body_q, self.state_0.body_qd, self.state_0.joint_q, self.state_0.joint_qd)
+        assert all(np.isfinite(array.numpy()).all() for array in arrays)
+        if self.dynamics_solver == "lox":
+            solver = self.solver._solver_kamino.solver_fd
+            assert not solver.world_failed.numpy().any()
 
     @staticmethod
     def create_parser():
@@ -156,6 +184,38 @@ class Example:
             action=argparse.BooleanOptionalAction,
             default=True,
             help="Load the heterogeneous basic models from USD (otherwise build them manually).",
+        )
+        parser.add_argument(
+            "--scenario",
+            choices=(
+                "all",
+                "box_on_plane",
+                "box_pendulum",
+                "boxes_hinged",
+                "boxes_nunchaku",
+                "boxes_fourbar",
+                "cartpole",
+            ),
+            default="all",
+            help="Run all basic worlds or one selected model.",
+        )
+        parser.add_argument(
+            "--z-offset",
+            type=float,
+            default=0.0,
+            help="Initial vertical offset for a manually built selected model [m].",
+        )
+        parser.add_argument(
+            "--dynamics-solver",
+            choices=("padmm", "lox"),
+            default="padmm",
+            help="Kamino rigid-body dynamics backend.",
+        )
+        parser.add_argument(
+            "--lox-tolerance",
+            type=float,
+            default=1.0e-7,
+            help="Position and rotation tolerance for the LOX backend.",
         )
         return parser
 

--- a/newton/examples/kamino/example_kamino_robot_anymal_d.py
+++ b/newton/examples/kamino/example_kamino_robot_anymal_d.py
@@ -10,6 +10,7 @@
 #
 ###########################################################################
 
+import numpy as np
 import warp as wp
 
 import newton
@@ -26,6 +27,12 @@ class Example:
         self.sim_time = 0.0
         self.world_count = args.world_count if args else 1
         self.use_kamino_contacts = args.use_kamino_contacts if args else False
+        self.linear_solver_type = getattr(args, "linear_solver_type", "LLTB") if args else "LLTB"
+        self.linear_solver_kwargs = getattr(args, "linear_solver_kwargs", {}) if args else {}
+        self.dynamics_solver = getattr(args, "dynamics_solver", "padmm") if args else "padmm"
+        self.actuated = getattr(args, "actuated", False) if args else False
+        self.max_iterations = getattr(args, "max_iterations", 25) if args else 25
+        self.projection_iterations = getattr(args, "projection_iterations", 3) if args else 3
         self.viewer = viewer
         self.device = wp.get_device()
 
@@ -50,6 +57,7 @@ class Example:
         # Create the multi-world model by duplicating the single-robot
         # builder for the specified number of worlds
         builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        builder.request_contact_attributes("force")
         for _ in range(self.world_count):
             builder.add_world(robot_builder)
 
@@ -58,11 +66,43 @@ class Example:
 
         # Create the model from the builder
         self.model = builder.finalize()
+        self.model.rigid_contact_max = 1000 * self.world_count
+
+        if self.actuated:
+            # Match the public ANYmal D pose controller without actuating the floating base.
+            target_ke = self.model.joint_target_ke.numpy()
+            target_kd = self.model.joint_target_kd.numpy()
+            target_mode = self.model.joint_target_mode.numpy()
+            joint_type = self.model.joint_type.numpy()
+            joint_dof_start = self.model.joint_qd_start.numpy()
+            for joint in range(self.model.joint_count):
+                if joint_type[joint] != newton.JointType.REVOLUTE:
+                    continue
+                dof_slice = slice(joint_dof_start[joint], joint_dof_start[joint + 1])
+                target_ke[dof_slice] = 150.0
+                target_kd[dof_slice] = 5.0
+                target_mode[dof_slice] = int(newton.JointTargetMode.POSITION_VELOCITY)
+            self.model.joint_target_ke.assign(target_ke)
+            self.model.joint_target_kd.assign(target_kd)
+            self.model.joint_target_mode.assign(target_mode)
 
         # Create the Kamino solver for the given model
-        self.config = newton.solvers.SolverKamino.Config.from_model(self.model)
+        self.config = newton.solvers.SolverKamino.Config.from_model(
+            self.model,
+            dynamics_solver=self.dynamics_solver,
+        )
         self.config.use_collision_detector = self.use_kamino_contacts
-        self.config.padmm.warmstart_mode = "none"
+        self.config.dynamics.linear_solver_type = self.linear_solver_type
+        self.config.dynamics.linear_solver_kwargs = self.linear_solver_kwargs
+        if self.dynamics_solver == "padmm":
+            self.config.padmm.warmstart_mode = "none"
+            self.config.padmm.use_graph_conditionals = getattr(args, "use_graph_conditionals", True) if args else True
+        else:
+            # The simple row metric settles the passive robot more reliably
+            # with a moderate penalty and projected structural feedback.
+            self.config.lox.joint_penalty_scale = 20.0
+            self.config.lox.max_iterations = self.max_iterations
+            self.config.lox.projection_iterations = self.projection_iterations
         self.solver = newton.solvers.SolverKamino(self.model, config=self.config)
 
         # Create state and control data containers
@@ -92,8 +132,7 @@ class Example:
         )
         self.solver.reset(state=self.state_0, config=reset_config)
 
-        # Capture the simulation graph if running on CUDA
-        # NOTE: This only has an effect on GPU devices
+        # Capture with CUDA graphs on GPU or APIC graphs on CPU.
         self.capture()
 
         # If only a single-world is created, set initial
@@ -106,7 +145,7 @@ class Example:
 
     def capture(self):
         self.graph = None
-        if self.device.is_cuda and not wp.config.verify_cuda:
+        if not self.device.is_cuda or not wp.config.verify_cuda:
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -138,7 +177,34 @@ class Example:
         self.viewer.log_contacts(self.contacts, self.state_0)
         self.viewer.end_frame()
 
+    def _test_state_finite(self):
+        invalid = []
+        for name, array in (
+            ("body_q", self.state_0.body_q),
+            ("body_qd", self.state_0.body_qd),
+            ("joint_q", self.state_0.joint_q),
+            ("joint_qd", self.state_0.joint_qd),
+            ("contact_force", self.contacts.rigid_contact_force),
+        ):
+            if not np.isfinite(array.numpy()).all():
+                invalid.append(name)
+        if self.dynamics_solver == "lox":
+            solver = self.solver._solver_kamino.solver_fd
+            if solver.world_failed.numpy().any():
+                invalid.append("LOX backend status")
+        assert not invalid, f"Non-finite or failed ANYmal state: {', '.join(invalid)}"
+
+    def test_post_step(self):
+        self._test_state_finite()
+
     def test_final(self):
+        self._test_state_finite()
+        if self.dynamics_solver == "lox":
+            structural_residual = self.solver._solver_kamino.solver_fd.problem.structural_residual.numpy()
+            assert np.max(np.abs(structural_residual), initial=0.0) < 0.02, (
+                "ANYmal structural joint residual must settle below 0.02 m or rad"
+            )
+
         newton.examples.test_body_state(
             self.model,
             self.state_0,
@@ -156,14 +222,52 @@ class Example:
                     max(abs(qd)) < 0.25
                 ),  # Relaxed from 0.1 - unified pipeline has residual velocities up to ~0.2
             )
+        assert int(self.contacts.rigid_contact_count.numpy()[0]) > 0, "ANYmal must finish in contact with the ground"
 
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
         newton.examples.add_world_count_arg(parser)
         newton.examples.add_kamino_contacts_arg(parser)
+        parser.add_argument(
+            "--dynamics-solver",
+            choices=("padmm", "lox"),
+            default="padmm",
+            help="Kamino rigid-body dynamics backend.",
+        )
+        parser.add_argument(
+            "--actuated",
+            action="store_true",
+            help="Enable position-velocity drives that hold the imported joint pose.",
+        )
+        parser.add_argument(
+            "--max-iterations",
+            type=int,
+            default=25,
+            help="Maximum LOX splitting iterations per solve.",
+        )
+        parser.add_argument(
+            "--projection-iterations",
+            type=int,
+            default=3,
+            help="Sequential projection sweeps per LOX splitting iteration.",
+        )
+        parser.add_argument(
+            "--linear-solver-type",
+            choices=("LLTB", "LLTBRCM", "CR"),
+            default="LLTB",
+            type=str.upper,
+            help="Kamino dynamics linear solver to use.",
+        )
+        parser.add_argument(
+            "--no-graph-conditionals",
+            dest="use_graph_conditionals",
+            action="store_false",
+            help="Disable graph conditional loops in Kamino PADMM.",
+        )
         parser.set_defaults(world_count=1)
         parser.set_defaults(use_kamino_contacts=True)
+        parser.set_defaults(use_graph_conditionals=True)
         return parser
 
 

--- a/newton/examples/kamino/example_kamino_robot_dr_legs.py
+++ b/newton/examples/kamino/example_kamino_robot_dr_legs.py
@@ -10,6 +10,7 @@
 #
 ###########################################################################
 
+import numpy as np
 import warp as wp
 
 import newton
@@ -34,6 +35,8 @@ class Example:
         # constraints slightly less accurately than PADMM. Contact forces remain
         # zero until the shapes overlap.
         dvi_contact_margin = 5.0e-4 if self.dynamics_solver == "dvi" else 1e-6
+        self.max_iterations = getattr(args, "max_iterations", 25) if args else 25
+        self.projection_iterations = getattr(args, "projection_iterations", 3) if args else 3
         self.viewer = viewer
         self.device = wp.get_device()
         self.animated = getattr(args, "animated", False) if args else False
@@ -104,7 +107,7 @@ class Example:
             self.model,
             dynamics_solver=self.dynamics_solver,
             sparse_dynamics=self.dynamics_solver == "dvi",
-            sparse_jacobian=self.dynamics_solver == "dvi",
+            sparse_jacobian=self.dynamics_solver in ("dvi", "lox"),
         )
         self.config.use_fk_solver = True
         self.config.use_collision_detector = self.use_kamino_contacts
@@ -134,6 +137,12 @@ class Example:
             self.config.dvi.inequality_sweeps_per_iteration = 3
             self.config.dvi.bilateral_solve_interval = 1
             self.config.dvi.contact_warmstart_method = "key_and_position_with_tangential_net_force"
+        if self.dynamics_solver == "lox":
+            # The light articulated links need stronger structural enforcement once their feet make contact.
+            self.config.lox.joint_penalty_scale = 100.0
+            self.config.lox.max_iterations = self.max_iterations
+            self.config.lox.projection_iterations = self.projection_iterations
+            self.config.lox.use_graph_conditionals = getattr(args, "use_graph_conditionals", True) if args else True
         self.solver = newton.solvers.SolverKamino(self.model, config=self.config)
 
         # Create state and control data containers
@@ -169,8 +178,7 @@ class Example:
             animation_asset = str(asset_path / "dr_legs" / "animation" / "dr_legs_animation_100fps.npy")
             self._init_animation(asset_file, animation_asset)
 
-        # Capture the simulation graph if running on CUDA
-        # NOTE: This only has an effect on GPU devices
+        # Capture with CUDA graphs on GPU or APIC graphs on CPU.
         self.graph = None
         self.capture()
 
@@ -184,7 +192,7 @@ class Example:
 
     def capture(self):
         self.graph = None
-        if self.device.is_cuda and not wp.config.verify_cuda:
+        if not self.device.is_cuda or not wp.config.verify_cuda:
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -218,8 +226,36 @@ class Example:
         self.viewer.log_contacts(self.contacts, self.state_1)
         self.viewer.end_frame()
 
+    def _test_state_finite(self):
+        invalid = []
+        for name, array in (
+            ("body_q", self.state_0.body_q),
+            ("body_qd", self.state_0.body_qd),
+            ("joint_q", self.state_0.joint_q),
+            ("joint_qd", self.state_0.joint_qd),
+            ("contact_force", self.contacts.rigid_contact_force),
+        ):
+            values = array.numpy()
+            finite = np.isfinite(values)
+            if not finite.all():
+                finite_max = np.max(np.abs(values[finite])) if finite.any() else float("nan")
+                invalid.append(f"{name} ({np.count_nonzero(~finite)} invalid, finite max {finite_max:.6g})")
+        if self.dynamics_solver == "lox":
+            solver = self.solver._solver_kamino.solver_fd
+            if solver.world_failed.numpy().any():
+                invalid.append("LOX backend failure")
+            structural_residual = solver.problem.structural_residual.numpy()
+            if not np.isfinite(structural_residual).all():
+                invalid.append("structural joint residual is not finite")
+            elif np.max(np.abs(structural_residual), initial=0.0) > 0.25:
+                invalid.append("structural joint residual exceeds 0.25 m or rad")
+        assert not invalid, f"Invalid simulation state at t={self.sim_time:.6g} s: {', '.join(invalid)}"
+
+    def test_post_step(self):
+        self._test_state_finite()
+
     def test_final(self):
-        pass  # TODO: Add some assertions here once we have a more meaningful test scenario
+        self._test_state_finite()
 
     def _init_animation(self, model_asset: str, animation_asset: str):
         import numpy as np  # noqa: PLC0415
@@ -318,9 +354,21 @@ class Example:
         newton.examples.add_kamino_contacts_arg(parser)
         parser.add_argument(
             "--dynamics-solver",
-            choices=("padmm", "dvi"),
+            choices=("padmm", "dvi", "lox"),
             default="padmm",
             help="Kamino dynamics solver to use.",
+        )
+        parser.add_argument(
+            "--max-iterations",
+            type=int,
+            default=25,
+            help="Maximum LOX splitting iterations per solve.",
+        )
+        parser.add_argument(
+            "--projection-iterations",
+            type=int,
+            default=3,
+            help="Sequential projection sweeps per LOX splitting iteration.",
         )
         parser.add_argument(
             "--linear-solver-type",
@@ -333,7 +381,7 @@ class Example:
             "--no-graph-conditionals",
             dest="use_graph_conditionals",
             action="store_false",
-            help="Disable CUDA graph conditional nodes in Kamino PADMM.",
+            help="Disable graph conditional loops in Kamino PADMM and LOX.",
         )
         parser.add_argument(
             "--animated",

--- a/newton/tests/kamino/test_kamino_geometry_contacts.py
+++ b/newton/tests/kamino/test_kamino_geometry_contacts.py
@@ -1717,6 +1717,60 @@ class TestGeometryContactConversions(unittest.TestCase):
             err_msg="Culled contacts must not retain stale force data",
         )
 
+    def test_13_skip_fully_prescribed_contacts(self):
+        """Skip contacts whose two bodies are static or zero-mass."""
+
+        def build_scene():
+            builder = ModelBuilder()
+            static_body = builder.add_body(xform=wp.transform((0.0, 0.0, 0.45), wp.quat_identity()))
+            builder.add_shape_box(
+                static_body,
+                hx=0.5,
+                hy=0.5,
+                hz=0.5,
+                cfg=ModelBuilder.ShapeConfig(density=0.0),
+            )
+            dynamic_body = builder.add_body(xform=wp.transform((2.0, 0.0, 0.45), wp.quat_identity()))
+            builder.add_shape_box(
+                dynamic_body,
+                hx=0.5,
+                hy=0.5,
+                hz=0.5,
+                cfg=ModelBuilder.ShapeConfig(density=1.0),
+            )
+            builder.add_ground_plane()
+            return builder
+
+        model, state, contacts = self._setup_newton_scene(builder_fn=build_scene)
+        newton_count = int(contacts.rigid_contact_count.numpy()[0])
+        self.assertGreaterEqual(newton_count, 2)
+
+        shape_body = model.shape_body.numpy()
+        body_inv_mass = model.body_inv_mass.numpy()
+        shape0 = contacts.rigid_contact_shape0.numpy()[:newton_count]
+        shape1 = contacts.rigid_contact_shape1.numpy()[:newton_count]
+        responsive = [
+            (shape_body[s0] >= 0 and body_inv_mass[shape_body[s0]] > 0.0)
+            or (shape_body[s1] >= 0 and body_inv_mass[shape_body[s1]] > 0.0)
+            for s0, s1 in zip(shape0, shape1, strict=True)
+        ]
+        self.assertIn(False, responsive)
+        self.assertIn(True, responsive)
+
+        kamino = ContactsKamino(capacity=contacts.rigid_contact_max, device=self.default_device)
+        convert_contacts_newton_to_kamino(
+            model,
+            state,
+            contacts,
+            kamino,
+            skip_fully_prescribed_contacts=True,
+        )
+
+        kamino_count = int(kamino.model_active_contacts.numpy()[0])
+        self.assertEqual(kamino_count, sum(responsive))
+        body_b = kamino.bid_AB.numpy()[:kamino_count, 1]
+        self.assertTrue(np.all(body_inv_mass[body_b] > 0.0))
+
 
 ###
 # Test execution

--- a/newton/tests/kamino/test_kamino_linalg_solver_hybrid_llt.py
+++ b/newton/tests/kamino/test_kamino_linalg_solver_hybrid_llt.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for per-block hybrid LLT dispatch."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+from newton._src.solvers.kamino._src.linalg import (
+    DenseLinearOperatorData,
+    DenseSquareMultiLinearInfo,
+    HybridLLTBlockedSolver,
+)
+from newton.tests.kamino import setup_tests, test_context
+
+
+def _complete_adjacency(dimension: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(column for column in range(dimension) if column != row) for row in range(dimension))
+
+
+def _path_adjacency(dimension: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(column for column in (row - 1, row + 1) if 0 <= column < dimension) for row in range(dimension))
+
+
+def _make_spd(adjacency: tuple[tuple[int, ...], ...], rng: np.random.Generator) -> np.ndarray:
+    dimension = len(adjacency)
+    matrix = np.zeros((dimension, dimension), dtype=np.float32)
+    for row, neighbors in enumerate(adjacency):
+        for column in neighbors:
+            if column > row:
+                matrix[row, column] = matrix[column, row] = rng.uniform(-0.1, 0.1)
+    matrix[np.diag_indices(dimension)] = np.sum(np.abs(matrix), axis=1) + 1.0
+    return matrix
+
+
+class TestLinAlgHybridLLTBlockedSolver(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def _make_problem(self, adjacency):
+        rng = np.random.default_rng(17)
+        matrices = [_make_spd(block, rng) for block in adjacency]
+        right_hand_sides = [rng.standard_normal(matrix.shape[0]).astype(np.float32) for matrix in matrices]
+        info = DenseSquareMultiLinearInfo()
+        info.finalize(
+            dimensions=[matrix.shape[0] for matrix in matrices],
+            dtype=wp.float32,
+            device=self.device,
+        )
+        matrix = wp.array(np.concatenate([value.reshape(-1) for value in matrices]), device=self.device)
+        right_hand_side = wp.array(np.concatenate(right_hand_sides), device=self.device)
+        solution = wp.zeros(info.total_vec_size, dtype=wp.float32, device=self.device)
+        return info, matrices, right_hand_sides, matrix, right_hand_side, solution
+
+    def test_mixed_batch_preserves_small_block_specialization(self):
+        """Dispatch isolated 6-DoF blocks separately from a large sparse block."""
+        adjacency = (
+            _complete_adjacency(6),
+            _complete_adjacency(6),
+            _complete_adjacency(20),
+            _path_adjacency(128),
+        )
+        info, matrices, right_hand_sides, matrix, right_hand_side, solution = self._make_problem(adjacency)
+        solver = HybridLLTBlockedSolver(
+            operator=DenseLinearOperatorData(info=info, mat=matrix),
+            factorize_block_size=64,
+            solve_block_dim=256,
+            rcm_min_dimension=64,
+            symbolic_adjacency=adjacency,
+            device=self.device,
+        )
+
+        self.assertEqual(solver.sequential_block_indices, (0, 1))
+        self.assertEqual(solver.tiled_block_indices, (2,))
+        self.assertEqual(solver.rcm_block_indices, (3,))
+        self.assertIs(solver.L, solver._rcm_solver.L)
+
+        solver.compute(matrix)
+        solver.solve(right_hand_side, solution)
+
+        offsets = np.cumsum([0, *(value.shape[0] for value in matrices)])
+        solution_np = solution.numpy()
+        for block, (block_matrix, block_rhs) in enumerate(zip(matrices, right_hand_sides, strict=True)):
+            expected = np.linalg.solve(block_matrix, block_rhs)
+            np.testing.assert_allclose(
+                solution_np[offsets[block] : offsets[block + 1]], expected, rtol=2.0e-4, atol=2.0e-5
+            )
+        np.testing.assert_array_equal(solver.P.numpy()[:12], np.tile(np.arange(6, dtype=np.int32), 2))
+
+    def test_dense_intermediate_block_uses_tiled_llt(self):
+        """Keep an intermediate dense block on the ordinary tiled path."""
+        adjacency = (_complete_adjacency(48),)
+        info, matrices, right_hand_sides, matrix, right_hand_side, solution = self._make_problem(adjacency)
+        solver = HybridLLTBlockedSolver(
+            operator=DenseLinearOperatorData(info=info, mat=matrix),
+            rcm_min_dimension=32,
+            symbolic_adjacency=adjacency,
+            device=self.device,
+        )
+
+        self.assertEqual(solver.sequential_block_indices, ())
+        self.assertEqual(solver.tiled_block_indices, (0,))
+        self.assertEqual(solver.rcm_block_indices, ())
+
+        solver.compute(matrix)
+        solver.solve(right_hand_side, solution)
+
+        expected = np.linalg.solve(matrices[0], right_hand_sides[0])
+        np.testing.assert_allclose(solution.numpy(), expected, rtol=2.0e-4, atol=2.0e-5)
+
+    def test_permutation_initializes_inactive_capacity(self):
+        """Initialize packed permutations through every block's maximum dimension."""
+        adjacency = (_complete_adjacency(6), _path_adjacency(128))
+        info, _matrices, _right_hand_sides, matrix, _right_hand_side, _solution = self._make_problem(adjacency)
+        info.dim.assign([3, 64])
+        solver = HybridLLTBlockedSolver(
+            operator=DenseLinearOperatorData(info=info, mat=matrix),
+            rcm_min_dimension=64,
+            symbolic_adjacency=adjacency,
+            device=self.device,
+        )
+
+        permutation = solver.P.numpy()
+        np.testing.assert_array_equal(permutation[:6], np.arange(6, dtype=np.int32))
+        np.testing.assert_array_equal(np.sort(permutation[6:]), np.arange(128, dtype=np.int32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/kamino/test_kamino_linalg_solver_llt_blocked_rcm.py
+++ b/newton/tests/kamino/test_kamino_linalg_solver_llt_blocked_rcm.py
@@ -287,6 +287,58 @@ class TestLinAlgLLTBlockedRCMSolver(unittest.TestCase):
         expected = np.linalg.solve(matrix, rhs)
         np.testing.assert_allclose(result_wp.numpy(), expected, rtol=1.0e-4, atol=1.0e-5)
 
+    def test_fixed_symbolic_structure_reuses_ordering_across_numeric_changes(self):
+        """Reuse fixed symbolic analysis when structurally present values change."""
+        n = 18
+        edges = [(index, index + 1) for index in range(n - 1)]
+        edges.extend((index, index + 3) for index in range(0, n - 3, 3))
+        adjacency = [set() for _ in range(n)]
+        for first, second in edges:
+            adjacency[first].add(second)
+            adjacency[second].add(first)
+
+        def make_matrix(scale: float, zero_edge: tuple[int, int] | None) -> np.ndarray:
+            matrix = np.zeros((n, n), dtype=np.float32)
+            for edge_index, (first, second) in enumerate(edges):
+                value = np.float32(-scale * (0.1 + 0.01 * edge_index))
+                if zero_edge == (first, second):
+                    value = np.float32(0.0)
+                matrix[first, second] = value
+                matrix[second, first] = value
+            matrix[np.diag_indices(n)] = np.sum(np.abs(matrix), axis=1) + np.float32(1.0)
+            return matrix
+
+        matrix_first = make_matrix(0.8, edges[5])
+        matrix_second = make_matrix(1.3, None)
+        rhs = np.linspace(-0.75, 1.0, n, dtype=np.float32)
+        info = DenseSquareMultiLinearInfo()
+        info.finalize(dimensions=[n], dtype=wp.float32, device=self.default_device)
+        matrix_wp = wp.array(matrix_first.reshape(-1), dtype=wp.float32, device=self.default_device)
+        rhs_wp = wp.array(rhs, dtype=wp.float32, device=self.default_device)
+        result_wp = wp.zeros(n, dtype=wp.float32, device=self.default_device)
+        solver = LLTBlockedRCMSolver(
+            operator=DenseLinearOperatorData(info=info, mat=matrix_wp),
+            block_size=4,
+            parallel_factorization=True,
+            symbolic_adjacency=[[tuple(sorted(neighbors)) for neighbors in adjacency]],
+            device=self.default_device,
+        )
+
+        solver.compute(matrix_wp)
+        solver.solve(rhs_wp, result_wp)
+        np.testing.assert_allclose(result_wp.numpy(), np.linalg.solve(matrix_first, rhs), rtol=2.0e-4, atol=2.0e-5)
+        permutation = solver.P.numpy().copy()
+
+        solver.reset()
+        matrix_wp.assign(matrix_second.reshape(-1))
+        solver.compute(matrix_wp)
+        solver.solve(rhs_wp, result_wp)
+
+        np.testing.assert_array_equal(solver.P.numpy(), permutation)
+        result = result_wp.numpy()
+        np.testing.assert_allclose(result, np.linalg.solve(matrix_second, rhs), rtol=2.0e-4, atol=2.0e-5)
+        np.testing.assert_allclose(matrix_second @ result, rhs, rtol=2.0e-4, atol=2.0e-5)
+
     def test_cached_permutation_on_cpu_fallback(self):
         """Verify the CPU fallback reuses a cached permutation."""
         device = wp.get_device("cpu")

--- a/newton/tests/kamino/test_kamino_solver_kamino.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino.py
@@ -26,13 +26,14 @@ from newton._src.solvers.kamino._src.kinematics.joints import JointCorrectionMod
 from newton._src.solvers.kamino._src.kinematics.limits import LimitsKamino
 from newton._src.solvers.kamino._src.solver_kamino_impl import SolverKaminoImpl
 from newton._src.solvers.kamino._src.solvers import PADMMSolver
+from newton._src.solvers.kamino._src.solvers.lox.solver import _low_mode_eigenvalue
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino.examples import print_progress_bar
 from newton._src.solvers.kamino.solver_kamino import SolverKamino
 from newton.tests.kamino import setup_tests, test_context
 from newton.tests.kamino.utils.sampling import sample_world_mask
 from newton.tests.utils import basics
-from newton.tests.utils.basics import build_boxes_fourbar
+from newton.tests.utils.basics import build_box_on_plane, build_boxes_fourbar, build_boxes_hinged
 from newton.tests.utils.testing import build_binary_revolute_joint_test, build_shape_pairs_test
 
 ###
@@ -120,6 +121,7 @@ def assert_solver_config(testcase: unittest.TestCase, config: SolverKaminoImpl.C
     testcase.assertIsInstance(config.constraints, kamino_config.ConstraintStabilizationConfig)
     testcase.assertIsInstance(config.dynamics, kamino_config.ConstrainedDynamicsConfig)
     testcase.assertIsInstance(config.padmm, kamino_config.PADMMSolverConfig)
+    testcase.assertIsInstance(config.lox, kamino_config.LOXSolverConfig)
     testcase.assertIsInstance(config.rotation_correction, str)
 
 
@@ -386,6 +388,7 @@ class TestSolverKaminoConfig(unittest.TestCase):
             msg.reset_log_level()
 
     def test_00_make_default(self):
+        """Construct the default solver configuration."""
         config = SolverKaminoImpl.Config()
         assert_solver_config(self, config)
         self.assertEqual(config.rotation_correction, "twopi")
@@ -419,6 +422,99 @@ class TestSolverKaminoConfig(unittest.TestCase):
                 sparse_dynamics=False,
                 padmm=kamino_config.PADMMSolverConfig(penalty_update_method="balanced"),
             )
+
+    def test_02_lox_config_validation(self):
+        """Accept supported LOX projection methods and reject invalid config values."""
+        with self.assertRaises(TypeError):
+            kamino_config.LOXSolverConfig(10)
+
+        config = SolverKaminoImpl.Config(dynamics_solver="lox")
+        self.assertEqual(config.dynamics_solver, "lox")
+        for method in (
+            "key_and_position",
+            "geom_pair_net_force",
+            "key_and_position_with_net_force_backup",
+            "key_and_position_with_tangential_net_force",
+            "key_and_position_with_net_force_backup_and_tangential_net_force",
+        ):
+            with self.subTest(contact_warmstart_method=method):
+                kamino_config.LOXSolverConfig(contact_warmstart_method=method)
+        for method in ("geom_pair_net_wrench", "key_and_position_with_net_wrench_backup"):
+            with self.subTest(contact_warmstart_method=method):
+                with self.assertRaisesRegex(ValueError, "contact warmstart method is not implemented"):
+                    kamino_config.LOXSolverConfig(contact_warmstart_method=method)
+        for projection_method in ("jacobi", "gauss_seidel", "apgd"):
+            with self.subTest(projection_method=projection_method):
+                self.assertEqual(
+                    kamino_config.LOXSolverConfig(projection_method=projection_method).projection_method,
+                    projection_method,
+                )
+
+        with self.assertRaisesRegex(ValueError, "'jacobi'.*'gauss_seidel'.*'apgd'"):
+            kamino_config.LOXSolverConfig(projection_method="invalid")
+
+        for color_count in (0, 1, 2, 17):
+            with self.subTest(gauss_seidel_max_colors=color_count):
+                projection_method = "jacobi" if color_count == 0 else "gauss_seidel"
+                self.assertEqual(
+                    kamino_config.LOXSolverConfig(
+                        projection_method=projection_method,
+                        gauss_seidel_max_colors=color_count,
+                    ).gauss_seidel_max_colors,
+                    color_count,
+                )
+        for color_count in (-1, 1.0, True):
+            with self.subTest(invalid_gauss_seidel_max_colors=color_count):
+                with self.assertRaisesRegex(ValueError, "gauss_seidel_max_colors"):
+                    kamino_config.LOXSolverConfig(gauss_seidel_max_colors=color_count)
+
+        invalid_values = (
+            {"max_iterations": 0},
+            {"use_graph_conditionals": 1},
+            {"fixed_iterations": 1},
+            {"projection_iterations": 0},
+            {"position_tolerance": 0.0},
+            {"rotation_tolerance": 0.0},
+            {"velocity_tolerance": 0.0},
+            {"weight_sigma": 0.0},
+            {"weight_sigma": 1.1},
+            {"weight_beta": 0.0},
+            {"weight_beta": 0.5},
+            {"selective_weights": 1},
+            {"joint_penalty_scale": 0.0},
+            {"joint_multiplier_projected_fraction": -0.1},
+            {"joint_multiplier_projected_fraction": 1.1},
+            {"joint_warmstart_factor": -0.1},
+            {"joint_warmstart_factor": 1.1},
+            {"contact_recoverable_response": 1},
+            {"impact_velocity_threshold": -1.0},
+            {"position_tolerance": float("nan")},
+            {"velocity_tolerance": float("nan")},
+            {"weight_beta": float("inf")},
+            {"joint_multiplier_projected_fraction": float("nan")},
+            {"joint_warmstart_factor": float("nan")},
+            {"impact_velocity_threshold": float("nan")},
+        )
+        for kwargs in invalid_values:
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                kamino_config.LOXSolverConfig(**kwargs)
+
+        with self.assertRaises(ValueError):
+            SolverKaminoImpl.Config(dynamics_solver="invalid")
+        SolverKaminoImpl.Config(dynamics_solver="lox", sparse_jacobian=True)
+        with self.assertRaises(ValueError):
+            SolverKaminoImpl.Config(
+                dynamics_solver="lox",
+                sparse_jacobian=True,
+                sparse_dynamics=True,
+            )
+        config = SolverKaminoImpl.Config(dynamics_solver="lox", integrator="moreau")
+        self.assertEqual(config.integrator, "moreau")
+
+    def test_reject_removed_lox_avbd_projection_method(self):
+        """Reject the removed LOX AVBD projection method."""
+        with self.assertRaisesRegex(ValueError, "Invalid projection_method: avbd"):
+            kamino_config.LOXSolverConfig(projection_method="avbd")
 
 
 class TestCollisionCapacityInitialization(unittest.TestCase):
@@ -478,49 +574,80 @@ class TestCollisionCapacityInitialization(unittest.TestCase):
 
         self.assertIsInstance(solver._solver_kamino._integrator, IntegratorMoreauJean)
 
+    def test_lox_uses_standard_integrators(self):
+        """Verify LOX composes with Kamino's Euler and Moreau-Jean integrators."""
+        for integrator, integrator_type in (
+            ("euler", IntegratorEuler),
+            ("moreau", IntegratorMoreauJean),
+        ):
+            with self.subTest(integrator=integrator):
+                model = self._make_three_world_model()
+                solver = SolverKamino(
+                    model,
+                    config=SolverKamino.Config(
+                        dynamics_solver="lox",
+                        integrator=integrator,
+                        use_collision_detector=True,
+                    ),
+                )
+
+                self.assertIsInstance(solver._solver_kamino._integrator, integrator_type)
+
     def test_moreau_detects_midpoint_contact(self):
-        """Verify Moreau-Jean detects contacts created at the midpoint."""
-        # Start the sphere surface 0.3 m above the zero-gap ground plane.
-        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
-        SolverKamino.register_custom_attributes(builder)
-        basics.build_sphere_on_plane(builder=builder, z_offset=0.3)
-        model = builder.finalize(device=self.default_device, skip_validation_joints=True)
+        """Verify Moreau-Jean detects midpoint contacts with each dynamics solver."""
+        for dynamics_solver in ("padmm", "lox"):
+            with self.subTest(dynamics_solver=dynamics_solver):
+                # Start the sphere surface 0.3 m above the zero-gap ground plane.
+                builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+                SolverKamino.register_custom_attributes(builder)
+                basics.build_sphere_on_plane(builder=builder, z_offset=0.3)
+                model = builder.finalize(device=self.default_device, skip_validation_joints=True)
 
-        config = SolverKamino.Config(integrator="moreau", use_collision_detector=True)
-        solver = SolverKamino(model, config=config)
+                config = SolverKamino.Config(
+                    dynamics_solver=dynamics_solver,
+                    integrator="moreau",
+                    use_collision_detector=True,
+                )
+                solver = SolverKamino(model, config=config)
 
-        detector = solver._collision_detector_kamino
-        contacts = solver._contacts_kamino
-        assert detector is not None
-        assert contacts is not None
-        assert contacts.model_active_contacts is not None
+                detector = solver._collision_detector_kamino
+                contacts = solver._contacts_kamino
+                assert detector is not None
+                assert contacts is not None
+                assert contacts.model_active_contacts is not None
 
-        # Establish that the step-start configuration has no contacts.
-        detector.collide(data=solver._solver_kamino._data, contacts=contacts)
-        self.assertEqual(int(contacts.model_active_contacts.numpy()[0]), 0)
+                # Establish that the step-start configuration has no contacts.
+                detector.collide(data=solver._solver_kamino._data, contacts=contacts)
+                self.assertEqual(int(contacts.model_active_contacts.numpy()[0]), 0)
 
-        state_in = model.state()
-        state_out = model.state()
-        assert state_in.body_qd is not None
-        # Over the first half-step, the sphere moves 0.35 m down and penetrates the plane.
-        state_in.body_qd.assign(np.array([[0.0, 0.0, -7.0, 0.0, 0.0, 0.0]], dtype=np.float32))
+                state_in = model.state()
+                state_out = model.state()
+                assert state_in.body_qd is not None
+                # The sphere moves 0.35 m down over the first half-step.
+                state_in.body_qd.assign(np.array([[0.0, 0.0, -7.0, 0.0, 0.0, 0.0]], dtype=np.float32))
 
-        solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+                solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
 
-        # This contact exists only if detection uses the midpoint rather than state_in.
-        self.assertGreater(int(contacts.model_active_contacts.numpy()[0]), 0)
+                # This contact exists only if detection uses the midpoint.
+                self.assertGreater(int(contacts.model_active_contacts.numpy()[0]), 0)
 
     def test_external_contacts_use_euler(self):
-        """Verify external-contact configurations warn and pick Euler."""
-        model = self._make_three_world_model()
-        with self.assertLogs(level="WARNING") as logs:
-            solver = SolverKamino(
-                model,
-                config=SolverKamino.Config(integrator="moreau", use_collision_detector=False),
-            )
+        """Verify external-contact configurations warn and pick Euler for each solver."""
+        for dynamics_solver in ("padmm", "lox"):
+            with self.subTest(dynamics_solver=dynamics_solver):
+                model = self._make_three_world_model()
+                with self.assertLogs(level="WARNING") as logs:
+                    solver = SolverKamino(
+                        model,
+                        config=SolverKamino.Config(
+                            dynamics_solver=dynamics_solver,
+                            integrator="moreau",
+                            use_collision_detector=False,
+                        ),
+                    )
 
-        self.assertIsInstance(solver._solver_kamino._integrator, IntegratorEuler)
-        self.assertTrue(any("Falling back to the 'euler' integrator" in message for message in logs.output))
+                self.assertIsInstance(solver._solver_kamino._integrator, IntegratorEuler)
+                self.assertTrue(any("Falling back to the 'euler' integrator" in message for message in logs.output))
 
     def test_external_collisions_preserve_explicit_rigid_contact_max(self):
         """Verify external collisions preserve an explicit contact capacity."""
@@ -632,6 +759,57 @@ class TestSolverKaminoStatus(unittest.TestCase):
                 )
                 self._step_and_assert_status_contract(solver, model)
 
+    def test_lox_status_maps_native_state_and_optional_metrics(self):
+        """Map LOX termination state and conditionally evaluated NCP residuals."""
+        model = self._make_three_world_model()
+
+        for compute_solution_metrics in (False, True):
+            with self.subTest(compute_solution_metrics=compute_solution_metrics):
+                solver = newton.solvers.SolverKamino(
+                    model,
+                    config=newton.solvers.SolverKamino.Config(
+                        dynamics_solver="lox",
+                        compute_solution_metrics=compute_solution_metrics,
+                    ),
+                )
+                solver.step(model.state(), model.state(), control=None, contacts=None, dt=SIM_DT)
+
+                lox = solver._solver_kamino.solver_fd
+                status = solver.status
+                self.assertIs(status, lox.status)
+                self.assertEqual(status.shape, (3,))
+                self.assertEqual(status.device, self.default_device)
+                self.assertTrue(
+                    {
+                        "converged",
+                        "iterations",
+                        "r_p",
+                        "r_d",
+                        "r_c",
+                        "accepted",
+                        "failed",
+                        "iteration_limit",
+                    }.issubset(status.dtype.vars)
+                )
+
+                status_host = status.numpy()
+                expected_converged = lox.world_converged.numpy() & ~lox.world_failed.numpy()
+                np.testing.assert_array_equal(status_host["converged"], expected_converged)
+                np.testing.assert_array_equal(status_host["iterations"], lox.iteration_count.numpy())
+                np.testing.assert_array_equal(status_host["accepted"], lox.world_accepted.numpy())
+                np.testing.assert_array_equal(status_host["failed"], lox.world_failed.numpy())
+                np.testing.assert_array_equal(status_host["iteration_limit"], lox.world_iteration_limit.numpy())
+
+                if compute_solution_metrics:
+                    metrics = solver.metrics
+                    self.assertIsNotNone(metrics)
+                    np.testing.assert_allclose(status_host["r_p"], metrics.data.r_ncp_primal.numpy(), equal_nan=True)
+                    np.testing.assert_allclose(status_host["r_d"], metrics.data.r_ncp_dual.numpy(), equal_nan=True)
+                    np.testing.assert_allclose(status_host["r_c"], metrics.data.r_ncp_compl.numpy(), equal_nan=True)
+                else:
+                    for field in ("r_p", "r_d", "r_c"):
+                        self.assertTrue(np.all(np.isnan(status_host[field])))
+
 
 class TestSolverKaminoImpl(unittest.TestCase):
     def setUp(self):
@@ -707,6 +885,52 @@ class TestSolverKaminoImpl(unittest.TestCase):
         self.assertIsInstance(solver, SolverKaminoImpl)
         assert_solver_components(self, solver)
         self.assertIsNone(solver._limits.data.wid)
+
+    def test_backend_specific_sparse_jacobian_default(self):
+        """Select sparse Jacobians by default only for LOX."""
+        model = ModelKamino.from_newton(build_boxes_fourbar().finalize(device=self.default_device))
+
+        padmm_solver = SolverKaminoImpl(model=model, config=SolverKaminoImpl.Config())
+        self.assertIsInstance(padmm_solver._jacobians, DenseSystemJacobians)
+
+        lox_config = SolverKaminoImpl.Config(dynamics_solver="lox")
+        lox_solver = SolverKaminoImpl(model=model, config=lox_config)
+        self.assertIsInstance(lox_solver._jacobians, SparseSystemJacobians)
+
+        with self.assertRaisesRegex(ValueError, "requires `sparse_jacobian=True`"):
+            SolverKaminoImpl(
+                model=model,
+                config=SolverKaminoImpl.Config(dynamics_solver="lox", sparse_jacobian=False),
+            )
+
+    def test_joint_penalty_scale_seed(self):
+        """Seed each world's LOX joint penalty from its structural spectrum."""
+        builder = newton.ModelBuilder()
+        builder.add_world(build_box_on_plane(ground=False))
+        builder.add_world(build_boxes_hinged(ground=False))
+        model = ModelKamino.from_newton(builder.finalize(device=self.default_device))
+        config = SolverKaminoImpl.Config(dynamics_solver="lox")
+        config.lox.joint_penalty_scale = 123.0
+        solver = SolverKaminoImpl(model=model, config=config)
+        lox_solver = solver.solver_fd
+
+        with self.assertRaises(ValueError):
+            lox_solver.joint_penalty_scale_seed(0.0)
+
+        seed = lox_solver.joint_penalty_scale_seed(0.001)
+        self.assertEqual(len(seed), 2)
+        self.assertTrue(np.all(np.isfinite(seed)))
+        self.assertTrue(np.all(np.asarray(seed) > 0.0))
+        self.assertAlmostEqual(seed[0], 123.0)
+        self.assertNotAlmostEqual(seed[1], seed[0])
+        np.testing.assert_allclose(solver.solver_fd.joint_penalty_scale.numpy(), seed)
+        self.assertEqual(config.lox.joint_penalty_scale, 123.0)
+
+    def test_joint_penalty_scale_seed_uses_low_percentile(self):
+        """Select the configured low spectral percentile for LOX penalty seeding."""
+        np.testing.assert_equal(_low_mode_eigenvalue(np.arange(1.0, 50.0)), 1.0)
+        np.testing.assert_equal(_low_mode_eigenvalue(np.arange(1.0, 51.0)), 2.0)
+        np.testing.assert_equal(_low_mode_eigenvalue(np.arange(1.0, 101.0)), 3.0)
 
     ###
     # Test Reset Operations
@@ -1699,7 +1923,19 @@ class TestSolverKaminoImpl(unittest.TestCase):
 
 
 class TestSolverKaminoMasslessBodies(unittest.TestCase):
-    """Massless bodies are supported when welded to the world and rejected otherwise."""
+    """Massless bodies are supported when fixed or prescribed and rejected otherwise."""
+
+    def test_massless_kinematic_body_attached_to_dynamic_body_is_supported(self):
+        """Accept an explicitly kinematic body coupled to a dynamic body."""
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        base = builder.add_link(mass=0.0, label="kinematic_base")
+        link = builder.add_link(mass=1.0, inertia=UNIT_INERTIA, label="dynamic_link")
+        builder.body_flags[base] = int(newton.BodyFlags.KINEMATIC)
+        joint = builder.add_joint_revolute(parent=base, child=link, axis=newton.Axis.Y)
+        builder.add_articulation([joint])
+        model = builder.finalize()
+
+        self.assertEqual(SolverKamino._find_unsupported_singular_inertia_bodies(model), [])
 
     def test_massless_body_welded_to_world_stays_at_rest(self):
         """Verify a massless body welded to the world stays at rest, along with its welded child.

--- a/newton/tests/kamino/test_kamino_solver_kamino_joint_friction.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino_joint_friction.py
@@ -73,6 +73,17 @@ def _build_revolute(
     return model
 
 
+def _make_lox_sparse_config(**kwargs) -> SolverKamino.Config:
+    """Create a sparse-constraint LOX configuration without collision detection."""
+    return SolverKamino.Config(
+        dynamics_solver="lox",
+        use_fk_solver=False,
+        sparse_jacobian=True,
+        use_collision_detector=False,
+        **kwargs,
+    )
+
+
 def _initialize_state(model: newton.Model, q: float = 0.0, qd: float = 0.0) -> newton.State:
     """Initialize generalized and maximal state consistently."""
     model.joint_q.assign([q])
@@ -277,41 +288,43 @@ class TestSolverKaminoJointFriction(unittest.TestCase):
             builder.add_articulation([joint])
             builder.end_world()
         model = builder.finalize()
-        solver = SolverKamino(model, make_padmm_sparse_config())
-        kamino = solver._model_kamino
+        for name, config_factory in (("padmm", make_padmm_sparse_config), ("lox", _make_lox_sparse_config)):
+            with self.subTest(config=name):
+                solver = SolverKamino(model, config_factory())
+                kamino = solver._model_kamino
 
-        friction_prefix = kamino.info.joint_friction_cts_offset.numpy()
-        friction_group = kamino.info.joint_friction_cts_group_offset.numpy()
-        total_prefix = kamino.info.total_cts_offset.numpy()
-        friction_offset = kamino.joints.friction_cts_offset.numpy()
-        friction_total_offset = kamino.joints.friction_cts_offset_total_cts.numpy()
-        joint_world = kamino.joints.wid.numpy()
-        self.assertListEqual(friction_prefix.tolist(), [0, 1])
-        for jid, wid in enumerate(joint_world):
-            self.assertEqual(
-                friction_total_offset[jid],
-                total_prefix[wid] + friction_group[wid] + friction_offset[jid] - friction_prefix[wid],
-            )
+                friction_prefix = kamino.info.joint_friction_cts_offset.numpy()
+                friction_group = kamino.info.joint_friction_cts_group_offset.numpy()
+                total_prefix = kamino.info.total_cts_offset.numpy()
+                friction_offset = kamino.joints.friction_cts_offset.numpy()
+                friction_total_offset = kamino.joints.friction_cts_offset_total_cts.numpy()
+                joint_world = kamino.joints.wid.numpy()
+                self.assertListEqual(friction_prefix.tolist(), [0, 1])
+                for jid, wid in enumerate(joint_world):
+                    self.assertEqual(
+                        friction_total_offset[jid],
+                        total_prefix[wid] + friction_group[wid] + friction_offset[jid] - friction_prefix[wid],
+                    )
 
-        sparse_jacobians = solver._solver_kamino._jacobians
-        expected_rows = kamino.info.num_joint_bilateral_cts.numpy() + kamino.info.num_joint_bounded_cts.numpy()
-        self.assertTrue(np.all(sparse_jacobians._J_cts.bsm.max_dims.numpy()[:, 0] >= expected_rows))
-        world_max_inequalities = (
-            kamino.info.num_joint_bounded_cts.numpy()
-            + kamino.info.max_limits.numpy()
-            + kamino.info.max_contacts.numpy()
-        )
-        self.assertEqual(kamino.size.sum_of_max_inequalities, int(np.sum(world_max_inequalities)))
-        self.assertEqual(kamino.size.max_of_max_inequalities, int(np.max(world_max_inequalities)))
-        np.testing.assert_array_equal(
-            kamino.info.inequalities_offset.numpy(),
-            np.cumsum(np.concatenate(([0], world_max_inequalities[:-1]))),
-        )
+                sparse_jacobians = solver._solver_kamino._jacobians
+                expected_rows = kamino.info.num_joint_bilateral_cts.numpy() + kamino.info.num_joint_bounded_cts.numpy()
+                self.assertTrue(np.all(sparse_jacobians._J_cts.bsm.max_dims.numpy()[:, 0] >= expected_rows))
+                world_max_inequalities = (
+                    kamino.info.num_joint_bounded_cts.numpy()
+                    + kamino.info.max_limits.numpy()
+                    + kamino.info.max_contacts.numpy()
+                )
+                self.assertEqual(kamino.size.sum_of_max_inequalities, int(np.sum(world_max_inequalities)))
+                self.assertEqual(kamino.size.max_of_max_inequalities, int(np.max(world_max_inequalities)))
+                np.testing.assert_array_equal(
+                    kamino.info.inequalities_offset.numpy(),
+                    np.cumsum(np.concatenate(([0], world_max_inequalities[:-1]))),
+                )
 
-        state_in = model.state()
-        newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
-        solver.step(state_in, model.state(), control=None, contacts=None, dt=DT)
-        np.testing.assert_array_equal(sparse_jacobians._J_cts.bsm.dims.numpy()[:, 0], expected_rows)
+                state_in = model.state()
+                newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+                solver.step(state_in, model.state(), control=None, contacts=None, dt=DT)
+                np.testing.assert_array_equal(sparse_jacobians._J_cts.bsm.dims.numpy()[:, 0], expected_rows)
 
 
 class TestSolverKaminoJointFrictionWarmstart(unittest.TestCase):
@@ -433,6 +446,41 @@ class TestSolverKaminoJointFrictionLimitStopsMotion(unittest.TestCase):
                     np.abs(friction_torques),
                     friction + 1.0e-4,
                 )
+
+    def test_box_natural_map_metrics(self):
+        """Include bounded friction rows in PADMM iteration-info and solution natural maps."""
+        model = _build_revolute(friction=2.0)
+        model.set_gravity((0.0, 0.0, 0.0))
+        solver = SolverKamino(
+            model,
+            make_padmm_dense_config(collect_solver_info=True, compute_solution_metrics=True),
+        )
+        state_in = _initialize_state(model, qd=1.0)
+        solver.step(state_in, model.state(), control=None, contacts=None, dt=DT)
+
+        solver_impl = solver._solver_kamino
+        solver_fd = solver_impl.solver_fd
+        metrics = solver_impl.metrics
+        self.assertIsNotNone(metrics)
+        self.assertEqual(int(solver_impl.problem_fd.data.nbc.numpy()[0]), 1)
+
+        problem_data = solver_impl.problem_fd.data
+        row = int(problem_data.vio.numpy()[0] + problem_data.bcgo.numpy()[0])
+        bound_idx = int(problem_data.bcio.numpy()[0])
+        lower = float(problem_data.P.numpy()[row] * problem_data.bound_lower.numpy()[bound_idx])
+        upper = float(problem_data.P.numpy()[row] * problem_data.bound_upper.numpy()[bound_idx])
+
+        iterations = int(solver_fd.data.status.numpy()[0]["iterations"])
+        info_idx = int(solver_fd.data.info.offsets.numpy()[0]) + iterations - 1
+        lambda_info = float(solver_fd.data.info.lambdas.numpy()[row])
+        v_aug_info = float(solver_fd.data.info.v_aug.numpy()[row])
+        expected_info = abs(lambda_info - np.clip(lambda_info - v_aug_info, lower, upper))
+        self.assertAlmostEqual(float(solver_fd.data.info.r_ncp_natmap.numpy()[info_idx]), expected_info, places=6)
+
+        lambda_solution = float(solver_fd.data.solution.lambdas.numpy()[row])
+        v_aug_metrics = float(metrics._buffer_v.numpy()[row])
+        expected_metrics = abs(lambda_solution - np.clip(lambda_solution - v_aug_metrics, lower, upper))
+        self.assertAlmostEqual(float(metrics.data.r_vi_natmap.numpy()[0]), expected_metrics, places=6)
 
 
 class TestSolverKaminoJointFrictionSpinDown(unittest.TestCase):

--- a/newton/tests/kamino/test_kamino_solver_kamino_notify.py
+++ b/newton/tests/kamino/test_kamino_solver_kamino_notify.py
@@ -83,8 +83,8 @@ def _build_revolute(
         limit_lower=-1.0 if limited else None,
         limit_upper=1.0 if limited else None,
         armature=1.0 if dynamic else 0.0,
-        friction=friction,
         damping=0.0,
+        friction=friction,
         effort_limit=effort_limit,
         target_ke=target_ke,
         target_kd=target_kd,
@@ -215,6 +215,74 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         )
         self.assertEqual(warning.call_count, 2)
         _assert_model_arrays_unchanged(model, snapshot)
+
+    def test_external_contacts_default_to_newton_capacity(self):
+        """Match the automatic Newton contact capacity for external collisions."""
+        model = _build_revolute()
+        self.assertEqual(model.rigid_contact_max, 0)
+
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=False))
+        pipeline = newton.CollisionPipeline(model)
+
+        self.assertEqual(solver._contacts_kamino.model_max_contacts_host, pipeline.rigid_contact_max)
+        self.assertEqual(model.rigid_contact_max, pipeline.rigid_contact_max)
+
+    def test_lox_model_update_without_joint_friction(self):
+        """Validate LOX model values when the friction array is absent."""
+        model = _build_revolute(friction=0.0)
+        solver = SolverKamino(model, config=SolverKamino.Config(dynamics_solver="lox"))
+        model.joint_friction = None
+        solver._solver_kamino.solver_fd.validate_model_changed()
+        self.assertEqual(solver._model_kamino.size.sum_of_num_friction_joint_cts, 0)
+        model.joint_effort_limit.fill_(-1.0)
+        with self.assertRaisesRegex(ValueError, "Joint effort limits"):
+            solver._solver_kamino.solver_fd.validate_model_changed()
+
+    def test_lox_joint_friction_magnitude_updates_preserve_topology(self):
+        """Allow friction magnitude edits without changing allocated scalar rows."""
+        model = _build_revolute(friction=1.0)
+        solver = SolverKamino(model, config=SolverKamino.Config(dynamics_solver="lox"))
+
+        model.joint_friction.fill_(2.0)
+        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+        model.joint_friction.zero_()
+        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+        zero_model = _build_revolute(friction=0.0)
+        zero_solver = SolverKamino(
+            zero_model,
+            config=SolverKamino.Config(dynamics_solver="lox"),
+        )
+        zero_model.joint_friction.fill_(1.0)
+        with self.assertRaisesRegex(RuntimeError, "joint friction allocation"):
+            zero_solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+    def test_lox_joint_effort_limit_updates_preserve_topology(self):
+        """Allow finite effort edits without changing bounded-row topology."""
+        config = SolverKamino.Config(dynamics_solver="lox")
+        finite_model = _build_revolute(
+            dynamic=True,
+            effort_limit=5.0,
+            actuator_mode=newton.JointTargetMode.POSITION,
+        )
+        finite_solver = SolverKamino(finite_model, config=config)
+
+        finite_model.joint_effort_limit.fill_(10.0)
+        finite_solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+        finite_model.joint_effort_limit.fill_(float("inf"))
+        with self.assertRaisesRegex(RuntimeError, "effort-limit allocation"):
+            finite_solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+        unlimited_model = _build_revolute(
+            dynamic=True,
+            effort_limit=float("inf"),
+            actuator_mode=newton.JointTargetMode.POSITION,
+        )
+        unlimited_solver = SolverKamino(unlimited_model, config=SolverKamino.Config(dynamics_solver="lox"))
+        unlimited_model.joint_effort_limit.fill_(5.0)
+        with self.assertRaisesRegex(RuntimeError, "effort-limit allocation"):
+            unlimited_solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
 
     def test_aliased_properties_reference_newton(self):
         """Every aliased Newton array shares storage with Kamino, so in-place edits need no notify."""
@@ -755,12 +823,14 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
     def test_enabling_joint_friction_raises(self):
         """Reject enabling friction when no bounded rows were allocated."""
-        model = _build_revolute(friction=0.0)
-        solver = SolverKamino(model, SolverKamino.Config(dynamics_solver="padmm"))
-        model.joint_friction.assign([1.0])
+        for backend in ("padmm", "lox"):
+            with self.subTest(backend=backend):
+                model = _build_revolute(friction=0.0)
+                solver = SolverKamino(model, SolverKamino.Config(dynamics_solver=backend))
+                model.joint_friction.assign([1.0])
 
-        with self.assertRaisesRegex(RuntimeError, "joint friction allocation"):
-            solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+                with self.assertRaisesRegex(RuntimeError, "joint friction allocation"):
+                    solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
 
     def test_enabling_friction_on_unallocated_axis_raises(self):
         """Reject friction enabled on an axis without a preallocated row."""

--- a/newton/tests/kamino/test_kamino_solvers_lox_state.py
+++ b/newton/tests/kamino/test_kamino_solvers_lox_state.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for LOX structural assembly and convergence validation."""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import warp as wp
+
+from newton import StateFlags
+from newton._src.solvers.kamino._src.core.model import ModelKamino
+from newton._src.solvers.kamino._src.core.state import StateKamino
+from newton._src.solvers.kamino._src.core.types import vec6f
+from newton._src.solvers.kamino._src.solver_kamino_impl import SolverKaminoImpl
+from newton._src.solvers.kamino._src.solvers.lox.system import BatchedPrimalBodySystem
+from newton._src.solvers.kamino._src.solvers.lox.types import SplittingState
+from newton._src.solvers.kamino.tests import setup_tests as setup_internal_tests
+from newton.solvers import SolverKamino
+from newton.tests.kamino import setup_tests, test_context
+from newton.tests.utils.basics import build_box_on_plane
+
+
+class TestLOXState(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def test_internal_setup_preserves_backward_generation(self):
+        """Preserve global backward generation when initializing internal Kamino tests."""
+        with mock.patch.object(wp.config, "enable_backward", True):
+            setup_internal_tests(device=self.device, clear_cache=False)
+            self.assertTrue(wp.config.enable_backward)
+
+    def test_consensus_impulse_follows_native_state(self):
+        """Copy and warm-start consensus impulses through native Kamino states."""
+        model = ModelKamino.from_newton(build_box_on_plane(ground=False).finalize(device=self.device))
+        state_in, state_out = model.state(), model.state()
+        state_in.lambda_w_i.fill_(3.0)
+        state_out.copy_from(state_in)
+        np.testing.assert_array_equal(state_out.lambda_w_i.numpy(), state_in.lambda_w_i.numpy())
+        solver = SolverKaminoImpl(model, config=SolverKamino.Config(dynamics_solver="lox"))
+        backend = solver.solver_fd
+        solve = backend.solve
+
+        def check_warmstart(**kwargs):
+            np.testing.assert_array_equal(backend.splitting.splitting_dual_impulse.numpy(), state_in.lambda_w_i.numpy())
+            solve(**kwargs)
+
+        backend.splitting.splitting_dual_impulse.fill_(17.0)
+        with mock.patch.object(backend, "solve", side_effect=check_warmstart):
+            solver.step(state_in, state_out, model.control(), dt=0.01)
+        np.testing.assert_array_equal(state_in.lambda_w_i.numpy(), np.full((1, 6), 3.0))
+        np.testing.assert_array_equal(state_out.lambda_w_i.numpy(), np.zeros((1, 6)))
+
+    def test_consensus_impulse_alias_and_selective_reset(self):
+        """Alias Newton consensus history and preserve unselected reset fields and worlds."""
+        builder = build_box_on_plane(ground=False)
+        build_box_on_plane(builder=builder, ground=False)
+        model = builder.finalize(device=self.device)
+        solver = SolverKamino(model, SolverKamino.Config(dynamics_solver="lox"))
+        state = model.state()
+        adapted = StateKamino.from_newton(solver._model_kamino.size, model, state)
+        self.assertIs(adapted.lambda_w_i, state.body_lox_dual_impulse)
+        state.body_lox_dual_impulse.fill_(3.0)
+        mask = wp.array([True, False, False], dtype=wp.bool, device=self.device)
+        solver.reset(state, world_mask=mask, flags=StateFlags.BODY_Q)
+        np.testing.assert_array_equal(state.body_lox_dual_impulse.numpy(), np.full((2, 6), 3.0))
+        solver.reset(state, world_mask=mask, flags=StateFlags.BODY_QD)
+        np.testing.assert_array_equal(state.body_lox_dual_impulse.numpy(), [[0.0] * 6, [3.0] * 6])
+
+    def test_invalid_structural_world_clears_penalty(self):
+        """Discard stale penalties and contributions from invalid structural worlds."""
+        system = BatchedPrimalBodySystem([1], device=self.device)
+        penalty = wp.full(3, 7.0, dtype=wp.float32, device=self.device)
+        jacobian = wp.array([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 3, dtype=vec6f, device=self.device)
+        system.add_structural_rows(
+            row_world=wp.array([-1, 1, 0], dtype=wp.int32, device=self.device),
+            body_first=wp.zeros(3, dtype=wp.int32, device=self.device),
+            body_second=wp.full(3, -1, dtype=wp.int32, device=self.device),
+            jacobian_first=jacobian,
+            jacobian_second=wp.zeros(3, dtype=vec6f, device=self.device),
+            residual=wp.ones(3, dtype=wp.float32, device=self.device),
+            reaction=wp.zeros(3, dtype=wp.float32, device=self.device),
+            effective_mass=wp.ones(3, dtype=wp.float32, device=self.device),
+            linearization_twist=wp.zeros(1, dtype=vec6f, device=self.device),
+            time_step=wp.ones(1, dtype=wp.float32, device=self.device),
+            joint_penalty_scale=wp.full(1, 2.0, dtype=wp.float32, device=self.device),
+            penalty=penalty,
+        )
+        np.testing.assert_array_equal(penalty.numpy(), [0.0, 0.0, 2.0])
+        expected_matrix = np.zeros((6, 6), dtype=np.float32)
+        expected_matrix[0, 0] = 2.0
+        np.testing.assert_array_equal(system.smooth_matrix.numpy().reshape(6, 6), expected_matrix)
+        np.testing.assert_array_equal(system.right_hand_side.numpy(), [-2.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def test_invalid_convergence_tolerances_preserve_state(self):
+        """Reject invalid tolerances before updating iteration state."""
+        state = SplittingState([1], device=self.device)
+        status = wp.zeros(1, dtype=wp.int32, device=self.device)
+        time_step = wp.ones(1, dtype=wp.float32, device=self.device)
+        for name in ("position_tolerance", "rotation_tolerance", "velocity_tolerance"):
+            for value in (0.0, -1.0, float("nan"), float("inf")):
+                with self.subTest(tolerance=name, value=value):
+                    tolerances = {
+                        "position_tolerance": 1.0e-5,
+                        "rotation_tolerance": 1.0e-5,
+                        "velocity_tolerance": 1.0e-5,
+                    }
+                    tolerances[name] = value
+                    with self.assertRaisesRegex(ValueError, "Convergence tolerances"):
+                        state.finish_iteration(status, time_step, **tolerances)
+                    np.testing.assert_array_equal(state.iteration_count.numpy(), [0])
+                    np.testing.assert_array_equal(state.world_active.numpy(), [True])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_kinematic_links.py
+++ b/newton/tests/test_kinematic_links.py
@@ -224,7 +224,13 @@ KINEMATIC_TEST_WRENCH = np.array([20.0, -15.0, 10.0, 0.5, -0.4, 0.3], dtype=np.f
 
 
 def _uses_maximal_coordinates(solver) -> bool:
-    return isinstance(solver, newton.solvers.SolverXPBD | newton.solvers.SolverSemiImplicit | newton.solvers.SolverVBD)
+    return isinstance(
+        solver,
+        newton.solvers.SolverKamino
+        | newton.solvers.SolverXPBD
+        | newton.solvers.SolverSemiImplicit
+        | newton.solvers.SolverVBD,
+    )
 
 
 def _create_contacts(model: newton.Model, solver):
@@ -693,7 +699,10 @@ def test_kinematic_runtime_toggle(
     pos_after_dynamic = state_0.body_q.numpy()[body, :3].copy()
     test.assertGreater(pos_after_dynamic[0], 0.05, "Dynamic body should move under applied force")
 
-    # Toggle back to kinematic.
+    # Toggle back to kinematic and prescribe a stationary state.
+    body_qd = state_0.body_qd.numpy()
+    body_qd[body] = 0.0
+    state_0.body_qd.assign(body_qd)
     flags = model.body_flags.numpy()
     flags[body] = int(BodyFlags.KINEMATIC)
     model.body_flags.assign(flags)
@@ -723,6 +732,10 @@ solvers = {
     "xpbd": lambda model: newton.solvers.SolverXPBD(model, iterations=5, angular_damping=0.0),
     "semi_implicit": lambda model: newton.solvers.SolverSemiImplicit(model, angular_damping=0.0),
     "vbd": lambda model: newton.solvers.SolverVBD(model, rigid_compliant_alm=True),
+    "lox": lambda model: newton.solvers.SolverKamino(
+        model,
+        config=newton.solvers.SolverKamino.Config.from_model(model, dynamics_solver="lox"),
+    ),
 }
 for device in devices:
     for solver_name, solver_fn in solvers.items():
@@ -752,13 +765,15 @@ for device in devices:
             devices=[device],
             solver_fn=solver_fn,
         )
-        add_function_test(
-            TestKinematicLinksCanonical,
-            f"test_kinematic_runtime_toggle_{solver_name}",
-            test_kinematic_runtime_toggle,
-            devices=[device],
-            solver_fn=solver_fn,
-        )
+        # Kamino freezes body immovability when constructing the solver.
+        if solver_name != "lox":
+            add_function_test(
+                TestKinematicLinksCanonical,
+                f"test_kinematic_runtime_toggle_{solver_name}",
+                test_kinematic_runtime_toggle,
+                devices=[device],
+                solver_fn=solver_fn,
+            )
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_solver_kamino_lox.py
+++ b/newton/tests/test_solver_kamino_lox.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-platform quality gates for the Kamino LOX solver."""
+
+import unittest
+
+from newton._src.solvers.kamino.tests.test_solver_kamino_lox import TestSolverKaminoLOX
+
+_LOX_QUALITY_TESTS = (
+    "test_box_on_plane_projects_detected_contact",
+    "test_relaxed_joint_proximal_preserves_nonlinear_fixed_point",
+    "test_cartpole_projects_detected_joint_limit",
+    "test_cartpole_sustained_joint_force_remains_bounded",
+    "test_free_fall_advances_projected_velocity_and_pose",
+    "test_joint_damping_is_implicit_in_the_smooth_row",
+    "test_product_space_structural_split_hinged_contact",
+)
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: str | None) -> unittest.TestSuite:
+    """Load a focused cross-platform subset into the main test suite."""
+    del loader, tests, pattern
+    return unittest.TestSuite(TestSolverKaminoLOX(name) for name in _LOX_QUALITY_TESTS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_solver_kamino_lox_cuda.py
+++ b/newton/tests/test_solver_kamino_lox_cuda.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA graph-capture quality gate for the Kamino LOX solver."""
+
+import unittest
+
+from newton._src.solvers.kamino.tests.test_solver_kamino_lox import TestSolverKaminoLOX
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, pattern: str | None) -> unittest.TestSuite:
+    """Load the focused CUDA graph-capture check into the main test suite."""
+    del loader, tests, pattern
+    return unittest.TestSuite((TestSolverKaminoLOX("test_cuda_graph_capture_uses_conditional_loop"),))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

This introduces a third backend to SolverKamino. Compared to the other two, this solver mostly operates in primal space; it enforces bilateral and unilateral  constraints and two distinct velocity duplicates, and use ADMM to reach a consensus. 
The bilateral constraints are enforced using an ALM formulation which keeps the matrix structure constant over timesteps.
By default, colored Gauss Seidel is used to solve the unilateral projection, though other schedules are available.


This version only include support for rigid bodies; cable and deformable extensions have been implemented,  but left outside of this pull request. 

Changes to core Kamino should be minimal; one subject of attention is the handling of kinematic/zero-mass bodies. It is necessary to handle some newton examples like `panda_hydro` (two zero-inertia fixed helper bodies in the FR3 USD, fr3_link8 and fr3_hand_tcp). Besides, in many scenarios, integrating kinematic bodies from the begin-of-step position and velocity is preferable. In particle, for IK-driven animation, this avoids having to maintain a separate integrator for the target vs current pose residual. The new flag, `integrate_singular_bodies`, should not affect the other two kamino backends, though ideally they would  follow the same convention.

## Testing plan

On top of unit tests, the solver has been successfully tested on all Newton examples (though to keep this PR focused, the corresponding flags are not exposed here)

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental LOX rigid-body dynamics backend for Kamino.
  - Added configurable LOX solver settings, diagnostics, metrics, warm-starting, contact handling, and Euler/Moreau integration support.
  - Added support for singular-body integration and selective handling of fully prescribed contacts.
  - Added hybrid sparse/dense factorization capabilities for improved solver performance.
  - Updated Kamino examples and documentation with LOX configuration and usage options.

- **Bug Fixes**
  - Improved handling of kinematic, prescribed, massless, and singular-inertia bodies.
  - Preserved solver state and warm starts more reliably across resets and model updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->