### PR TITLE
Fix ViewerRTX debug markers and arrow rendering

### DIFF
--- a/changelog/4048.fixed.md
+++ b/changelog/4048.fixed.md
@@ -1,0 +1,1 @@
+Support debug markers and custom mesh instances created after the first frame in `ViewerRTX`, including changing instance counts, colors, and visibility. Render `log_arrows()` with cylinder shafts and cone heads, and update runtime lines without rebuilding their geometry on every frame.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -286,6 +286,14 @@ RTX Viewer
 It builds a USD scene on the first frame and updates rigid-body transforms each frame via the OVRTX attribute API,
 presenting the result in a pyglet/OpenGL window.
 
+Debug geometry can be added before or after the first rendered frame using
+:meth:`~newton.viewer.ViewerBase.log_shapes`, :meth:`~newton.viewer.ViewerBase.log_points`,
+:meth:`~newton.viewer.ViewerBase.log_lines`, and :meth:`~newton.viewer.ViewerBase.log_arrows`.
+For custom markers, register a triangle mesh with :meth:`~newton.viewer.ViewerBase.log_mesh`
+and place it with :meth:`~newton.viewer.ViewerBase.log_instances`. Instance batches support
+changing counts, transforms, scales, colors, and visibility. RTX arrows have cylinder shafts
+and cone heads; their ``width`` specifies the shaft radius in meters.
+
 .. note::
     The RTX viewer is experimental and may not have the same functionality as the OpenGL viewer.
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -1953,6 +1953,7 @@ class ViewerBase(ABC):
 
         The GL viewer renders these with a dedicated arrow shader that draws
         a screen-space quad line body plus a triangular arrowhead per segment.
+        The RTX viewer renders cylinder shafts with cone heads in world space.
         Other backends fall back to :meth:`log_lines`.
 
         Args:
@@ -1960,9 +1961,9 @@ class ViewerBase(ABC):
             starts: Optional arrow start points as a Warp vec3 array.
             ends: Optional arrow end points (arrowhead tip) as a Warp vec3 array.
             colors: Per-arrow colors as a Warp array, or a single RGB triplet.
-            width: Reserved for future use (world-space line width).
-                Currently ignored; arrow size is set in screen-space pixels
-                via the renderer (e.g. ``RendererGL.arrow_scale``).
+            width: Shaft radius [m] in the RTX viewer. Ignored by the GL viewer,
+                where arrow size is set in screen-space pixels via
+                ``RendererGL.arrow_scale``.
             hidden: Whether the arrow batch should be hidden.
         """
         self.log_lines(self._qualify(name), starts, ends, colors, width=width, hidden=hidden)

--- a/newton/_src/viewer/viewer_rtx.py
+++ b/newton/_src/viewer/viewer_rtx.py
@@ -41,7 +41,7 @@ from .picking import Picking
 from .utils import OPAQUE_OPACITY_THRESHOLD
 from .viewer import _DEFAULT_LAYER_ID
 from .viewer_gui import ViewerGui
-from .viewer_usd import ViewerUSD, _compute_segment_xform
+from .viewer_usd import ViewerUSD
 from .wind import Wind
 
 PROFILE_ENABLED = os.environ.get("NEWTON_PROFILE", "0") != "0"
@@ -107,7 +107,8 @@ class ViewerRTX(ViewerUSD):
     base class, serializes it to disk, then creates an OVRTX renderer for
     real-time path-traced rendering.  Subsequent frames update rigid-body
     transforms (and deforming-mesh vertices) via the OVRTX attribute API
-    and present the rendered image in a pyglet / OpenGL window.
+    and present the rendered image in a pyglet / OpenGL window. Debug markers
+    and custom mesh instances can also be added after rendering starts.
     """
 
     _PHASE_BUILD = 0
@@ -706,21 +707,16 @@ void main() {
             config.log_level = "error"
             self._rtx = ovrtx.Renderer(config=config)
             self._rtx.open_usd(ovrtx_usd_path)
-
-            # Flat prim-path list for a single transform binding
-            self._all_instance_paths = []
-            for paths in self._instance_prim_paths.values():
-                self._all_instance_paths.extend(paths)
-
-            if self._all_instance_paths:
-                from ovrtx import PrimMode, Semantic
-
-                self._transform_binding = self._rtx.bind_attribute(
-                    prim_paths=self._all_instance_paths,
-                    attribute_name="omni:xform",
-                    semantic=Semantic.XFORM_MAT4x4,
-                    prim_mode=PrimMode.MUST_EXIST,
+            self._runtime_prim_paths = {
+                path: path
+                for path in (
+                    *self._mesh_prim_paths.values(),
+                    *self._point_batch_paths.values(),
+                    *(self._get_path(name) for name in self._instance_prim_paths),
                 )
+            }
+
+            self._bind_ovrtx_transforms()
         except Exception as e:
             raise RuntimeError(f"Failed to create OVRTX renderer: {e}") from e
         finally:
@@ -791,6 +787,72 @@ void main() {
         self._flat_shape_scales = wp.array(np.concatenate(chunks_scales, axis=0), dtype=wp.vec3, device=dev)
         self._flat_total_shapes = len(self._flat_shape_xforms)
         self._flat_mat44_offset = flat_mat44_offset
+
+    def _bind_ovrtx_transforms(self):
+        """Refresh the transform binding after adding or resizing an instance batch."""
+        from ovrtx import PrimMode, Semantic
+
+        if self._transform_binding is not None:
+            self._transform_binding.unbind()
+            self._transform_binding = None
+        self._all_instance_paths = [path for paths in self._instance_prim_paths.values() for path in paths]
+        if self._all_instance_paths:
+            self._transform_binding = self._rtx.bind_attribute(
+                prim_paths=self._all_instance_paths,
+                attribute_name="omni:xform",
+                semantic=Semantic.XFORM_MAT4x4,
+                prim_mode=PrimMode.MUST_EXIST,
+            )
+
+    def _replace_runtime_prim(self, path: str) -> str:
+        """Publish a self-contained USD subtree, including its bound materials."""
+        from pxr import Sdf, Usd, UsdShade
+
+        flattened = self.stage.Flatten()
+        stage = Usd.Stage.CreateInMemory()
+        Sdf.CopySpec(flattened, path, stage.GetRootLayer(), "/Marker")
+        stage.SetDefaultPrim(stage.GetPrimAtPath("/Marker"))
+
+        # Material targets outside the copied subtree cannot cross a reference
+        # boundary. Copy those materials inside it and rebind the geometry.
+        materials = {}
+        for prim in list(stage.Traverse()):
+            binding = UsdShade.MaterialBindingAPI(prim).GetDirectBindingRel()
+            if not binding:
+                continue
+            for target in binding.GetTargets():
+                if target.HasPrefix(Sdf.Path("/Marker")):
+                    continue
+                if target not in materials:
+                    material_path = f"/Marker/Materials/material_{len(materials)}"
+                    self._ensure_scopes_for_path(stage, material_path)
+                    Sdf.CopySpec(flattened, target, stage.GetRootLayer(), material_path)
+                    materials[target] = material_path
+                binding.SetTargets([materials[target]])
+
+        # OVRTX consumes the current frame, not the USD export timeline.
+        for prim in stage.Traverse():
+            for attr in prim.GetAttributes():
+                if attr.GetNumTimeSamples():
+                    value = attr.Get(self._frame_index)
+                    attr.Clear()
+                    attr.Set(value)
+
+        handle = self._runtime_prim_handles.pop(path, None)
+        if handle is not None:
+            self._rtx.remove_usd(handle)
+        elif path in self._runtime_prim_paths:
+            self._rtx.write_attribute(prim_paths=[path], attribute_name="visibility", tensor=["invisible"])
+        # OVRTX rejects references at existing prim paths. Keep the original
+        # build-phase batch hidden and publish replacements at fresh sibling paths.
+        self._runtime_prim_serial += 1
+        runtime_path = f"{path}_rtx_{self._runtime_prim_serial}"
+        self._runtime_prim_handles[path] = self._rtx.add_usd_reference_from_string(
+            stage.GetRootLayer().ExportToString(), prefix_path=runtime_path
+        )
+        self._runtime_prim_paths[path] = runtime_path
+        self._runtime_scene_changed = True
+        return runtime_path
 
     # ------------------------------------------------ ViewerUSD overrides
 
@@ -904,14 +966,6 @@ void main() {
 
         self._instance_prim_paths[self._PICKING_LINE_NAME] = [path]
 
-    def _remove_runtime_line_batch_layer(self, name: str):
-        if self._rtx is None:
-            return
-
-        handle = self._line_batch_handles.pop(name, None)
-        if handle is not None:
-            self._rtx.remove_usd(handle)
-
     def _ensure_point_batch_primitive(self, name: str):
         if Gf is None or UsdGeom is None:
             return None
@@ -986,82 +1040,6 @@ void main() {
 
         return positions, scales, proto_indices, ids, colors_np, color_indices
 
-    def _rebuild_runtime_line_batch_layer(self, name: str, starts, ends, colors, width: float, hidden: bool) -> bool:
-        if self._rtx is None or Gf is None or UsdGeom is None:
-            return False
-
-        self._remove_runtime_line_batch_layer(name)
-
-        (
-            positions,
-            orientations,
-            scales,
-            _proto_indices,
-            _ids,
-            colors_np,
-            color_indices,
-        ) = self._build_line_batch_arrays(starts, ends, colors, hidden)
-
-        if hidden or len(positions) == 0:
-            return True
-
-        try:
-            from pxr import Sdf as _Sdf
-            from pxr import Usd as _Usd
-            from pxr import UsdGeom as _UsdGeom
-            from pxr import UsdShade as _UsdShade
-        except ImportError:
-            return False
-
-        target_path = self._get_path(name)
-        prim_name = target_path.rsplit("/", 1)[-1]
-        stage = _Usd.Stage.CreateInMemory()
-        root = _UsdGeom.Xform.Define(stage, f"/{prim_name}")
-        stage.SetDefaultPrim(root.GetPrim())
-
-        # OVRTX reliably renders fully authored runtime capsule prims, whereas
-        # runtime PointInstancer color updates fell back to gray.
-        material_paths: dict[tuple[float, float, float], str] = {}
-
-        for i in range(len(positions)):
-            color_index = int(color_indices[i]) if len(color_indices) > i else min(i, len(colors_np) - 1)
-            color = colors_np[color_index].astype(np.float32)
-            color_key = (float(color[0]), float(color[1]), float(color[2]))
-
-            seg_path = f"/{prim_name}/seg_{i}"
-            xform = _UsdGeom.Xform.Define(stage, seg_path)
-            xform.ClearXformOpOrder()
-            xform.AddTranslateOp().Set(Gf.Vec3d(*positions[i].astype(np.float64).tolist()))
-            orient = orientations[i].astype(np.float32)
-            xform.AddOrientOp().Set(Gf.Quatf(float(orient[3]), float(orient[0]), float(orient[1]), float(orient[2])))
-            xform.AddScaleOp().Set(Gf.Vec3d(*scales[i].astype(np.float64).tolist()))
-
-            capsule = _UsdGeom.Capsule.Define(stage, f"{seg_path}/capsule")
-            capsule.GetAxisAttr().Set(_UsdGeom.Tokens.z)
-            capsule.GetRadiusAttr().Set(float(width))
-            capsule.GetHeightAttr().Set(1.0)
-            capsule.GetDisplayColorAttr().Set([Gf.Vec3f(*color.tolist())])
-
-            mat_path = material_paths.get(color_key)
-            if mat_path is None:
-                mat_path = f"/{prim_name}/Materials/mat_{len(material_paths)}"
-                material_paths[color_key] = mat_path
-                material = _UsdShade.Material.Define(stage, mat_path)
-                surface = _UsdShade.Shader.Define(stage, f"{mat_path}/PreviewSurface")
-                surface.CreateIdAttr("UsdPreviewSurface")
-                surface.CreateInput("diffuseColor", _Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*color.tolist()))
-                surface.CreateInput("emissiveColor", _Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*color.tolist()))
-                surface.CreateInput("roughness", _Sdf.ValueTypeNames.Float).Set(1.0)
-                surface.CreateInput("metallic", _Sdf.ValueTypeNames.Float).Set(0.0)
-                material.CreateSurfaceOutput().ConnectToSource(surface.ConnectableAPI(), "surface")
-
-            _UsdShade.MaterialBindingAPI.Apply(capsule.GetPrim())
-            _UsdShade.MaterialBindingAPI(capsule).Bind(_UsdShade.Material.Get(stage, mat_path))
-
-        handle = self._rtx.add_usd_reference_from_string(stage.GetRootLayer().ExportToString(), prefix_path=target_path)
-        self._line_batch_handles[name] = handle
-        return True
-
     @staticmethod
     def _build_line_instance_buffers(
         starts_np: np.ndarray, ends_np: np.ndarray, capacity: int
@@ -1112,88 +1090,6 @@ void main() {
             np.zeros((1, 3), dtype=np.float32),
             np.zeros((1, 3), dtype=np.float32),
         )
-
-    def _build_line_batch_arrays(
-        self, starts, ends, colors, hidden: bool
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        empty_positions = np.zeros((0, 3), dtype=np.float32)
-        empty_orientations = np.zeros((0, 4), dtype=np.float16)
-        empty_scales = np.zeros((0, 3), dtype=np.float32)
-        empty_proto_indices = np.zeros(0, dtype=np.int32)
-        empty_ids = np.zeros(0, dtype=np.int64)
-        empty_colors = np.zeros((0, 3), dtype=np.float32)
-        empty_color_indices = np.zeros(0, dtype=np.int32)
-
-        if hidden or starts is None or ends is None or colors is None or Gf is None:
-            return (
-                empty_positions,
-                empty_orientations,
-                empty_scales,
-                empty_proto_indices,
-                empty_ids,
-                empty_colors,
-                empty_color_indices,
-            )
-
-        starts_np = (
-            starts.numpy().astype(np.float32) if isinstance(starts, wp.array) else np.asarray(starts, dtype=np.float32)
-        )
-        ends_np = ends.numpy().astype(np.float32) if isinstance(ends, wp.array) else np.asarray(ends, dtype=np.float32)
-        num_lines = min(len(starts_np), len(ends_np))
-        if num_lines == 0:
-            return (
-                empty_positions,
-                empty_orientations,
-                empty_scales,
-                empty_proto_indices,
-                empty_ids,
-                empty_colors,
-                empty_color_indices,
-            )
-
-        colors_np = self._promote_colors_to_array(colors, num_lines)
-        colors_np = np.asarray(colors_np, dtype=np.float32)
-        if colors_np.ndim == 1:
-            if colors_np.shape[0] != 3:
-                raise ValueError("Line colors must be an RGB triplet or an array of RGB triplets.")
-            colors_np = np.tile(colors_np, (num_lines, 1))
-        elif colors_np.shape[0] == 1 and num_lines > 1:
-            colors_np = np.repeat(colors_np, num_lines, axis=0)
-        elif colors_np.shape[0] != num_lines:
-            raise ValueError("Number of line colors must match the number of lines.")
-
-        positions = np.zeros((num_lines, 3), dtype=np.float32)
-        orientations = np.zeros((num_lines, 4), dtype=np.float16)
-        orientations[:, 3] = np.float16(1.0)
-        scales = np.zeros((num_lines, 3), dtype=np.float32)
-
-        for i in range(num_lines):
-            pos0 = starts_np[i]
-            pos1 = ends_np[i]
-            delta = pos1 - pos0
-            if float(np.linalg.norm(delta)) <= 1.0e-8:
-                positions[i] = 0.5 * (pos0 + pos1)
-                continue
-
-            pos, rot, scale = _compute_segment_xform(
-                Gf.Vec3f(float(pos0[0]), float(pos0[1]), float(pos0[2])),
-                Gf.Vec3f(float(pos1[0]), float(pos1[1]), float(pos1[2])),
-            )
-            imag = rot.GetImaginary()
-            positions[i] = (float(pos[0]), float(pos[1]), float(pos[2]))
-            # quath memory layout is imaginary xyz first, then real w.
-            orientations[i] = (
-                np.float16(imag[0]),
-                np.float16(imag[1]),
-                np.float16(imag[2]),
-                np.float16(rot.GetReal()),
-            )
-            scales[i] = (float(scale[0]), float(scale[1]), float(scale[2]))
-
-        proto_indices = np.zeros(num_lines, dtype=np.int32)
-        ids = np.arange(num_lines, dtype=np.int64)
-        color_indices = np.arange(num_lines, dtype=np.int32)
-        return positions, orientations, scales, proto_indices, ids, colors_np, color_indices
 
     @override
     def is_key_down(self, key: str | int) -> bool:
@@ -1376,7 +1272,6 @@ void main() {
             self._pending_mesh_normals.clear()
             self._pending_mesh_topology.clear()
             self._pending_mesh_visibility.clear()
-            self._pending_line_batches.clear()
             self._pending_point_batches.clear()
             self._gizmo_log = {}
 
@@ -1416,9 +1311,12 @@ void main() {
             self._update_ovrtx_camera()
             self._update_ovrtx_transforms()
             self._update_ovrtx_instance_visibility()
-            self._update_ovrtx_line_batches()
             self._update_ovrtx_point_batches()
             self._update_ovrtx_mesh_points()
+            if self._runtime_scene_changed:
+                # Discard accumulated samples of removed geometry and old colors.
+                self._rtx.reset(time=self._frame_index / self.fps)
+                self._runtime_scene_changed = False
             self._render_and_display()
 
     # ViewerUSD authors PreviewSurface materials while ViewerRTX is in the
@@ -1482,7 +1380,7 @@ void main() {
         """
         name = self._qualify(name)
 
-        if self._phase == self._PHASE_BUILD:
+        if self._phase == self._PHASE_BUILD or name not in self._mesh_prim_paths:
             super().log_mesh(
                 name,
                 points,
@@ -1499,6 +1397,8 @@ void main() {
                 dynamic=dynamic,
             )
             self._mesh_prim_paths[name] = self._get_path(name)
+            if self._phase == self._PHASE_RENDER:
+                self._mesh_prim_paths[name] = self._replace_runtime_prim(self._get_path(name))
         elif name in self._mesh_prim_paths:
             pts = (
                 points.numpy().astype(np.float32)
@@ -1551,7 +1451,19 @@ void main() {
         name = self._qualify(name)
         mesh = self._qualify(mesh)
 
-        if self._phase == self._PHASE_BUILD:
+        count = len(xforms) if xforms is not None else 0
+        previous = self._instance_specs.get(name)
+        appearance = tuple(
+            value.numpy().copy() if value is not None else None for value in (colors, materials, opacities)
+        )
+        changed = previous is None or previous[0] != mesh or previous[1] != count
+        if previous is not None:
+            appearance = tuple(old if new is None else new for old, new in zip(previous[2], appearance, strict=True))
+            changed |= any(not np.array_equal(old, new) for old, new in zip(previous[2], appearance, strict=True))
+
+        if self._phase == self._PHASE_BUILD or (xforms is not None and changed):
+            if previous is not None and (previous[0] != mesh or previous[1] != count):
+                self.stage.RemovePrim(self._get_path(name))
             super().log_instances(
                 name,
                 mesh,
@@ -1562,16 +1474,23 @@ void main() {
                 opacities=opacities,
                 hidden=hidden,
             )
-            if xforms is not None:
-                count = len(xforms)
-                paths = [self._get_path(name) + f"/instance_{i}" for i in range(count)]
-                self._instance_prim_paths[name] = paths
-        else:
-            self._pending_instance_visibility[name] = not hidden
-            if xforms is not None:
-                if scales is None:
-                    scales = wp.ones(len(xforms), dtype=wp.vec3, device=xforms.device)
-                self._pending_xforms[name] = (xforms, scales)
+            self._instance_specs[name] = (mesh, count, appearance)
+            self._instance_prim_paths[name] = [self._get_path(name) + f"/instance_{i}" for i in range(count)]
+            if self._phase == self._PHASE_RENDER:
+                if self._transform_binding is not None:
+                    self._transform_binding.unbind()
+                    self._transform_binding = None
+                runtime_path = self._replace_runtime_prim(self._get_path(name))
+                self._instance_prim_paths[name] = [f"{runtime_path}/instance_{i}" for i in range(count)]
+                self._bind_ovrtx_transforms()
+                if not self._use_layered_transform_updates:
+                    self._build_flat_shape_arrays()
+
+        self._pending_instance_visibility[name] = not hidden and count > 0
+        if xforms is not None:
+            if scales is None:
+                scales = wp.ones(count, dtype=wp.vec3, device=xforms.device)
+            self._pending_xforms[name] = (xforms, scales)
 
     @override
     def log_lines(
@@ -1590,22 +1509,78 @@ void main() {
             starts: Array of line start positions [m], shape ``[N, 3]``, or ``None`` for empty.
             ends: Array of line end positions [m], shape ``[N, 3]``, or ``None`` for empty.
             colors: Array of per-line RGB colors, a single RGB triplet, or ``None`` for empty.
-            width: Line width [m].
+            width: Line radius [m].
             hidden: Whether the lines are initially hidden.
         """
-        name = self._qualify(name)
+        self._log_segments(name, starts, ends, colors, width, hidden, arrow=False)
 
-        if self._phase == self._PHASE_BUILD:
-            super().log_lines(name, starts, ends, colors, width, hidden)
-            self._line_batch_paths[name] = self._get_path(name)
-            self._line_batch_proto_paths[name] = self._get_path(name) + "/capsule"
-            self._line_batch_widths[name] = float(width)
+    @override
+    def log_arrows(
+        self,
+        name: str,
+        starts: wp.array[wp.vec3] | None,
+        ends: wp.array[wp.vec3] | None,
+        colors: (wp.array[wp.vec3] | wp.array[wp.float32] | tuple[float, float, float] | list[float] | None),
+        width: float = 0.01,
+        hidden: bool = False,
+    ) -> None:
+        """Log arrows as cylinder shafts with cone heads.
+
+        Args:
+            name: Unique identifier for the arrow batch.
+            starts: Arrow start positions [m], shape ``[N, 3]``, or ``None`` for empty.
+            ends: Arrow tip positions [m], shape ``[N, 3]``, or ``None`` for empty.
+            colors: Per-arrow RGB colors, a single RGB triplet, or ``None`` for empty.
+            width: Shaft radius [m]. The head radius is twice this value.
+            hidden: Whether the arrows are hidden.
+        """
+        self._log_segments(name, starts, ends, colors, width, hidden, arrow=True)
+
+    def _log_segments(self, name, starts, ends, colors, width, hidden, *, arrow: bool):
+        name = self._qualify(name)
+        mesh_name = self._qualify("/geometry/rtx_arrow" if arrow else "/geometry/rtx_line")
+        if hidden or starts is None or ends is None or colors is None or len(starts) == 0 or len(ends) == 0:
+            self._pending_instance_visibility[name] = False
             return
 
-        if name not in self._line_batch_paths:
-            self._rebuild_runtime_line_batch_layer(name, starts, ends, colors, float(width), bool(hidden))
-        elif name in self._line_batch_paths:
-            self._pending_line_batches[name] = (starts, ends, colors, float(width), bool(hidden))
+        if mesh_name not in self._segment_meshes:
+            mesh = (
+                newton.Mesh.create_arrow(
+                    1.0, 0.8, cap_radius=2.0, cap_height=0.2, up_axis=Axis.Z, compute_inertia=False
+                )
+                if arrow
+                else newton.Mesh.create_cylinder(1.0, 0.5, up_axis=Axis.Z, compute_inertia=False)
+            )
+            self.log_mesh(
+                mesh_name,
+                wp.array(mesh.vertices, dtype=wp.vec3, device=self.device),
+                wp.array(mesh.indices, dtype=wp.int32, device=self.device),
+                normals=wp.array(mesh.normals, dtype=wp.vec3, device=self.device),
+                hidden=True,
+            )
+            self._segment_meshes[mesh_name] = float(mesh.vertices[:, 2].max()) if arrow else 1.0
+
+        starts_np = starts.numpy()
+        ends_np = ends.numpy()
+        count = min(len(starts_np), len(ends_np))
+        xforms, scales = self._build_line_instance_buffers(starts_np, ends_np, capacity=count)
+        scales[:, :2] *= float(width)
+        if arrow:
+            xforms[:, :3] = starts_np[:count]
+            scales[:, 2] /= self._segment_meshes[mesh_name]
+        colors_np = np.asarray(self._promote_colors_to_array(colors, count), dtype=np.float32).reshape(-1, 3)
+        if len(colors_np) == 1:
+            colors_np = np.repeat(colors_np, count, axis=0)
+        if len(colors_np) != count:
+            raise ValueError("Number of segment colors must match the number of segments.")
+        self.log_instances(
+            name,
+            mesh_name,
+            wp.array(xforms, dtype=wp.transform, device=self.device),
+            wp.array(scales, dtype=wp.vec3, device=self.device),
+            wp.array(colors_np, dtype=wp.vec3, device=self.device),
+            None,
+        )
 
     @override
     def log_points(
@@ -1627,7 +1602,7 @@ void main() {
         """
         name = self._qualify(name)
 
-        if self._phase == self._PHASE_BUILD:
+        if self._phase == self._PHASE_BUILD or name not in self._point_batch_paths:
             if points is None:
                 return None
 
@@ -1657,7 +1632,9 @@ void main() {
                 "inherited" if not hidden and len(positions) > 0 else "invisible",
                 self._frame_index,
             )
-            return instancer.GetPath()
+            if self._phase == self._PHASE_RENDER:
+                self._point_batch_paths[name] = self._replace_runtime_prim(str(instancer.GetPath()))
+            return self._point_batch_paths[name]
 
         if name in self._point_batch_paths:
             self._pending_point_batches[name] = (points, radii, colors, bool(hidden))
@@ -1739,6 +1716,15 @@ void main() {
 
         for name, visible in self._pending_instance_visibility.items():
             paths = self._instance_prim_paths.get(name)
+            if paths is None:
+                continue
+            # The group may have been hidden before its first rendered frame.
+            group_path = self._get_path(name)
+            self._rtx.write_attribute(
+                prim_paths=[self._runtime_prim_paths.get(group_path, group_path)],
+                attribute_name="visibility",
+                tensor=["inherited" if visible else "invisible"],
+            )
             if not paths:
                 continue
             self._rtx.write_attribute(
@@ -1827,64 +1813,6 @@ void main() {
                     attribute_name="visibility",
                     tensor=["inherited" if visible else "invisible"],
                 )
-
-    def _update_ovrtx_line_batches(self):
-        if self._rtx is None or not self._pending_line_batches:
-            return
-
-        with wp.ScopedTimer("ViewerRTX::update_line_batches", active=PROFILE_ENABLED, use_nvtx=True):
-            for name, (starts, ends, colors, width, hidden) in self._pending_line_batches.items():
-                prim_path = self._line_batch_paths.get(name)
-                proto_path = self._line_batch_proto_paths.get(name)
-                if prim_path is None or proto_path is None:
-                    continue
-
-                if self._line_batch_widths.get(name) != width:
-                    self._rtx.write_attribute(
-                        prim_paths=[proto_path],
-                        attribute_name="radius",
-                        tensor=np.asarray([width], dtype=np.float32),
-                    )
-                    self._line_batch_widths[name] = width
-
-                (
-                    positions,
-                    orientations,
-                    scales,
-                    proto_indices,
-                    ids,
-                    colors_np,
-                    color_indices,
-                ) = self._build_line_batch_arrays(starts, ends, colors, hidden)
-
-                is_visible = not hidden and len(positions) > 0
-                self._rtx.write_attribute(
-                    prim_paths=[prim_path],
-                    attribute_name="visibility",
-                    tensor=["inherited" if is_visible else "invisible"],
-                )
-                if not is_visible:
-                    continue
-
-                self._rtx.write_array_attribute(
-                    [prim_path], "positions", [self._make_laned_array_dltensor(positions.astype(np.float32), lanes=3)]
-                )
-                self._rtx.write_array_attribute(
-                    [prim_path],
-                    "orientations",
-                    [self._make_laned_array_dltensor(orientations.astype(np.float16), lanes=4)],
-                )
-                self._rtx.write_array_attribute(
-                    [prim_path], "scales", [self._make_laned_array_dltensor(scales.astype(np.float32), lanes=3)]
-                )
-                self._rtx.write_array_attribute([prim_path], "protoIndices", [proto_indices])
-                self._rtx.write_array_attribute([prim_path], "ids", [ids])
-                self._rtx.write_array_attribute(
-                    [prim_path],
-                    "primvars:displayColor",
-                    [self._make_laned_array_dltensor(colors_np.astype(np.float32), lanes=3)],
-                )
-                self._rtx.write_array_attribute([prim_path], "primvars:displayColor:indices", [color_indices])
 
     def _update_ovrtx_point_batches(self):
         if self._rtx is None or not self._pending_point_batches:
@@ -2126,12 +2054,14 @@ void main() {
 
         # Reset build-phase state
         self._instance_prim_paths = {}
+        self._instance_specs = {}
+        self._runtime_prim_handles = {}
+        self._runtime_prim_paths = {}
+        self._runtime_prim_serial = 0
+        self._runtime_scene_changed = False
+        self._segment_meshes = {}
         self._all_instance_paths = []
         self._mesh_prim_paths = {}
-        self._line_batch_paths = {}
-        self._line_batch_proto_paths = {}
-        self._line_batch_widths = {}
-        self._line_batch_handles = {}
         self._point_batch_paths = {}
         self._point_batch_colors = {}
         self._point_batch_synced_counts = {}
@@ -2142,7 +2072,6 @@ void main() {
         self._pending_mesh_normals = {}
         self._pending_mesh_topology = {}
         self._pending_mesh_visibility = {}
-        self._pending_line_batches = {}
         self._pending_point_batches = {}
 
         self._flat_shape_xforms = None

--- a/newton/tests/test_viewer_rtx_markers.py
+++ b/newton/tests/test_viewer_rtx_markers.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.tests.unittest_utils import USD_AVAILABLE
+from newton.viewer import ViewerRTX
+
+if USD_AVAILABLE:
+    from pxr import Sdf, Usd, UsdGeom, UsdShade
+
+
+@unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+class TestViewerRTXMarkers(unittest.TestCase):
+    def setUp(self):
+        self.ovrtx = mock.MagicMock()
+        patcher = mock.patch.dict("sys.modules", {"ovrtx": self.ovrtx})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.viewer = ViewerRTX(headless=True)
+        self.addCleanup(self.viewer.close)
+        self.viewer._phase = ViewerRTX._PHASE_RENDER
+        self.viewer._rtx = self.ovrtx.Renderer()
+
+    def _log_spheres(self, count, *, hidden=False, color=(1.0, 0.0, 0.0)):
+        xforms = wp.array([wp.transform_identity()] * count, dtype=wp.transform, device="cpu")
+        colors = wp.array([color] * count, dtype=wp.vec3, device="cpu")
+        self.viewer.log_shapes("/markers/spheres", newton.GeoType.SPHERE, 0.1, xforms, colors, hidden=hidden)
+
+    def test_add_markers_after_first_frame(self):
+        """Register mesh prototypes and instances after rendering starts."""
+        self._log_spheres(2)
+        self.assertEqual(len(self.viewer._instance_prim_paths["/markers/spheres"]), 2)
+        self.assertTrue(self.viewer._rtx.add_usd_reference_from_string.called)
+        self.assertTrue(self.viewer._rtx.bind_attribute.called)
+
+    def test_resize_and_clear_marker_batch(self):
+        """Grow, shrink, and hide an existing runtime marker batch."""
+        for count in (1, 3, 1, 0, 2):
+            self._log_spheres(count)
+            self.assertEqual(len(self.viewer._instance_prim_paths["/markers/spheres"]), count)
+        self._log_spheres(2, hidden=True)
+        self.viewer._update_ovrtx_instance_visibility()
+        self.assertEqual(self.viewer._rtx.write_attribute.call_args.kwargs["tensor"], ["invisible"] * 2)
+        self._log_spheres(2)
+        self.viewer._update_ovrtx_instance_visibility()
+        self.assertEqual(self.viewer._rtx.write_attribute.call_args.kwargs["tensor"], ["inherited"] * 2)
+
+    def test_reuse_geometry_until_appearance_changes(self):
+        """Reuse runtime geometry for motion and refresh changed colors."""
+        self._log_spheres(2)
+        self.viewer._rtx.add_usd_reference_from_string.reset_mock()
+        self._log_spheres(2)
+        self.viewer._rtx.add_usd_reference_from_string.assert_not_called()
+        self._log_spheres(2, color=(0.0, 1.0, 0.0))
+        self.viewer._rtx.add_usd_reference_from_string.assert_called_once()
+
+    def test_runtime_materials_are_self_contained(self):
+        """Keep material bindings valid when a runtime batch is referenced elsewhere."""
+        self._log_spheres(2, color=(0.0, 1.0, 0.0))
+        content = self.viewer._rtx.add_usd_reference_from_string.call_args.args[0]
+        layer = Sdf.Layer.CreateAnonymous()
+        self.assertTrue(layer.ImportFromString(content))
+        stage = Usd.Stage.CreateInMemory()
+        root = stage.DefinePrim("/Referenced")
+        root.GetReferences().AddReference(layer.identifier)
+        mesh = stage.GetPrimAtPath("/Referenced/instance_0")
+        material, _ = UsdShade.MaterialBindingAPI(mesh).ComputeBoundMaterial()
+        self.assertTrue(material)
+        shader = UsdShade.Shader(material.GetPrim().GetChild("PreviewSurface"))
+        np.testing.assert_allclose(shader.GetInput("diffuseColor").Get(), [0.0, 1.0, 0.0])
+        self.assertEqual(material.GetSurfaceOutput().GetConnectedSource()[0].GetPrim(), shader.GetPrim())
+
+    def test_hidden_build_markers_can_be_shown(self):
+        """Preserve initial visibility and allow markers to be enabled after startup."""
+        self.viewer._phase = ViewerRTX._PHASE_BUILD
+        self._log_spheres(2, hidden=True)
+        group = UsdGeom.Imageable(self.viewer.stage.GetPrimAtPath("/root/markers/spheres"))
+        self.assertEqual(group.ComputeVisibility(self.viewer._frame_index), "invisible")
+        self.viewer._phase = ViewerRTX._PHASE_RENDER
+        self._log_spheres(2)
+        self.viewer._update_ovrtx_instance_visibility()
+        self.viewer._rtx.write_attribute.assert_any_call(
+            prim_paths=["/root/markers/spheres"], attribute_name="visibility", tensor=["inherited"]
+        )
+
+    def test_points_can_be_added_after_startup(self):
+        """Create sphere markers after the first rendered frame."""
+        points = wp.array([[0, 0, 1]], dtype=wp.vec3, device="cpu")
+        path = self.viewer.log_points("/points", points, radii=0.1, colors=(1.0, 0.8, 0.0))
+        self.assertEqual(str(path), self.viewer._point_batch_paths["/points"])
+        self.viewer._rtx.add_usd_reference_from_string.assert_called_once()
+        self.viewer.log_points("/points", points, radii=0.2)
+        self.assertIn("/points", self.viewer._pending_point_batches)
+
+    def test_replace_build_batch_and_reset_render_history(self):
+        """Replace an initial batch without colliding with its prims or retaining old samples."""
+        self.viewer._phase = ViewerRTX._PHASE_BUILD
+        self._log_spheres(3)
+        path = "/root/markers/spheres"
+        self.viewer._runtime_prim_paths[path] = path
+        self.viewer._phase = ViewerRTX._PHASE_RENDER
+        self._log_spheres(1)
+        runtime_path = self.viewer._rtx.add_usd_reference_from_string.call_args.kwargs["prefix_path"]
+        self.assertNotEqual(path, runtime_path)
+        self.assertEqual(self.viewer._instance_prim_paths["/markers/spheres"], [f"{runtime_path}/instance_0"])
+        self.viewer._rtx.write_attribute.assert_any_call(
+            prim_paths=[path], attribute_name="visibility", tensor=["invisible"]
+        )
+        with (
+            mock.patch.object(self.viewer, "_update_ovrtx_camera"),
+            mock.patch.object(self.viewer, "_update_ovrtx_transforms"),
+            mock.patch.object(self.viewer, "_render_and_display"),
+        ):
+            self.viewer.end_frame()
+            self.viewer.end_frame()
+        self.viewer._rtx.reset.assert_called_once_with(time=0.0)
+
+    def test_arrows_have_heads_and_correct_endpoints(self):
+        """Render arrow meshes with tips at their endpoints, including reversed arrows."""
+        starts = wp.array([[0, 0, 0], [1, 2, 3], [1, 0, 0]], dtype=wp.vec3, device="cpu")
+        ends = wp.array([[0, 0, 2], [1, 2, 1], [1, 0, 0]], dtype=wp.vec3, device="cpu")
+        self.viewer.log_arrows("/arrows", starts, ends, (1.0, 0.0, 0.0), width=0.02)
+        paths = self.viewer._instance_prim_paths["/arrows"]
+        xforms, scales = self.viewer._pending_xforms["/arrows"]
+        for i in range(len(paths)):
+            mesh = UsdGeom.Mesh.Get(self.viewer.stage, f"/root/arrows/instance_{i}")
+            self.assertTrue(mesh)
+            points = np.asarray(mesh.GetPointsAttr().Get(self.viewer._frame_index))
+            # The cone is wider than the shaft and converges to a single tip.
+            tip = points[np.argmax(points[:, 2])]
+            self.assertAlmostEqual(float(np.linalg.norm(tip[:2])), 0.0, places=6)
+            self.assertGreater(float(np.max(np.linalg.norm(points[:, :2], axis=1))), 1.5)
+            tip_world = wp.transform_point(wp.transform(*xforms.numpy()[i]), wp.vec3(*(tip * scales.numpy()[i])))
+            np.testing.assert_allclose(np.asarray(tip_world), ends.numpy()[i], atol=1e-6)
+
+    def test_lines_added_at_runtime_reuse_geometry(self):
+        """Keep runtime lines colored and update motion without recreating the scene."""
+        starts = wp.array([[0, 0, 0]], dtype=wp.vec3, device="cpu")
+        ends = wp.array([[0, 0, 1]], dtype=wp.vec3, device="cpu")
+        for _ in range(2):
+            self.viewer.log_lines("/lines", starts, ends, (0.0, 1.0, 0.0))
+        self.assertEqual(len(self.viewer._instance_prim_paths["/lines"]), 1)
+        self.assertEqual(self.viewer._rtx.add_usd_reference_from_string.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

ViewerRTX previously ignored meshes and instance batches first logged after startup and rendered arrows as plain lines. This adds debug markers and custom triangle-mesh markers through the existing Viewer API.

- Support runtime mesh prototypes, instance batches, and sphere points.
- Render arrows with cylinder shafts and cone heads; `width` specifies the shaft radius in meters.
- Reuse line geometry for transform updates instead of rebuilding it every frame.
- Handle instance count, color, material, and visibility changes, including empty batches and markers hidden during startup.
- Preserve material bindings in runtime USD references, refresh transform bindings when batches change, and clear accumulated render samples after scene changes.

Fixes #4048 on the Newton side. Isaac Lab's current mesh/line adapter can use the existing API; removing its explicit RTX marker exclusion remains an Isaac Lab follow-up.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] For user-facing changes, a fragment has been added by following the [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

- Confirmed the initial five marker regression tests fail before the fix.
- Broader viewer suite during implementation: `uv run --no-sync -m newton.tests -k test_viewer --quiet` — 261 tests passed.
- Final focused checks: `uv run --no-sync -m unittest newton.tests.test_viewer_rtx_markers newton.tests.test_viewer_usd newton.tests.test_viewer_layers` — 54 tests passed, including all nine new marker tests.
- `uvx --from pre-commit==4.2.0 pre-commit run -a` passed. Version 4.2.0 was used because the current pre-commit release requires a newer Git than this Windows host provides. Hooks also passed on all five changed files.
- Towncrier draft preview passed.
- Manually rendered on an RTX 4090 with OVRTX 0.3.0.312915: runtime insertion, resizing, recoloring, hiding/restoring, arrowheads, custom meshes, points, and diagnostic lines, with synchronous and asynchronous rendering.

## Bug fix

**Steps to reproduce:**

1. Render an initial frame with ViewerRTX.
2. Log a new custom mesh/instance batch or call `log_shapes()` in a later frame.
3. Observe that the new instances are missing. Log an arrow and observe that it has no arrowhead.

**Minimal reproduction:**

```python
import warp as wp
import newton

viewer = newton.viewer.ViewerRTX(headless=True, async_rendering=False)
try:
    viewer.begin_frame(0.0)
    viewer.end_frame()

    viewer.begin_frame(1.0 / 60.0)
    viewer.log_shapes(
        "/debug/goal",
        newton.GeoType.BOX,
        0.1,
        wp.array([wp.transform_identity()], dtype=wp.transform),
    )
    viewer.log_arrows(
        "/debug/velocity",
        wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3),
        wp.array([[0.0, 0.0, 1.0]], dtype=wp.vec3),
        (1.0, 0.0, 0.0),
    )
    viewer.end_frame()
finally:
    viewer.close()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom mesh markers after rendering begins in the RTX Viewer.
  - Marker batches can change size, transforms, scale, colors, and visibility at runtime.
  - Added RTX debug arrows with cylinder shafts and cone heads.
  - Debug lines, arrows, points, and markers update dynamically without recreating geometry each frame.
  - Runtime scene changes refresh path-traced rendering automatically.
  - Debug lines and markers support emissive rendering for improved visibility.

- **Documentation**
  - Expanded guidance for debug shapes, points, lines, arrows, and custom mesh markers.
  - Documented RTX arrow width as the shaft radius in meters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->