### PR TITLE
Fix SDF sampling on affected CUDA builds

### DIFF
--- a/changelog/4147.fixed.md
+++ b/changelog/4147.fixed.md
@@ -1,0 +1,1 @@
+Disable paired SDF texture samples on pre-SM90 CUDA devices when Warp was built with CUDA Toolkit 13.0 or earlier to avoid incorrect texture reads.

--- a/newton/_src/geometry/sdf_utils.py
+++ b/newton/_src/geometry/sdf_utils.py
@@ -27,6 +27,18 @@ logger = logging.getLogger(__name__)
 
 SignMethod = Literal["auto", "parity", "winding", "normal"]
 
+
+def _resolve_paired_samples_flag(paired_samples: bool, device: wp.DeviceLike | None) -> bool:
+    """Return whether paired SDF texture sampling is safe on the target device."""
+    device = wp.get_device(device)
+    if paired_samples and device.is_cuda and device.arch < 90:
+        # CUDA toolkits before 13.1 can miscompile kernels that mix scalar and vector texture
+        # fetches on pre-SM90 devices, so fall back to the scalar layout.
+        toolkit_version = wp.get_cuda_toolkit_version()
+        return toolkit_version is not None and toolkit_version >= (13, 1)
+    return bool(paired_samples)
+
+
 if TYPE_CHECKING:
     from .sdf_texture import TextureSDFData
 
@@ -428,6 +440,9 @@ class SDF:
             paired_samples: Store each SDF sample with its positive-X
                 neighbor for faster software interpolation. Disable to halve
                 texture memory at the cost of slower hydroelastic sampling.
+                This optimization is automatically disabled on CUDA devices
+                with architectures older than SM90 when Warp was built with
+                CUDA Toolkit 13.0 or earlier.
 
         Returns:
             A validated :class:`SDF` runtime handle.
@@ -509,10 +524,11 @@ class SDF:
             loaded_sparse_data = _sdf_cache.try_load_sparse_data(cache_dir, cache_hash)
 
         with wp.ScopedDevice(device):
+            use_paired_samples = _resolve_paired_samples_flag(paired_samples, wp.get_device())
             if loaded_sparse_data is not None:
                 sdf_device = str(wp.get_device())
                 sdf_params, coarse_texture, subgrid_texture = create_sparse_sdf_textures(
-                    loaded_sparse_data, sdf_device, paired_samples
+                    loaded_sparse_data, sdf_device, use_paired_samples
                 )
                 sdf_params.scale_baked = bake_scale
                 texture_data = sdf_params
@@ -544,7 +560,7 @@ class SDF:
                     scale_baked=bake_scale,
                     sign_mode=_sign_mode_map[sign_method_resolved],
                     return_sparse_data=want_sparse,
-                    paired_samples=paired_samples,
+                    paired_samples=use_paired_samples,
                 )
                 if want_sparse:
                     texture_data, coarse_texture, subgrid_texture, sparse_data = result

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -890,8 +890,11 @@ class Mesh:
             paired_samples: Store each SDF sample with its positive-X
                 neighbor for faster software interpolation. Disable to halve
                 texture memory at the cost of slower hydroelastic sampling.
-                When the mesh is added to a :class:`ModelBuilder`, this value
-                must match :attr:`ModelBuilder.sdf_texture_paired_samples`.
+                This optimization is automatically disabled on CUDA devices
+                with architectures older than SM90 when Warp was built with
+                CUDA Toolkit 13.0 or earlier. When the mesh is added to a
+                :class:`ModelBuilder`, its effective layout must match the
+                builder's effective layout.
             edge_lower_angle_threshold_rad: Drop internal edges whose
                 dihedral angle is below this value [rad]. Set to 0 to keep
                 every manifold edge. A negative value opts out of edge

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -48,6 +48,7 @@ from ..geometry import (
 )
 from ..geometry.flags import MeshProperties
 from ..geometry.inertia import validate_and_correct_inertia_kernel, verify_and_correct_inertia
+from ..geometry.sdf_utils import _resolve_paired_samples_flag
 from ..geometry.types import Heightfield
 from ..geometry.utils import RemeshingMethod, compute_inertia_obb, remesh_mesh
 from ..math import quat_between_vectors_robust
@@ -1492,15 +1493,18 @@ class ModelBuilder:
             sdf_texture_paired_samples: Store adjacent X samples together in
                 SDF textures for faster software interpolation. Disable to
                 halve SDF texture memory at the cost of slower hydroelastic
-                sampling. Every prebuilt mesh SDF added to this builder must
-                use the same layout, selected by the ``paired_samples``
-                argument to :meth:`Mesh.build_sdf`.
+                sampling. This optimization is automatically disabled on CUDA
+                devices with architectures older than SM90 when Warp was built
+                with CUDA Toolkit 13.0 or earlier. Every prebuilt mesh SDF
+                added to this builder must use the same effective layout,
+                selected by the ``paired_samples`` argument to
+                :meth:`Mesh.build_sdf` and the target device.
         """
         self.world_count: int = 0
         """Number of worlds accumulated for :attr:`Model.world_count`."""
 
         self.sdf_texture_paired_samples = bool(sdf_texture_paired_samples)
-        """Whether generated SDF textures store adjacent X samples together."""
+        """Whether generated SDF textures should store adjacent X samples together."""
 
         # region defaults
         self.default_bvh_cfg = ModelBuilder.BvhConfig()
@@ -12361,11 +12365,14 @@ class ModelBuilder:
         shape_collision_filter_packed = self._build_shape_collision_filter_packed()
 
         with wp.ScopedDevice(device):
+            current_device = wp.get_device()
+            sdf_texture_paired_samples = _resolve_paired_samples_flag(self.sdf_texture_paired_samples, current_device)
+
             # -------------------------------------
             # construct Model (non-time varying) data
 
             m = Model(device)
-            m._sdf_texture_paired_samples = self.sdf_texture_paired_samples
+            m._sdf_texture_paired_samples = sdf_texture_paired_samples
             m._set_shape_collision_filter_packed(shape_collision_filter_packed)  # pyright: ignore[reportPrivateUsage]
             m.request_contact_attributes(*self._requested_contact_attributes)
             m.request_state_attributes(*self._requested_state_attributes)
@@ -12802,7 +12809,6 @@ class ModelBuilder:
 
             # ---------------------
             # Compute and compact texture SDF resources (shared table + per-shape index indirection)
-            current_device = wp.get_device(device)
             is_gpu = current_device.is_cuda
 
             has_mesh_sdf = any(
@@ -12903,7 +12909,7 @@ class ModelBuilder:
                         sdf_kwargs["margin"] = sdf_gen_margin
                         sdf_kwargs["scale"] = tuple(shape_scale)
                         sdf_kwargs["texture_format"] = sdf_tex_fmt
-                        sdf_kwargs["paired_samples"] = self.sdf_texture_paired_samples
+                        sdf_kwargs["paired_samples"] = sdf_texture_paired_samples
                         # Convex collision geometry is deduplicated before finalization,
                         # so build and cache its deferred SDF against that same topology.
                         sdf_source = generated_shape_sources[i] if shape_type == GeoType.CONVEX_MESH else shape_src
@@ -12929,13 +12935,13 @@ class ModelBuilder:
                     if mesh_sdf is not None:
                         coarse_texture = getattr(mesh_sdf, "_coarse_texture", None)
                         if coarse_texture is not None and (
-                            (coarse_texture.num_channels == 2) != self.sdf_texture_paired_samples
+                            (coarse_texture.num_channels == 2) != sdf_texture_paired_samples
                         ):
-                            mode = "paired" if self.sdf_texture_paired_samples else "scalar"
+                            mode = "paired" if sdf_texture_paired_samples else "scalar"
                             raise ValueError(
                                 f"ModelBuilder requires {mode} SDF textures, but shape {i} uses a prebuilt SDF "
                                 "with a different layout. Rebuild it with mesh.build_sdf(paired_samples="
-                                f"{self.sdf_texture_paired_samples})."
+                                f"{sdf_texture_paired_samples})."
                             )
                         cache_key = ("mesh_sdf", id(mesh_sdf))
                 elif has_shape_collision and (
@@ -12990,7 +12996,7 @@ class ModelBuilder:
                                     target_voxel_size=sdf_target_voxel_size,
                                     quantization_mode=_tex_fmt_map[sdf_tex_fmt],
                                     scale_baked=True,
-                                    paired_samples=self.sdf_texture_paired_samples,
+                                    paired_samples=sdf_texture_paired_samples,
                                     device=device,
                                 )
                             except NotImplementedError:
@@ -13077,7 +13083,7 @@ class ModelBuilder:
                             quantization_mode=_tex_fmt_map[self.shape_sdf_texture_format[i]],
                             scale_baked=False,
                             device=device,
-                            paired_samples=self.sdf_texture_paired_samples,
+                            paired_samples=sdf_texture_paired_samples,
                         )
                     except Exception as e:
                         warnings.warn(

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -2781,7 +2781,9 @@ def test_scalar_sdf_texture_routes_to_sdf_contact(test, device):
 
     paired_channels, paired = collide(True)
     scalar_channels, scalar = collide(False)
-    test.assertEqual(paired_channels, 2)
+    toolkit_version = wp.get_cuda_toolkit_version()
+    paired_samples_supported = device.arch >= 90 or (toolkit_version is not None and toolkit_version >= (13, 1))
+    test.assertEqual(paired_channels, 2 if paired_samples_supported else 1)
     test.assertEqual(scalar_channels, 1)
     for name, paired_values, scalar_values in zip(
         ("shape0", "shape1", "point0", "point1", "normal", "penetration"), paired, scalar, strict=True
@@ -4421,6 +4423,30 @@ def _make_box_mesh_sdf_model(device):
     return model, int(model._shape_sdf_index.numpy()[0])
 
 
+def test_eval_shape_sdf_mesh_distance(test, device):
+    """Evaluate the correct distance outside a builder-generated mesh SDF."""
+    model, sdf_idx = _make_box_mesh_sdf_model(device)
+    test.assertGreaterEqual(sdf_idx, 0)
+    out_phi = wp.zeros(1, dtype=float, device=device)
+    out_grad = wp.zeros(1, dtype=wp.vec3, device=device)
+
+    wp.launch(
+        _eval_shape_sdf_kernel,
+        dim=1,
+        inputs=[
+            int(GeoType.MESH),
+            wp.vec3(1.0, 1.0, 1.0),
+            wp.vec3(1.0, 0.0, 0.0),
+            sdf_idx,
+            model._texture_sdf_data,
+        ],
+        outputs=[out_phi, out_grad],
+        device=device,
+    )
+
+    test.assertAlmostEqual(float(out_phi.numpy()[0]), 0.5, delta=1.0e-6)
+
+
 def test_eval_shape_sdf_mirrored_mesh_scale_preserves_sign(test, device):
     """A mirrored (negative) mesh scale must not flip the SDF sign (E3). wp.min(scale) would go
     negative and invert an outside distance; wp.min(wp.abs(scale)) keeps the magnitude positive."""
@@ -4663,6 +4689,7 @@ for _name, _fn in (
     add_function_test(TestFullSurfaceSoftContact, _name, _fn, devices=soft_devices)
 
 for _name, _fn in (
+    ("test_eval_shape_sdf_mesh_distance", test_eval_shape_sdf_mesh_distance),
     ("test_eval_shape_sdf_mirrored_mesh_scale_preserves_sign", test_eval_shape_sdf_mirrored_mesh_scale_preserves_sign),
     ("test_full_surface_empty_sdf_descriptor_rejected", test_full_surface_empty_sdf_descriptor_rejected),
     ("test_full_surface_nonuniform_mesh_accurate_distance", test_full_surface_nonuniform_mesh_accurate_distance),

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -2520,7 +2520,9 @@ def test_scalar_sdf_texture_hydroelastic_contacts(test, device):
 
     paired_channels, paired = collide(True)
     scalar_channels, scalar = collide(False)
-    test.assertEqual(paired_channels, 2)
+    toolkit_version = wp.get_cuda_toolkit_version()
+    paired_samples_supported = device.arch >= 90 or (toolkit_version is not None and toolkit_version >= (13, 1))
+    test.assertEqual(paired_channels, 2 if paired_samples_supported else 1)
     test.assertEqual(scalar_channels, 1)
     test.assertEqual(len(scalar[0]), len(paired[0]))
     paired = _canonicalize_contact_records(paired)


### PR DESCRIPTION
## Description

Closes #4147.

Paired SDF textures can return incorrect distances on pre-SM90 GPUs when Warp's native library was built with CUDA Toolkit 13.0 or earlier. On the L40 reproduction, querying a unit box 0.5 m outside its positive-X face returns approximately `0.4` instead of `0.5`. Scalar SDF textures return the correct result.

This change resolves the effective texture layout for the target device while preserving the requested setting. Pre-SM90 devices use scalar textures with affected CUDA toolkit versions. SM90 and newer devices, along with pre-SM90 devices using CUDA Toolkit 13.1 or newer, retain paired sampling.

The check applies to direct SDF construction and `ModelBuilder.finalize()`, including cached SDF uploads.

### Performance

Benchmarks ran on the NVIDIA L40 (`sm_89`) used to reproduce the bug, with Warp 1.17.0 built against CUDA Toolkit 12.9.

| Measurement | Result |
|---|---:|
| Isolated software SDF sampler | Scalar sampling took `1.80x` as long as paired sampling, an approximately `80%` increase |
| End-to-end hydroelastic scenes | Total step time was approximately `0%` to `3%` slower, close to run-to-run variation |

The isolated result measures the specific optimization being disabled. SDF texture reads account for only part of a collision and simulation step, so the measured end-to-end impact is a low-single-digit slowdown rather than an 80% overall slowdown.

The scalar layout also uses half as many SDF texture channels as the paired layout.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

The numerical regression checks that a builder-generated box mesh SDF returns `0.5` at `(1, 0, 0)`. It does not encode an expected texture layout, GPU architecture, or toolkit version.

The failure is sensitive to the surrounding generated CUDA module. An extracted standalone probe returned `0.5` on both `upstream/main` and the fixed branch at the current revision. Keeping the probe in `test_collision_pipeline.py` preserves the source context that triggers the bug.

With the compatibility fallback temporarily removed on the L40, the regression returned `0.399999976` and failed. Restoring the fallback returned `0.5` and passed.

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-shi-eric-pre-sm90-sdf-texture-sampling \
uv run --extra dev python -m unittest -v \
  newton.tests.test_collision_pipeline.TestFullSurfaceSoftContact.test_eval_shape_sdf_mesh_distance_cuda_0 \
  newton.tests.test_collision_pipeline.TestFullSurfaceSoftContact.test_optimize_against_mesh_texture_sdf_cuda_0 \
  newton.tests.test_collision_pipeline.TestPlanarSDFRouting.test_scalar_sdf_texture_routes_to_sdf_contact_cuda_0 \
  newton.tests.test_hydroelastic.TestHydroelastic.test_scalar_sdf_texture_hydroelastic_contacts_cuda_0 \
  newton.tests.test_sdf_disk_cache.TestSDFDiskCacheCuda.test_disk_cache_hit_matches_live_cuda_0

uvx pre-commit run -a
```

All five focused CUDA tests and the full pre-commit suite passed.

## Bug fix

**Verified reproduction:**

1. Use an NVIDIA L40 (`sm_89`) with Warp 1.17.0 built against CUDA Toolkit 12.9.
2. Temporarily remove the scalar-layout fallback.
3. Run `test_eval_shape_sdf_mesh_distance_cuda_0` with a fresh Warp cache.
4. Observe `0.399999976` instead of the expected `0.5`.

```text
AssertionError: 0.3999999761581421 != 0.5 within 1e-06 delta
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SDF texture compatibility on older CUDA devices by automatically disabling paired texture samples when unsupported.
  - Ensured SDF generation and validation consistently use the effective texture layout, preventing incorrect texture reads.
  - Corrected mesh SDF distance evaluation and hydroelastic contact behavior across supported CUDA architectures and toolkit versions.

- **Documentation**
  - Clarified when paired SDF texture samples are automatically disabled and documented effective layout requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->