### PR TITLE
Restrict USD importer to supported schema sources

### DIFF
--- a/CODING_GUIDELINES.rst
+++ b/CODING_GUIDELINES.rst
@@ -273,8 +273,11 @@ define and leave the remaining properties at Newton's documented defaults.
 Under-importing a vendor material is the expected outcome, not a defect to be
 resolved by widening the parser.
 
-Pin the boundary with a regression test so an unsupported vocabulary cannot
-reappear one input name at a time.
+These restrictions apply prospectively. Existing vendor-shading parsing is
+frozen; removing it requires a separate behavioral change with compatibility
+review. When changing importer behavior to enforce this boundary, add
+regression tests so an unsupported vocabulary cannot reappear one input name
+at a time. Keep existing compatibility tests until that behavior changes.
 
 Python source conventions
 -------------------------

--- a/CODING_GUIDELINES.rst
+++ b/CODING_GUIDELINES.rst
@@ -224,6 +224,58 @@ needs the operation before it is available upstream:
 - treat any temporary public helper as supported API, including the normal
   deprecation requirements when migrating users to Warp.
 
+USD schema parsing
+------------------
+
+Parse only supported schema sources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Newton's USD importer must read only schemas from a supported source. Three
+tiers are supported, in order of preference:
+
+- OpenUSD schemas published by the OpenUSD project or ratified by AOUSD, such
+  as ``UsdGeom``, ``UsdShade``, ``UsdPhysics``, and the USD Preview Surface
+  shading model. These are the default source for both physics and visual
+  data.
+- Newton physics schemas, including those registered by ``newton-usd-schemas``
+  and the documented ``newton:*`` attribute namespace. Prefer this tier for a
+  physics concept OpenUSD does not yet standardize, and track that concept
+  toward standardization where a proposal exists.
+- Solver-native physics schemas such as ``physx*:*``, as a bounded fallback
+  for physics data the tiers above do not cover. Read them through an opt-in
+  schema resolver rather than a direct schema dependency, keep them out of the
+  default import path, and treat the fallback as temporary. A new fallback
+  should name the gap it fills and the standard schema expected to replace it.
+
+See :ref:`schema_resolvers` for the resolver mechanism.
+
+Do not parse proprietary shading schemas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The solver-native fallback covers physics data only. It does not extend to
+shading, materials, or any other visual concept.
+
+Newton must not add parsing for a proprietary or vendor-specific shading
+system, including MDL shader networks and OmniPBR parameter conventions such
+as ``diffuse_color_constant``, ``reflection_roughness_constant``, and
+``reflection_roughness_texture_influence``. Such a shading model sits outside
+Newton's physics domain, has no open specification Newton can hold it to, and
+commits Newton to tracking a vendor's material vocabulary indefinitely. Do not
+branch on a vendor shader identity, and do not encode a vendor's parameter
+semantics, such as the default blend weight a shader assigns to a texture
+input.
+
+Read visual material data exclusively from OpenUSD shading schemas: resolve
+the material through ``UsdShade`` and read the ``UsdPreviewSurface`` and
+``UsdUVTexture`` inputs defined by the USD Preview Surface specification. When
+an asset authors no OpenUSD shading, import what a supported schema does
+define and leave the remaining properties at Newton's documented defaults.
+Under-importing a vendor material is the expected outcome, not a defect to be
+resolved by widening the parser.
+
+Pin the boundary with a regression test so an unsupported vocabulary cannot
+reappear one input name at a time.
+
 Python source conventions
 -------------------------
 

--- a/CODING_GUIDELINES.rst
+++ b/CODING_GUIDELINES.rst
@@ -224,38 +224,43 @@ needs the operation before it is available upstream:
 - treat any temporary public helper as supported API, including the normal
   deprecation requirements when migrating users to Warp.
 
-USD schema parsing
+USD schema support
 ------------------
 
-Parse only supported schema sources
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Use only supported schema sources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Newton's USD importer must read only schemas from a supported source. Three
-tiers are supported, in order of preference:
+New or extended USD schema support must use a supported source. These rules
+govern what Newton reads, authors, and models, including importers, exporters,
+viewers, and public data models. Existing schema support and compatibility
+paths are grandfathered; editing nearby code does not authorize their removal
+or changes to their compatibility tests. Three tiers are supported, in order
+of preference:
 
 - OpenUSD schemas published by the OpenUSD project or ratified by AOUSD, such
   as ``UsdGeom``, ``UsdShade``, ``UsdPhysics``, and the USD Preview Surface
   shading model. These are the default source for both physics and visual
-  data.
+  data, including ``UsdGeom``'s ``primvars:displayColor`` and
+  ``primvars:displayOpacity`` when no material is bound.
 - Newton physics schemas, including those registered by ``newton-usd-schemas``
-  and the documented ``newton:*`` attribute namespace. Prefer this tier for a
-  physics concept OpenUSD does not yet standardize, and track that concept
-  toward standardization where a proposal exists.
-- Solver-native physics schemas such as ``physx*:*``, as a bounded fallback
-  for physics data the tiers above do not cover. Read them through an opt-in
-  schema resolver rather than a direct schema dependency, keep them out of the
-  default import path, and treat the fallback as temporary. A new fallback
-  should name the gap it fills and the standard schema expected to replace it.
+  and the documented ``newton:*`` attribute namespace. These extend the
+  ``UsdPhysics`` specification to configure the Newton runtime data model,
+  including Newton-specific concepts that do not belong in OpenUSD.
+- Solver-native physics schemas such as ``physx*:*`` or ``mjc:*``, as a bounded
+  fallback for physics data the tiers above do not cover. Newly added fallbacks
+  must read these schemas through an opt-in schema resolver rather than a
+  direct schema dependency and stay out of the default import path. A new
+  fallback should name the gap it fills and the solver data model it mirrors.
 
 See :ref:`schema_resolvers` for the resolver mechanism.
 
-Do not parse proprietary shading schemas
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Do not add proprietary shading support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The solver-native fallback covers physics data only. It does not extend to
 shading, materials, or any other visual concept.
 
-Newton must not add parsing for a proprietary or vendor-specific shading
+Newton must not add support for a proprietary or vendor-specific shading
 system, including MDL shader networks and OmniPBR parameter conventions such
 as ``diffuse_color_constant``, ``reflection_roughness_constant``, and
 ``reflection_roughness_texture_influence``. Such a shading model sits outside
@@ -263,9 +268,11 @@ Newton's physics domain, has no open specification Newton can hold it to, and
 commits Newton to tracking a vendor's material vocabulary indefinitely. Do not
 branch on a vendor shader identity, and do not encode a vendor's parameter
 semantics, such as the default blend weight a shader assigns to a texture
-input.
+input. This also applies to exporter or viewer authoring of vendor blends
+and to new public data-model parameters that encode those vendor semantics.
 
-Read visual material data exclusively from OpenUSD shading schemas: resolve
+Read visual material data from supported OpenUSD schemas, including the
+``UsdGeom`` display primvars above. For shader networks, resolve
 the material through ``UsdShade`` and read the ``UsdPreviewSurface`` and
 ``UsdUVTexture`` inputs defined by the USD Preview Surface specification. When
 an asset authors no OpenUSD shading, import what a supported schema does
@@ -273,11 +280,13 @@ define and leave the remaining properties at Newton's documented defaults.
 Under-importing a vendor material is the expected outcome, not a defect to be
 resolved by widening the parser.
 
-These restrictions apply prospectively. Existing vendor-shading parsing is
-frozen; removing it requires a separate behavioral change with compatibility
-review. When changing importer behavior to enforce this boundary, add
-regression tests so an unsupported vocabulary cannot reappear one input name
-at a time. Keep existing compatibility tests until that behavior changes.
+Existing vendor-shading parsing is frozen. If a reviewer finds an unsupported
+source in existing code, note it without removing it as part of an unrelated
+change. Do not initiate cleanup solely to enforce this policy. Removal or
+migration requires a separately scoped behavioral change with compatibility
+review. When implementing an agreed boundary change, add regression tests so
+an unsupported vocabulary cannot reappear one input name at a time. Keep
+existing compatibility tests until that behavior changes.
 
 Python source conventions
 -------------------------

--- a/REVIEW_GUIDELINES.rst
+++ b/REVIEW_GUIDELINES.rst
@@ -103,6 +103,11 @@ schema disposition: reuse an existing USD schema; add or track a USD schema
 with lifecycle ownership, importer coverage, and runtime coverage; or explain
 why the concept is intentionally runtime-only or non-authorable.
 
+Confirm that each schema the importer reads comes from a source the
+:ref:`source-code-guidelines` permit. Treat new parsing of a proprietary
+shading system, such as MDL or OmniPBR, as a Fit failure about ownership and
+durable cost rather than as an implementation detail.
+
 Return one explicit verdict:
 
 - **Fits:** The value, owner, evidence, scope, and approach are proportionate.
@@ -172,6 +177,8 @@ Check the repository obligations relevant to the change, including:
 - focused regression coverage and documentation;
 - accurate, correctly categorized Towncrier fragments for user-facing changes;
 - dependency and lockfile changes, licenses, and required notices;
+- USD schema sources, including whether new importer parsing stays within the
+  supported OpenUSD, Newton, and bounded solver-fallback tiers;
 - packaging, supported platforms, workflows, and downstream compatibility;
   and
 - release-visible semantic changes, including numerical behavior that changes

--- a/REVIEW_GUIDELINES.rst
+++ b/REVIEW_GUIDELINES.rst
@@ -103,10 +103,12 @@ schema disposition: reuse an existing USD schema; add or track a USD schema
 with lifecycle ownership, importer coverage, and runtime coverage; or explain
 why the concept is intentionally runtime-only or non-authorable.
 
-Confirm that each schema the importer reads comes from a source the
-:ref:`source-code-guidelines` permit. Treat new parsing of a proprietary
-shading system, such as MDL or OmniPBR, as a Fit failure about ownership and
-durable cost rather than as an implementation detail.
+Confirm that schemas the change newly reads, authors, or models come from
+sources the :ref:`source-code-guidelines` permit. Pre-existing sources are out
+of scope for this policy review unless their removal or migration is an
+explicit part of the task. Treat new support for a proprietary shading system,
+such as MDL or OmniPBR, as a Fit failure about ownership and durable cost
+rather than as an implementation detail.
 
 Return one explicit verdict:
 
@@ -177,8 +179,12 @@ Check the repository obligations relevant to the change, including:
 - focused regression coverage and documentation;
 - accurate, correctly categorized Towncrier fragments for user-facing changes;
 - dependency and lockfile changes, licenses, and required notices;
-- USD schema sources, including whether new importer parsing stays within the
-  supported OpenUSD, Newton, and bounded solver-fallback tiers;
+- USD schemas the change newly reads, authors, or models, including whether
+  they stay within the supported OpenUSD, Newton, and bounded solver-fallback
+  tiers. Existing proposal schemas are grandfathered, as are legacy
+  compatibility paths during their deprecation windows, including the
+  ``omniphysics:`` and ``physxDeformableBody:`` deformable fallbacks on the
+  default import path. Do not treat these as policy violations;
 - packaging, supported platforms, workflows, and downstream compatibility;
   and
 - release-visible semantic changes, including numerical behavior that changes

--- a/changelog/+usd-schema-source-policy-5b2e7a94.skip
+++ b/changelog/+usd-schema-source-policy-5b2e7a94.skip
@@ -1,1 +1,1 @@
-Guidelines and documentation only: records the supported USD schema sources without changing importer behavior.
+Document supported USD schema sources without changing importer behavior.

--- a/changelog/+usd-schema-source-policy-5b2e7a94.skip
+++ b/changelog/+usd-schema-source-policy-5b2e7a94.skip
@@ -1,0 +1,1 @@
+Guidelines and documentation only: records the supported USD schema sources without changing importer behavior.

--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -46,14 +46,16 @@ property that renders in another application may not survive import into Newton.
 * **OpenUSD schemas** are the primary source and cover both physics and visuals: ``UsdGeom``,
   ``UsdShade``, ``UsdPhysics``, and the
   `USD Preview Surface <https://openusd.org/release/spec_usdpreviewsurface.html>`__ shading model
-  (``UsdPreviewSurface``, ``UsdUVTexture``, ``UsdTransform2d``).
-* **Newton physics schemas** cover physics concepts that OpenUSD does not yet standardize. They are
-  registered by ``newton-usd-schemas`` and authored in the ``newton:*`` namespace. See
-  :ref:`custom_attributes` for authoring your own attributes.
-* **Solver-native physics schemas**, such as ``physx*:*``, are an opt-in fallback for physics data
-  only. They are read through a schema resolver passed to :meth:`~newton.ModelBuilder.add_usd`, are
-  not consulted by a default import, and are expected to be retired as the standard schemas grow.
-  See :ref:`schema_resolvers`.
+  (``UsdPreviewSurface``, ``UsdUVTexture``, ``UsdTransform2d``). This includes ``UsdGeom``'s
+  ``primvars:displayColor`` and ``primvars:displayOpacity`` when no material is bound.
+* **Newton physics schemas** extend the ``UsdPhysics`` specification to configure the Newton runtime
+  data model, including Newton-specific concepts that do not belong in OpenUSD. They are registered
+  by ``newton-usd-schemas`` and authored in the ``newton:*`` namespace. See :ref:`custom_attributes`
+  for authoring your own attributes.
+* **Solver-native physics schemas**, such as ``physx*:*`` or ``mjc:*``, are a bounded fallback for
+  physics data only. Newly added fallbacks require an opt-in schema resolver passed to
+  :meth:`~newton.ModelBuilder.add_usd`. Existing direct reads and legacy compatibility paths remain,
+  including some on the default import path. See :ref:`schema_resolvers`.
 
 Proprietary shading systems are **not** a supported schema source. Newton does not add parsing for
 MDL shader networks or OmniPBR parameter conventions: they fall outside Newton's physics domain and
@@ -61,10 +63,8 @@ are not governed by an open specification Newton can track. The importer still r
 vendor parameter names for historical reasons, but that handling is frozen — it is not extended to
 new vocabulary and should not be relied on.
 
-To guarantee that Newton imports a material, author it with USD Preview Surface. A material that
-carries no OpenUSD shading imports only the properties Newton can resolve through a supported
-schema; the remaining properties keep Newton's defaults rather than being inferred from
-vendor-specific inputs.
+For supported material import, author with USD Preview Surface. When neither a supported schema nor
+existing compatibility handling supplies a property, Newton uses its defaults.
 
 Particle Simulation Geometry
 ----------------------------

--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -37,6 +37,35 @@ Newton's :meth:`newton.ModelBuilder.add_usd` method provides a USD import pipeli
 * Collects solver-specific attributes preserving solver-native attributes for potential use in the solver
 * Supports parsing of custom Newton model/state/control attributes for specialized simulation requirements
 
+Supported Schema Sources
+------------------------
+
+Newton reads a bounded set of USD schemas. Knowing which sources are supported explains why a
+property that renders in another application may not survive import into Newton.
+
+* **OpenUSD schemas** are the primary source and cover both physics and visuals: ``UsdGeom``,
+  ``UsdShade``, ``UsdPhysics``, and the
+  `USD Preview Surface <https://openusd.org/release/spec_usdpreviewsurface.html>`__ shading model
+  (``UsdPreviewSurface``, ``UsdUVTexture``, ``UsdTransform2d``).
+* **Newton physics schemas** cover physics concepts that OpenUSD does not yet standardize. They are
+  registered by ``newton-usd-schemas`` and authored in the ``newton:*`` namespace. See
+  :ref:`custom_attributes` for authoring your own attributes.
+* **Solver-native physics schemas**, such as ``physx*:*``, are an opt-in fallback for physics data
+  only. They are read through a schema resolver passed to :meth:`~newton.ModelBuilder.add_usd`, are
+  not consulted by a default import, and are expected to be retired as the standard schemas grow.
+  See :ref:`schema_resolvers`.
+
+Proprietary shading systems are **not** a supported schema source. Newton does not add parsing for
+MDL shader networks or OmniPBR parameter conventions: they fall outside Newton's physics domain and
+are not governed by an open specification Newton can track. The importer still recognizes some
+vendor parameter names for historical reasons, but that handling is frozen — it is not extended to
+new vocabulary and should not be relied on.
+
+To guarantee that Newton imports a material, author it with USD Preview Surface. A material that
+carries no OpenUSD shading imports only the properties Newton can resolve through a supported
+schema; the remaining properties keep Newton's defaults rather than being inferred from
+vendor-specific inputs.
+
 Particle Simulation Geometry
 ----------------------------
 


### PR DESCRIPTION
## Description

Newton's USD importer has been steadily accumulating parsing for proprietary shading vocabulary — most visibly MDL/OmniPBR parameter names like `diffuse_color_constant` and `reflection_roughness_constant`. Nothing in the repository says which schemas the importer is allowed to read, so every addition gets argued case by case and the boundary drifts outward one input name at a time.

This PR writes the rule down. No behavior changes.

**The rule:** the USD importer reads only three tiers of schema, in order of preference:

1. **OpenUSD schemas** — `UsdGeom`, `UsdShade`, `UsdPhysics`, USD Preview Surface. The default source for both physics and visual data.
2. **Newton physics schemas** — `newton-usd-schemas` registrations and the `newton:*` namespace, for physics concepts OpenUSD does not yet standardize.
3. **Solver-native physics schemas** (`physx*:*`) — a bounded, opt-in fallback for *physics data only*, expected to be retired as standard schemas grow.

Proprietary shading systems are not a supported source. The physics fallback in tier 3 explicitly does **not** extend to shading. Visual material data must come from OpenUSD shading schemas only: OmniPBR is not physics-related, is not governed by an open specification Newton can hold it to, and commits us to tracking a vendor's material vocabulary indefinitely.

### Where the rule lives

Placed so coding agents, review agents, and users all reach it, with no agent-config changes needed:

| File | Purpose |
| --- | --- |
| `CODING_GUIDELINES.rst` | New **USD schema parsing** section — the normative rule |
| `REVIEW_GUIDELINES.rst` | Hooks from **Fit** (ownership) and **Standards** (obligations checklist) |
| `docs/concepts/usd_parsing.rst` | New **Supported Schema Sources** section for users |

The two root guideline files are already loaded automatically by `.claude/skills/code-review-newton/SKILL.md`, `AGENTS.md` / `CLAUDE.md`, and `.coderabbit.yml`, and are published via the `docs/guide/` include shims — so the rule propagates to every review path without touching skill configs.

### Scope note for reviewers

The importer **already** parses vendor names this rule would prohibit, in `newton/_src/usd/utils.py`: `diffuse_color_constant`, `reflection_roughness_constant`, `metallic_constant`, `opacity_constant`/`alpha_constant`, `uv_space_index`, the `_COLOR_TEXTURE_INPUT_NAMES` substring matchers.

Per `CODING_GUIDELINES.rst`'s own stated scope, the guidelines apply prospectively. I have deliberately **not** removed existing handling here — that is a separate behavioral change with test and asset-compatibility consequences. The user-facing docs describe that handling as frozen rather than claiming it does not exist, so the documentation stays truthful about shipped behavior.

Two follow-up questions worth settling in review:

- Should existing MDL/OmniPBR handling be removed, or grandfathered as frozen indefinitely?
- Is tier 3 (`physx*:*` as fallback) stated at the right strength? It is currently opt-in via `schema_resolvers=` and never consulted by a default import, which the text reflects.

Prior art this is consistent with: `newton/tests/test_import_usd.py::test_omnipbr_mapping_inputs_are_not_parsed` already asserts a scope boundary (no `_is_omnipbr_shader`, no texture-mapping parsing), and `docs/concepts/usd_parsing.rst` already states that `physx*:*` attributes are collected but not applied.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

Guidelines and prose only, so there is no behavior to test; a `.skip` fragment is included per repository precedent for documentation-only changes.

## Test plan

```
uvx pre-commit run --files CODING_GUIDELINES.rst REVIEW_GUIDELINES.rst \
  docs/concepts/usd_parsing.rst changelog/+usd-schema-source-policy-5b2e7a94.skip
```

- `pre-commit` passes (`typos` included).
- All three `.rst` files parse cleanly under docutils; section underline lengths verified.
- Cross-reference targets verified to exist: `schema_resolvers` and `usd_parsing` (`docs/concepts/usd_parsing.rst`), `custom_attributes` (`docs/concepts/custom_attributes.rst`), `source-code-guidelines` (`CODING_GUIDELINES.rst`).
- New lines in both root guideline files wrap within the existing 79-column convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on supported USD schema sources across import, export, viewing, and public data models.
  * Clarified handling of OpenUSD display color and opacity primvars when no material is assigned.
  * Documented Newton schemas, bounded `physx*:*` and `mjc:*` physics fallbacks, and opt-in requirements for newly added fallbacks.
  * Clarified default behavior, compatibility paths, and grandfathering during deprecation or migration.
  * Reaffirmed USD Preview Surface guidance and restrictions on proprietary shading systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->