### PR TITLE
Fix dark textures in ViewerViser

### DIFF
--- a/changelog/4221.fixed.md
+++ b/changelog/4221.fixed.md
@@ -1,0 +1,1 @@
+Fix overly dark textured meshes in `ViewerViser` by using an untinted, nonmetallic material.

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -56,7 +56,10 @@ class ViewerViser(ViewerBase):
         """Create a trimesh object with texture visuals (if trimesh is available)."""
         try:
             import trimesh
-        except Exception:
+            from PIL import Image
+            from trimesh.visual.material import PBRMaterial
+            from trimesh.visual.texture import TextureVisuals
+        except ImportError:
             return None
 
         if len(uvs) != len(points):
@@ -65,17 +68,14 @@ class ViewerViser(ViewerBase):
         faces = indices.astype(np.int64)
         mesh = trimesh.Trimesh(vertices=points, faces=faces, process=False)
 
-        try:
-            from PIL import Image
-            from trimesh.visual.texture import TextureVisuals
-
-            image = Image.fromarray(texture)
-            mesh.visual = TextureVisuals(uv=uvs, image=image)
-        except Exception:
-            visual_mod = getattr(trimesh, "visual", None)
-            TextureVisuals = getattr(visual_mod, "TextureVisuals", None) if visual_mod is not None else None
-            if TextureVisuals is not None:
-                mesh.visual = TextureVisuals(uv=uvs, image=texture)
+        # SimpleMaterial tints textures gray and leaves glTF's metallic default enabled.
+        material = PBRMaterial(
+            baseColorTexture=Image.fromarray(texture),
+            baseColorFactor=(255, 255, 255, 255),
+            metallicFactor=0.0,
+            roughnessFactor=1.0,
+        )
+        mesh.visual = TextureVisuals(uv=uvs, material=material)
 
         return mesh
 

--- a/newton/tests/test_viewer_viser.py
+++ b/newton/tests/test_viewer_viser.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import io
+import unittest
+
+import numpy as np
+
+from newton.viewer import ViewerViser
+
+
+@unittest.skipUnless(importlib.util.find_spec("trimesh") is not None, "Requires trimesh")
+@unittest.skipUnless(importlib.util.find_spec("PIL") is not None, "Requires Pillow")
+class TestViewerViser(unittest.TestCase):
+    def _roundtrip_textured_mesh(self, channels):
+        import trimesh
+
+        points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+        indices = np.array([[0, 1, 2]], dtype=np.uint32)
+        uvs = np.array([[0, 0], [1, 0], [0, 1]], dtype=np.float32)
+        texture = np.arange(2 * 2 * channels, dtype=np.uint8).reshape(2, 2, channels) * 16
+        mesh = ViewerViser._build_trimesh_mesh(points, indices, uvs, texture)
+        self.assertIsNotNone(mesh)
+
+        # Exercise the actual glTF export/import used by Viser, including glTF defaults.
+        scene = trimesh.load_scene(io.BytesIO(mesh.export(file_type="glb")), file_type="glb", process=False)
+        loaded = next(iter(scene.geometry.values()))
+        np.testing.assert_array_equal(loaded.visual.material.baseColorTexture, texture)
+        np.testing.assert_allclose(loaded.visual.uv, uvs)
+        return loaded.visual.material
+
+    def test_textured_mesh_preserves_texture_brightness(self):
+        """Export RGB and RGBA textures without an unintended gray multiplier."""
+        for channels in (3, 4):
+            with self.subTest(channels=channels):
+                material = self._roundtrip_textured_mesh(channels)
+                np.testing.assert_array_equal(material.baseColorFactor, [255, 255, 255, 255])
+
+    def test_textured_mesh_is_nonmetallic(self):
+        """Keep textured meshes nonmetallic after glTF applies material defaults."""
+        material = self._roundtrip_textured_mesh(3)
+        self.assertEqual(material.metallicFactor, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Fix dark textures in `ViewerViser`. The implicit trimesh `SimpleMaterial` applies a gray base-color multiplier of 0.4 and omits metalness, which glTF defaults to 1. Textured robots therefore render as dark metals even under the viewer's normal lights.

Construct an explicit PBR material with a white texture multiplier, zero metalness, and the same fully rough default as Viser's standard meshes. The shared conversion covers individual and instanced textured meshes. Lighting settings are unchanged.

Closes #4221.

### Visual comparison

Same ANYmal C USD asset, pose, camera and 45-degree field of view. The two Viser images use identical default lighting; the right image is a fresh render with this fix applied.

![GL reference, original Viser textures, and Viser with this fix](https://raw.githubusercontent.com/eric-heiden/newton/6ccff5f2af148997207ad507b224769831001562/viser-texture-comparison.png)

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- Both regression tests fail without the fix and pass with it. They use real trimesh GLB export/import, checking material parameters and preservation of RGB/RGBA pixels and UVs; no mocks.
- All 14 focused tests pass:

  ```powershell
  uv run --no-project --with-editable . --with trimesh==4.11.3 --with pillow python -m unittest newton.tests.test_viewer_viser newton.tests.test_viewer_geometry_batching newton.tests.test_viewer_log_shapes -v
  ```

- Visually verified the actual viewer in Chromium on Windows/RTX 4090 with Viser 1.0.26: ANYmal C's 29 instanced textured meshes and individual RGB/RGBA textured meshes. Confirmed neutral, nonmetallic materials in the browser. Isaac Lab is not required to reproduce the problem.
- All configured repository hooks pass with `uvx --from pre-commit==4.2.0 pre-commit run -a`. Used this runner version for compatibility with the local Git version; hook versions are unchanged.
- Towncrier draft renders `changelog/4221.fixed.md` successfully.

## Bug fix

**Steps to reproduce:**

1. Run the snippet below and open the printed viewer URL.
2. Before this fix, the solid red texture appears dark despite default lighting. The same behavior affects textured USD assets such as ANYmal C.
3. Apply this fix and run again; the texture renders without the unintended gray tint or metallic response.

**Minimal reproduction:**

```python
import time

import numpy as np
import warp as wp

from newton.viewer import ViewerViser

viewer = ViewerViser()
viewer.log_mesh(
    "textured_quad",
    wp.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=wp.vec3),
    wp.array([0, 1, 2, 0, 2, 3], dtype=wp.int32),
    uvs=wp.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=wp.vec2),
    texture=np.full((32, 32, 3), (220, 30, 20), dtype=np.uint8),
)
viewer.set_camera(wp.vec3(0.5, -3, 3), pitch=-40, yaw=90)
try:
    while True:
        time.sleep(0.1)
finally:
    viewer.close()
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed overly dark textured meshes in the viewer.
  - Textures now retain their intended brightness and use a nonmetallic material with standard roughness.

- **Tests**
  - Added coverage for textured meshes using both RGB and RGBA textures.
  - Verified texture brightness, UV coordinates, and nonmetallic material settings during export and import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->