### PR TITLE
Synchronize Newton 1.5.2 changelog to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,11 @@
 - Speed up `SolverMuJoCo` initialization for replicated models by querying collision filters only for the selected MuJoCo template shapes.
 - Use supported NumPy ufunc names when building anisotropic Style3D cloth.
 
+## [1.5.2] - 2026-09-09
+
+### Added
+
+- Add `Actuator.State.assign()` for preserving actuator state across odd-length CUDA graph replays with a single captured graph. ([#4098](https://github.com/newton-physics/newton/issues/4098))
 
 ## [1.5.1] - 2026-08-27
 


### PR DESCRIPTION
## Description

Add the shipped Newton 1.5.2 changelog section to `main` after publishing
`v1.5.2`.

The existing 1.6.0 release section remains first and is unchanged. The
`Actuator.State.assign()` entry intentionally appears in both 1.6.0 and 1.5.2
because the change shipped in both release lines. All pending 1.7 fragments
remain untouched.

The 1.5.2 changelog-management commit is cherry-picked from `release-1.5`
with provenance. No changelog fragment is added or deleted: the original
`changelog/4098.added.md` fragment was already consumed on `main` by the 1.6.0
release sync.

## Checklist

- [x] Tests are not required for this changelog-only change
- [x] The documentation is up to date with these changes
- [x] The shipped 1.5.2 entry is copied verbatim into `CHANGELOG.md`; its
      existing 1.6.0 entry is deliberately retained

## Test plan

- Verified the diff changes only `CHANGELOG.md` and adds exactly five lines.
- Verified the complete 1.6.0 section is byte-for-byte unchanged (SHA-256
  `01706e714451fdd21a824e95b152869b4d88fbf2144bc98e15ce4187f153ebbf`).
- Verified the order is `[Unreleased]`, 1.6.0, 1.5.2, then 1.5.1.
- Verified no changelog fragment is added or deleted and all 16 pending
  fragments remain under `changelog/`.
- Ran:

  ```console
  uvx --python 3.12 pre-commit run -a
  git diff --check upstream/main...HEAD
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.5.2.
  * Documented preservation of actuator state across certain CUDA graph replays using `Actuator.State.assign()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->