### PR TITLE
Rework random controller in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/utils/control/rand.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/rand.py
@@ -22,7 +22,7 @@ from ...core.joints import JointActuationType
 from ...core.math import FLOAT32_MAX
 from ...core.model import ModelKamino
 from ...core.time import TimeData
-from ...core.types import FloatArrayLike, IntArrayLike, to_warp_int32_array
+from ...core.types import FloatArrayLike
 
 ###
 # Module interface
@@ -60,12 +60,9 @@ class RandomJointControllerData:
     Shape of `(sum_of_num_actuated_joint_dofs,)`.
     """
 
-    decimation: wp.array[wp.int32] | None = None
+    interval: wp.array[wp.float32] | None = None
     """
-    Control decimation of each world expressed as a multiple of simulation steps.
-
-    Values greater than `1` result in a zero-order hold of the control
-    inputs, meaning that they will change only every `decimation` steps.
+    Interval between each torque application for each world.
 
     Shape of `(num_worlds,)`.
     """
@@ -80,13 +77,14 @@ class RandomJointControllerData:
 def _generate_random_control_inputs(
     # Inputs
     controller_seed: int,
-    controller_decimation: wp.array[wp.int32],
+    controller_interval: wp.array[wp.float32],
     controller_scale: wp.array[wp.float32],
     model_joints_wid: wp.array[wp.int32],
     model_joints_dof_act_types: wp.array[wp.int32],
     model_joints_dofs_offset: wp.array[wp.int32],
     model_joints_tau_j_max: wp.array[wp.float32],
-    state_time_steps: wp.array[wp.int32],
+    model_time_step: wp.array[wp.float32],
+    state_time: wp.array[wp.float32],
     # Outputs
     # TODO: Add support for other control types
     # (e.g. position and velocity targets)
@@ -98,21 +96,19 @@ def _generate_random_control_inputs(
     # Retrieve the the joint index from the thread indices
     jid = wp.tid()
 
-    # Retrieve the total number of joints from the size of the input arrays
-    num_joints = model_joints_wid.shape[0]
-
     # Retrieve the world index from the thread indices
     wid = model_joints_wid[jid]
 
-    # Retrieve the current simulation step
-    step = state_time_steps[wid]
+    # Determine whether we should apply torque
+    t = state_time[wid]
+    dt = model_time_step[wid]
+    interval = controller_interval[wid]
+    n = wp.floor(t / interval)
+    if t - n * interval >= dt:
+        return  # Early return if this is not the first time step after an interval multiple
 
-    # Retrieve the control decimation for the world
-    decimation = controller_decimation[wid]
-
-    # Only proceed at simulation steps matching the control decimation.
-    if step % decimation != 0:
-        return
+    # Retrieve the total number of joints from the size of the input arrays
+    num_joints = model_joints_wid.shape[0]
 
     # Retrieve the number of DoFs and offset of the joint
     dofs_start = model_joints_dofs_offset[jid]
@@ -135,8 +131,8 @@ def _generate_random_control_inputs(
         scale_j = controller_scale[joint_dof_index]
 
         # Initialize a random number generator based on the
-        # seed, current step, joint index, and DoF index
-        rng_j_dof = wp.rand_init(controller_seed, (step + 1) * (num_joints * jid + dof))
+        # seed, interval index, joint index, and DoF index
+        rng_j_dof = wp.rand_init(controller_seed + int(n), num_joints * jid + dof)
 
         # Generate a random control input for the joint DoF
         tau_j_c = scale_j * wp.randf(rng_j_dof, -1.0, 1.0)
@@ -162,7 +158,7 @@ class RandomJointController:
     def __init__(
         self,
         model: ModelKamino | None = None,
-        decimation: int | IntArrayLike | None = None,
+        interval: float | FloatArrayLike | None = None,
         scale: float | FloatArrayLike | None = None,
         seed: int | None = None,
     ):
@@ -173,8 +169,8 @@ class RandomJointController:
         Args:
             model: The model container describing the system to be simulated.
                 If `None`, a call to ``finalize()`` must be made later.
-            decimation: Control decimation for each world expressed as a multiple of simulation steps.
-                Defaults to `1` for all worlds if `None`.
+            interval: Interval at which a random torque is applied, in seconds.
+                Defaults to `1.0` for all worlds if `None`.
             scale: Scaling applied to randomly generated control inputs.
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
                 and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.
@@ -188,17 +184,12 @@ class RandomJointController:
         # Declare the device cache
         self._device: wp.DeviceLike = None
 
-        # Cache constructor arguments for potential later
-        self._decimation: int | IntArrayLike | None = decimation
-        self._scale: float | FloatArrayLike | None = scale
-        self._seed: int = seed
-
         # Declare the internal controller data
         self._data: RandomJointControllerData | None = None
 
         # If a model is provided, allocate the controller data
         if model is not None:
-            self.finalize(model=model, seed=seed, decimation=decimation, scale=scale)
+            self.finalize(model=model, seed=seed, interval=interval, scale=scale)
 
     ###
     # Properties
@@ -209,7 +200,7 @@ class RandomJointController:
         """The device used for allocations and execution."""
         if self._data is None:
             raise RuntimeError("Controller data is not allocated. Call finalize() first.")
-        return self._data.decimation.device
+        return self._data.interval.device
 
     @property
     def seed(self) -> int:
@@ -247,7 +238,7 @@ class RandomJointController:
         self,
         model: ModelKamino,
         seed: int | None = None,
-        decimation: int | IntArrayLike | None = None,
+        interval: float | FloatArrayLike | None = None,
         scale: float | FloatArrayLike | None = None,
     ):
         """
@@ -256,8 +247,8 @@ class RandomJointController:
 
         Args:
             model: The model container describing the system to be simulated.
-            decimation: Control decimation for each world expressed as a multiple of simulation steps.
-                Defaults to `1` for all worlds if `None`.
+            interval: Interval at which a random torque is applied, in seconds.
+                Defaults to `1.0` for all worlds if `None`.
             scale: Scaling applied to randomly generated control inputs.
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
                 and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.
@@ -266,7 +257,7 @@ class RandomJointController:
 
         Raises:
             ValueError: If the model has no actuated DoFs.
-            ValueError: If the length of the decimation array does not match the number of worlds.
+            ValueError: If the length of the interval array does not match the number of worlds.
         """
         # Ensure the model is valid and assign it to the controller
         if model is None:
@@ -283,12 +274,12 @@ class RandomJointController:
             raise ValueError("The provided model has no joint DoFs to generate control inputs for.")
 
         # Validate and process the constructor arguments
-        self._decimation, self._scale, self._seed = self._validate_arguments(
+        interval, scale, seed = self._validate_arguments(
             num_worlds=model.size.num_worlds,
             num_joint_dofs=num_joint_dofs,
-            decimation=decimation if decimation is not None else self._decimation,
-            scale=scale if scale is not None else self._scale,
-            seed=seed if seed is not None else self._seed,
+            interval=interval if interval is not None else 1.0,
+            scale=scale if scale is not None else 1.0,
+            seed=seed if seed is not None else 0,
         )
 
         # Use the model's device
@@ -297,9 +288,9 @@ class RandomJointController:
         # Allocate the controller data
         with wp.ScopedDevice(self._device):
             self._data = RandomJointControllerData(
-                seed=self._seed,
-                decimation=to_warp_int32_array(self._decimation),
-                scale=wp.array(self._scale, dtype=wp.float32),
+                seed=seed,
+                interval=wp.array(interval, dtype=wp.float32),
+                scale=wp.array(scale, dtype=wp.float32),
             )
 
     def compute(self, time: TimeData, control: ControlKamino):
@@ -324,13 +315,14 @@ class RandomJointController:
             inputs=[
                 # Inputs
                 self._data.seed,
-                self._data.decimation,
+                self._data.interval,
                 self._data.scale,
                 self._model.joints.wid,
                 self._model.joints.dof_act_types,
                 self._model.joints.dofs_offset,
                 self._model.joints.tau_j_max,
-                time.steps,
+                self._model.time.dt,
+                time.time,
                 # Outputs
                 # TODO: Add support for other control types
                 # (e.g. position and velocity targets)
@@ -347,24 +339,26 @@ class RandomJointController:
         self,
         num_worlds: int,
         num_joint_dofs: int,
-        decimation: int | IntArrayLike | None,
+        interval: float | FloatArrayLike | None,
         scale: float | FloatArrayLike | None,
         seed: int | None,
     ):
-        # Check if the decimation argument is specified, and validate it accordingly
-        if decimation is not None:
-            if isinstance(decimation, int):
-                _decimation = np.full(num_worlds, decimation, dtype=np.int32)
-            elif isinstance(decimation, get_args(IntArrayLike)):
-                decsize = len(decimation)
-                if decsize != num_worlds:
-                    raise ValueError(f"Expected decimation `IntArrayLike` of length {num_worlds}, but has {decsize}.")
-                _decimation = np.array(decimation, dtype=np.int32)
+        # Check if the interval argument is specified, and validate it accordingly
+        if interval is not None:
+            if isinstance(interval, float):
+                _interval = np.full(num_worlds, interval, dtype=np.float32)
+            elif isinstance(interval, get_args(FloatArrayLike)):
+                len_interval = len(interval)
+                if len_interval != num_worlds:
+                    raise ValueError(
+                        f"Expected interval `FloatArrayLike` of length {num_worlds}, but has {len_interval}."
+                    )
+                _interval = np.array(interval, dtype=np.float32)
             else:
-                raise ValueError(f"Expected decimation of type `int` or `IntArrayLike`, but got {type(decimation)}.")
-        # Otherwise, set it to the default value of 1 for all worlds
+                raise ValueError(f"Expected interval of type `float` or `FloatArrayLike`, but got {type(interval)}.")
+        # Otherwise, set it to the default value of 1.0 for all worlds
         else:
-            _decimation = np.ones(num_worlds, dtype=np.int32)
+            _interval = np.ones(num_worlds, dtype=np.float32)
 
         # Check if the scale argument is specified, and validate it accordingly
         if scale is not None:
@@ -391,4 +385,4 @@ class RandomJointController:
             _seed = int(0)
 
         # Return the validated and processed arguments
-        return _decimation, _scale, _seed
+        return _interval, _scale, _seed

--- a/newton/_src/solvers/kamino/tests/test_utils_control_rand.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_control_rand.py
@@ -69,9 +69,9 @@ class TestRandomController(unittest.TestCase):
         self.assertIsNotNone(controller._data, None)
         self.assertIs(controller.device, model.device)
 
-        # Check dimensions of the decimation array
-        self.assertEqual(controller.data.decimation.shape, (model.size.num_worlds,))
-        self.assertTrue((controller.data.decimation.numpy() == 1).all())
+        # Check dimensions of the interval array
+        self.assertEqual(controller.data.interval.shape, (model.size.num_worlds,))
+        self.assertTrue((controller.data.interval.numpy() == 1.0).all())
 
         # Check that the seed is set correctly
         self.assertEqual(controller.seed, self.seed)
@@ -100,9 +100,9 @@ class TestRandomController(unittest.TestCase):
         self.assertIsNotNone(controller._data, None)
         self.assertIs(controller.device, model.device)
 
-        # Check dimensions of the decimation array
-        self.assertEqual(controller.data.decimation.shape, (model.size.num_worlds,))
-        self.assertTrue((controller.data.decimation.numpy() == 1).all())
+        # Check dimensions of the interval array
+        self.assertEqual(controller.data.interval.shape, (model.size.num_worlds,))
+        self.assertTrue((controller.data.interval.numpy() == 1.0).all())
 
         # Check that the seed is set correctly
         self.assertEqual(controller.seed, self.seed)


### PR DESCRIPTION
## Description

This reworks the random controller in Kamino, so that torque application interval is specified in seconds rather than in time steps (decimation).

Note: this utility is not used directly in newton anymore (but could still potentially be useful for testing examples or debugging). Let me know if you'd rather remove it from newton and keep it only on our separate repo with external benchmarks.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] For user-facing changes, a fragment has been added by following the
      [changelog fragment instructions](https://github.com/newton-physics/newton/blob/main/changelog/README.md)

## Test plan

The Kamino-internal test_utils_control_rand.py was updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Random joint control now samples at time-based intervals instead of every set number of simulation steps.
  - The controller configuration now uses an `interval` value in seconds, defaulting to 1.0 second.
  - The previous `decimation` configuration is no longer supported.
  - Sampling remains synchronized with simulation time, with distinct random seeds used for each interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->