### PR TITLE
Add a temporary filter on conveyor to allow linesearch warnings

### DIFF
--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -16,7 +16,7 @@ import warp as wp
 
 import newton
 from newton.examples.basic.example_basic_conveyor_forces import ConveyorForceModel
-from newton.tests.unittest_utils import add_function_test, get_test_devices
+from newton.tests.unittest_utils import NewtonTestCase, add_function_test, get_test_devices
 
 BELT_HALF_X = 1.5
 BELT_HALF_Y = 6.0
@@ -25,6 +25,9 @@ BELT_TOP_Z = 0.5
 BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
+
+_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
+_MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations \w+ \d+\n?"
 
 
 def _make_solver(solver_name, model):
@@ -447,8 +450,13 @@ def test_backend_parity(test, device, _solver_name):
     test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
 
 
-class TestConveyorForces(unittest.TestCase):
+class TestConveyorForces(NewtonTestCase):
     """Scenario matrix for the force-based conveyor model."""
+
+    def setUp(self):
+        super().setUp()
+        self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
+        self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")
 
 
 _devices = get_test_devices()

--- a/newton/tests/test_conveyor_forces.py
+++ b/newton/tests/test_conveyor_forces.py
@@ -26,7 +26,7 @@ BOX_HALF = 0.2
 CONTACT_FRICTION = 2.0e-5
 BELT_FRICTION = 0.5
 
-_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device .*\n?"
+_MODULE_LOAD_OUTPUT_RE = r"^Module .* load on device '[^']*' took [\d.]+ ms\s*\((?:compiled|cached)\)\n?"
 _MUJOCO_LS_ITERATIONS_OUTPUT_RE = r"^linesearch iterations limit reached - please increase ls_iterations \w+ \d+\n?"
 
 
@@ -454,6 +454,7 @@ class TestConveyorForces(NewtonTestCase):
     """Scenario matrix for the force-based conveyor model."""
 
     def setUp(self):
+        """Allow the lazy module-load and MuJoCo linesearch messages these scenes emit."""
         super().setUp()
         self.allowOutputRegex(_MODULE_LOAD_OUTPUT_RE, stream="stdout")
         self.allowOutputRegex(_MUJOCO_LS_ITERATIONS_OUTPUT_RE, stream="stdout")


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated conveyor-force test setup to use the shared test framework.
  * Suppressed expected module-loading and solver iteration messages during test execution for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->