### PR TITLE
Benchmark full and partial environment resets

### DIFF
--- a/asv/benchmarks/simulation/bench_reset.py
+++ b/asv/benchmarks/simulation/bench_reset.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Absolute elapsed reset time for the batched selection cartpole on MuJoCo Warp.
+
+Both series time SolverMuJoCo.reset on state_0, including CUDA completion.
+Full means all worlds within this contract: joint_q and joint_qd are restored
+from model defaults; MuJoCo qacc_warmstart, qfrc_applied, xfrc_applied, act and
+ctrl are cleared. Empty actuator buffers are included but contain no values.
+Body poses/velocities, Newton body forces and Control are not restored. MuJoCo
+qpos/qvel and derived body state are synchronized by the next simulation step,
+which is excluded here (update_data_interval=1, sleeping disabled). This is not
+a reset of the entire Example, its second state buffer or its simulation clock.
+
+The partial reset selects every fourth world: 32 of 128 (25%). Model creation,
+a simulation step, reset compilation/warm-up, deterministic dirtying and host
+verification are outside timing. No CUDA graph wraps the measured reset.
+Run with ASV: ``uvx --with virtualenv asv run --launch-method spawn HEAD^! -b ResetCartpole``.
+The standalone run_benchmark helper repeats warm-up without setup and is unsuitable here.
+"""
+
+import os
+import sys
+
+import numpy as np
+import warp as wp
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
+import newton
+import newton.examples
+from newton.examples.selection.example_selection_cartpole import Example
+
+wp.config.enable_backward = False
+wp.config.log_level = wp.LOG_WARNING
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from benchmark_config import pr_gate_repeat
+
+
+class _ResetCartpole:
+    repeat = pr_gate_repeat(10)
+    number = 1
+    # asv_runner 0.2.x repeats warm-up calls without re-running setup.
+    warmup_time = 0
+    param_names = ["world_count", "reset_count"]
+
+    def setup(self, world_count, reset_count):
+        if not wp.get_device().is_cuda:
+            raise SkipNotImplemented
+
+        args = newton.examples.default_args(Example.create_parser())
+        args.world_count = world_count
+        args.solver = "mujoco"
+        self.example = Example(newton.viewer.ViewerNull(), args)
+        self.example.step()
+        self.solver = self.example.solver
+        self.state = self.example.state_0
+        self.device = self.example.model.device
+        assert not self.solver.use_mujoco_cpu
+        assert self.solver.update_data_interval == 1
+        assert not self.solver.enable_sleeping
+
+        self.selected = np.zeros(world_count, dtype=bool)
+        self.selected[:: world_count // reset_count] = True
+        assert np.count_nonzero(self.selected) == reset_count
+        self.world_mask = (
+            None
+            if reset_count == world_count
+            else wp.array(np.append(self.selected, False), dtype=wp.bool, device=self.device)
+        )
+        self.solver.reset(self.state, world_mask=self.world_mask)
+
+        model = self.example.model
+        data = self.solver.mjw_data
+        self.arrays = {
+            "joint_q": self.state.joint_q,
+            "joint_qd": self.state.joint_qd,
+            "qacc_warmstart": data.qacc_warmstart,
+            "qfrc_applied": data.qfrc_applied,
+            "xfrc_applied": data.xfrc_applied,
+            "act": data.act,
+            "ctrl": data.ctrl,
+        }
+        self.expected = {}
+        self.before = {}
+        for name, array in self.arrays.items():
+            if name in ("joint_q", "joint_qd"):
+                initial = getattr(model, name).numpy()
+            else:
+                initial = np.zeros_like(array.numpy())
+            # Every populated row differs from its reset target and other worlds.
+            offset = np.arange(initial.size, dtype=np.float32).reshape(initial.shape) * 0.001 + 0.25
+            dirty = initial + offset
+            array.assign(dirty)
+            self.before[name] = dirty.reshape((world_count, -1))
+            self.expected[name] = initial.reshape((world_count, -1))
+
+        control = self.example.control
+        self.untouched = {
+            "body_q": self.state.body_q,
+            "body_qd": self.state.body_qd,
+            "body_f": self.state.body_f,
+            "joint_f": control.joint_f,
+            "joint_target_q": control.joint_target_q,
+            "joint_target_qd": control.joint_target_qd,
+        }
+        self.untouched_before = {name: array.numpy() for name, array in self.untouched.items()}
+        # Drain the warm-up reset and all preparation before ASV starts its timer.
+        wp.synchronize_device(self.device)
+
+    def time_reset(self, world_count, reset_count):
+        self.solver.reset(self.state, world_mask=self.world_mask)
+        wp.synchronize_device(self.device)
+
+    def teardown(self, world_count, reset_count):
+        for name, array in self.arrays.items():
+            actual = array.numpy().reshape((world_count, -1))
+            np.testing.assert_array_equal(
+                actual[self.selected], self.expected[name][self.selected], err_msg=f"{name}: selected worlds"
+            )
+            np.testing.assert_array_equal(
+                actual[~self.selected], self.before[name][~self.selected], err_msg=f"{name}: unselected worlds"
+            )
+        for name, array in self.untouched.items():
+            np.testing.assert_array_equal(
+                array.numpy(), self.untouched_before[name], err_msg=f"{name}: outside reset scope"
+            )
+
+
+class FastFullResetCartpoleMuJoCo(_ResetCartpole):
+    params = [[128], [128]]
+
+
+class FastPartialResetCartpoleMuJoCo(_ResetCartpole):
+    params = [[128], [32]]


### PR DESCRIPTION
## Description

Add two ASV benchmarks for full (128/128 worlds) and partial (32/128, every fourth world) cartpole resets on MuJoCo Warp. This adds reset-cost regression visibility without changing reset performance.

Time `SolverMuJoCo.reset()` through CUDA completion. Restore joint positions/velocities and clear persistent MuJoCo buffers; document the excluded body state, Newton controls/forces and example state. Prepare noninitial inputs outside timing and verify selected, unselected and excluded state after each sample.

Fixes #3344. Both series and parameters render in the local ASV dashboard; upstream publication follows merging and normal benchmark collection.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] Changelog treatment checked: benchmark-only, no fragment required

## Test plan

- Real ASV against commit `3d808216` on an RTX 5070 Ti, driver 580.173.02, Warp 1.17.0, MuJoCo/MuJoCo Warp 3.12.0: 20 samples each, full 55.1 μs and partial 58.2 μs. Local ASV publish and browser inspection passed.
- Disposable CUDA probes: two valid resets accepted; four no-op/wrong-world resets rejected. ASV Runner 0.2.1 and 0.2.5 lifecycle probes verified fresh setup and teardown for every measured reset.
- `uv run asv check -E existing`: passed.
- ASV harness unittest suite with strict warnings: 23 passed.
- `uvx pre-commit run -a`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA benchmarks for resetting MuJoCo Warp cartpole simulations.
  * Added full-reset and 25% partial-reset benchmark scenarios.
  * Added validation to confirm selected simulation worlds reset correctly while unaffected state remains unchanged.
  * Unsupported devices and incompatible solver configurations are skipped automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->