### PR TITLE
Enable unordered Menagerie geometry comparisons

### DIFF
--- a/newton/tests/test_menagerie_model_comparison.py
+++ b/newton/tests/test_menagerie_model_comparison.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU regressions for the Menagerie model comparison entry point."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+from newton.tests import test_menagerie_usd_mujoco
+from newton.tests.test_menagerie_mujoco import (
+    DEFAULT_MODEL_SKIP_FIELDS,
+    MUJOCO_AVAILABLE,
+    _mujoco,
+    _mujoco_warp,
+    compare_models,
+)
+
+
+@unittest.skipIf(not MUJOCO_AVAILABLE, "mujoco/mujoco_warp not installed")
+class TestMenagerieModelComparison(unittest.TestCase):
+    def setUp(self):
+        """Keep all model allocations on CPU."""
+        self.device = wp.ScopedDevice("cpu")
+        self.device.__enter__()
+        self.addCleanup(self.device.__exit__, None, None, None)
+
+    @staticmethod
+    def _model(*, reverse=False, empty=False):
+        geoms = [
+            '<geom type="sphere" size="0.1" group="1" friction="0.7 0.01 0.001"/>',
+            '<geom type="box" size="0.1 0.2 0.3" group="2" pos="1 0 0"/>',
+            '<geom type="capsule" size="0.1 0.2" group="3" pos="2 0 0"/>',
+            '<geom type="cylinder" size="0.2 0.3" group="4" pos="3 0 0"/>',
+        ]
+        if reverse:
+            geoms.reverse()
+        if empty:
+            geoms = []
+        xml = "<mujoco><worldbody><body><freejoint/>"
+        xml += '<inertial pos="0 0 0" mass="1" diaginertia="1 1 1"/>'
+        xml += "".join(geoms) + "</body></worldbody></mujoco>"
+        return _mujoco_warp.put_model(_mujoco.MjModel.from_xml_string(xml))
+
+    def test_equal_and_reordered_models(self):
+        """Accept equal models and reordering of distinct body/type groups."""
+        expected = self._model()
+        for reverse in (False, True):
+            with self.subTest(reverse=reverse):
+                compare_models(self._model(reverse=reverse), expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+
+    def test_default_geom_mismatches(self):
+        """Reject friction and group differences through the default entry point."""
+        for field in ("geom_friction", "geom_group"):
+            with self.subTest(field=field):
+                actual, expected = self._model(), self._model()
+                arr = getattr(actual, field)
+                arr.assign(arr.numpy() + 1)
+                with self.assertRaisesRegex(AssertionError, field):
+                    compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+
+    def test_field_exclusion(self):
+        """Skip only the selected field while still detecting other differences."""
+        actual, expected = self._model(), self._model()
+        actual.geom_friction.assign(actual.geom_friction.numpy() * 2)
+        skips = DEFAULT_MODEL_SKIP_FIELDS | {"geom_friction"}
+        compare_models(actual, expected, skip_fields=skips)
+        actual.geom_group.assign(actual.geom_group.numpy() + 1)
+        with self.assertRaisesRegex(AssertionError, "geom_group"):
+            compare_models(actual, expected, skip_fields=skips)
+
+    def test_geom_opt_out(self):
+        """Preserve explicit broad geometry exclusions."""
+        actual, expected = self._model(), self._model()
+        actual.geom_friction.assign(actual.geom_friction.numpy() * 2)
+        actual.geom_group.assign(actual.geom_group.numpy() + 1)
+        for skips in (
+            DEFAULT_MODEL_SKIP_FIELDS | {"geom_"},
+            test_menagerie_usd_mujoco.TestMenagerieUSD.model_skip_fields,
+        ):
+            with self.subTest(skips=skips):
+                compare_models(actual, expected, skip_fields=skips)
+
+    def test_geom_counts(self):
+        """Accept empty models and reject unequal counts unless explicitly skipped."""
+        actual, expected = self._model(empty=True), self._model(empty=True)
+        compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+        actual = self._model()
+        with self.assertRaisesRegex(AssertionError, "ngeom"):
+            compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+        compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS | {"ngeom", "nmaxcondim", "nmaxpyramid"})
+
+    def test_batched_geom_fields(self):
+        """Compare every world of supported scalar and vector geometry arrays."""
+        actual, expected = self._model(), self._model()
+        for field in ("geom_friction", "geom_margin", "geom_size"):
+            for model in (actual, expected):
+                arr = getattr(model, field)
+                values = np.repeat(arr.numpy(), 2, axis=0)
+                setattr(model, field, wp.array(values, dtype=arr.dtype))
+        compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+        for field in ("geom_friction", "geom_margin", "geom_size"):
+            with self.subTest(field=field):
+                arr = getattr(actual, field)
+                original = arr.numpy().copy()
+                changed = original.copy()
+                changed[1, 0] += 1
+                arr.assign(changed)
+                with self.assertRaisesRegex(AssertionError, field):
+                    compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+                arr.assign(original)
+
+    def test_single_geom_and_plane_exceptions(self):
+        """Compare single geometries and preserve cosmetic plane exceptions."""
+        for geom in (
+            '<geom type="sphere" size="0.1"/>',
+            '<geom type="plane" size="1 1 0.1"/>',
+        ):
+            with self.subTest(geom=geom):
+                source = _mujoco.MjModel.from_xml_string(f"<mujoco><worldbody>{geom}</worldbody></mujoco>")
+                actual, expected = _mujoco_warp.put_model(source), _mujoco_warp.put_model(source)
+                compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+                if "plane" in geom:
+                    actual.geom_pos.assign(actual.geom_pos.numpy() + 1)
+                    actual.geom_quat.assign(actual.geom_quat.numpy() + 1)
+                    actual.geom_size.assign(actual.geom_size.numpy() + 1)
+                    compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+                actual.geom_friction.assign(actual.geom_friction.numpy() * 2)
+                with self.assertRaisesRegex(AssertionError, "geom_friction"):
+                    compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+
+    def test_geom_array_shapes(self):
+        """Reject unmatched batch sizes rather than ignoring extra worlds."""
+        for field in ("geom_friction", "geom_size"):
+            with self.subTest(field=field):
+                actual, expected = self._model(), self._model()
+                arr = getattr(expected, field)
+                setattr(expected, field, wp.array(np.repeat(arr.numpy(), 2, axis=0), dtype=arr.dtype))
+                with self.assertRaisesRegex(AssertionError, f"{field}: shape"):
+                    compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+
+    def test_geom_size_semantics(self):
+        """Ignore unused size components but compare physical dimensions."""
+        actual, expected = self._model(), self._model()
+        size = actual.geom_size.numpy()
+        size[0, 0, 1:] = 9  # sphere: radius only
+        size[0, 2:, 2] = 9  # capsule/cylinder: radius and half-length
+        actual.geom_size.assign(size)
+        compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+        size[0, 1, 2] += 1  # box: all three dimensions matter
+        actual.geom_size.assign(size)
+        with self.assertRaisesRegex(AssertionError, "geom_size"):
+            compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS)
+        compare_models(actual, expected, skip_fields=DEFAULT_MODEL_SKIP_FIELDS | {"geom_size"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -405,8 +405,6 @@ DEFAULT_MODEL_SKIP_FIELDS: set[str] = {
     "tendon_solref_lim",
     # RGBA: Newton uses different default color for geoms without explicit rgba
     "geom_rgba",
-    # Size: Compared via compare_geom_fields_unordered() which understands type-specific semantics
-    "geom_size",
     # Site size: Only a subset of the 3 elements is meaningful per type (sphere=1,
     # capsule/cylinder=2, box=3). Compared via _compare_sites() instead.
     "site_size",
@@ -423,7 +421,6 @@ DEFAULT_MODEL_SKIP_FIELDS: set[str] = {
     # visuals). Content is verified by compare_geom_fields_unordered() instead.
     "body_geomadr",
     "body_geomnum",
-    "geom_",
     "pair_geom",  # geom indices depend on geom ordering
     "nxn_",  # broadphase pairs depend on geom ordering
     # Compilation-dependent fields: validated at 1e-3 by compare_compiled_model_fields()
@@ -532,7 +529,8 @@ def compare_models(
     prefix is in skip_fields (as used by USD tests with reordered indices).
 
     Args:
-        skip_fields: Substrings to skip in field-level comparison.
+        skip_fields: Substrings to skip in field-level comparison. An explicit
+            "geom_" entry also disables unordered geometry comparison.
         backfill_fields: Fields to validate at relaxed tolerance via
             :func:`compare_compiled_model_fields`.
     """
@@ -542,7 +540,9 @@ def compare_models(
     def _skipped(prefix: str) -> bool:
         return any(s in prefix for s in skip_fields)
 
-    compare_mjw_models(newton_mjw, native_mjw, skip_fields=skip_fields)
+    # Geom arrays require unordered comparison; do not turn this ordered-only
+    # exclusion into an opt-out from the semantic checks below.
+    compare_mjw_models(newton_mjw, native_mjw, skip_fields=skip_fields | {"geom_"})
 
     if not _skipped("body_inertia"):
         compare_inertia_tensors(newton_mjw, native_mjw)
@@ -824,6 +824,7 @@ def compare_geom_fields_unordered(
     GEOM_PLANE = 0
 
     geom_fields = [
+        "geom_group",
         "geom_pos",
         "geom_quat",
         "geom_friction",
@@ -844,7 +845,11 @@ def compare_geom_fields_unordered(
         newton_np = newton_arr.numpy()
         native_np = native_arr.numpy()
 
-        if newton_np.ndim >= 2 and newton_np.shape[0] == newton_mjw.nworld:
+        assert newton_np.shape == native_np.shape, f"{field_name}: shape {newton_np.shape} != {native_np.shape}"
+
+        # Warp array dimensions exclude vector components: 2D arrays have a
+        # leading world axis, while geom_group is a shared 1D integer array.
+        if newton_arr.ndim == 2:
             # Batched: (nworld, ngeom, ...)
             for w in range(newton_np.shape[0]):
                 reordered_native = native_np[w][newton_to_native]
@@ -873,9 +878,10 @@ def compare_geom_fields_unordered(
                 )
 
     # Compare geom_size with type-specific semantics
-    if not any("geom_size" in s for s in skip_fields):
+    if not any(s in "geom_size" for s in skip_fields):
         newton_size = newton_mjw.geom_size.numpy()
         native_size = native_mjw.geom_size.numpy()
+        assert newton_size.shape == native_size.shape, f"geom_size: shape {newton_size.shape} != {native_size.shape}"
         for w in range(newton_size.shape[0]):
             for g in range(ngeom):
                 gtype = newton_type[g]

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1128,6 +1128,8 @@ class TestMenagerieUSD(TestMenagerieBase):
     # _compare_body_physics, _compare_dof_physics, _compare_geoms, _compare_jnt_range)
     # are skipped from the generic compare_mjw_models pass, not silently ignored.
     model_skip_fields: ClassVar[set[str]] = DEFAULT_MODEL_SKIP_FIELDS | {
+        # Body IDs and geom counts may differ -> compared via _compare_geoms
+        "geom_",
         # Actuator ordering may differ -> compared via _compare_actuator_physics
         "actuator_",
         # Equality constraints not yet imported from USD


### PR DESCRIPTION
## Description

Closes #3306. Keep the broad geometry exclusion local to the ordered comparison so default comparisons reach the existing unordered helper. Include `geom_group`, use Warp array dimensions instead of the absent `Model.nworld`, and enable type-aware size checks. Preserve field exclusions and explicitly retain USD's separate geometry comparison.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] Changelog disposition: no user-facing change; test infrastructure only

## Test plan

- `CUDA_VISIBLE_DEVICES='' uv run --extra sim -m unittest newton.tests.test_menagerie_model_comparison -v`: **9 passed**. Covers default-path mismatches, reordering, exclusions, counts, batches and size/plane semantics.
- `uvx pre-commit run -a`: **passed**.
- USD module: **44 tests reported, 107 skips** including class-level skips; USD/assets unavailable.
- UR5e and Apollo `test_model_comparison`: **2 passed on main; 2 failed with this change**, using the pinned Menagerie assets and repository-supported dependencies.

**Draft blockers:** Newly active checks expose UR5e `geom_gap` (`0.1` vs `0`) and Apollo `geom_pos` differences from reordering within one body/type mesh group. Apollo also has differing mesh-size representations. Resolving these requires disposition beyond this focused comparison repair. The full Menagerie suite has not passed.

## Bug fix

**Steps to reproduce:** Copy the new regression module onto unmodified main `90c56c3b` and run the CPU command above: **11 assertion/subtest failures across 9 tests**, because expected geometry mismatches are silently accepted.

AI assistance: implementation and independent local review performed with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for Menagerie model comparisons across multiple geometry types and configurations.
  * Improved validation of reordered geometry, friction and group mismatches, field exclusions, geometry counts, array shapes, and geometry size semantics.
  * Refined geometry comparison handling, including batched fields and single-geometry or plane cases.
  * Updated USD/MuJoCo comparisons to handle geometry data through dedicated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->